### PR TITLE
Append Branch Name to Automated Github Releases

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,7 +57,6 @@ jobs:
         name: xenia_canary
         path: artifacts\xenia_canary
         if-no-files-found: error
-    - uses: nelonoel/branch-name@v1
     - uses: softprops/action-gh-release@v1
       if: |
         github.repository == 'xenia-canary/xenia-canary' &&
@@ -66,6 +65,6 @@ jobs:
       with:
         files: '*.zip'
         tag_name: ${{ steps.prepare_artifacts.outputs.short_commit_sha }}
-        name: "${BRANCH_NAME}: ${tag_name}"
+        name: "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/}): ${tag_name}"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,6 +57,7 @@ jobs:
         name: xenia_canary
         path: artifacts\xenia_canary
         if-no-files-found: error
+    - uses: nelonoel/branch-name@v1
     - uses: softprops/action-gh-release@v1
       if: |
         github.repository == 'xenia-canary/xenia-canary' &&
@@ -65,5 +66,6 @@ jobs:
       with:
         files: '*.zip'
         tag_name: ${{ steps.prepare_artifacts.outputs.short_commit_sha }}
+        name: "${BRANCH_NAME}: ${tag_name}"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Simply puts the name of the branch that was built in front of the tag name for distinguishing between branch builds without first having to download releases.

Edit: It may be necessary to approve the workflow for a test run, to make sure it works.