### PR TITLE
Add vsync_interval option

### DIFF
--- a/src/xenia/gpu/gpu_flags.cc
+++ b/src/xenia/gpu/gpu_flags.cc
@@ -20,6 +20,8 @@ DEFINE_path(
 
 DEFINE_bool(vsync, true, "Enable VSYNC.", "GPU");
 
+DEFINE_uint64(vsync_interval, 16, "VSYNC interval. Value is frametime in milliseconds.", "GPU");
+
 DEFINE_bool(
     gpu_allow_invalid_fetch_constants, false,
     "Allow texture and vertex fetch constants with invalid type - generally "

--- a/src/xenia/gpu/gpu_flags.h
+++ b/src/xenia/gpu/gpu_flags.h
@@ -18,6 +18,8 @@ DECLARE_path(dump_shaders);
 
 DECLARE_bool(vsync);
 
+DECLARE_uint64(vsync_interval);
+
 DECLARE_bool(gpu_allow_invalid_fetch_constants);
 
 DECLARE_bool(half_pixel_offset);

--- a/src/xenia/gpu/graphics_system.cc
+++ b/src/xenia/gpu/graphics_system.cc
@@ -7,6 +7,8 @@
  ******************************************************************************
  */
 
+#include <algorithm>
+
 #include "xenia/gpu/graphics_system.h"
 
 #include "xenia/base/byte_stream.h"
@@ -119,7 +121,7 @@ X_STATUS GraphicsSystem::Setup(cpu::Processor* processor,
   vsync_worker_running_ = true;
   vsync_worker_thread_ = kernel::object_ref<kernel::XHostThread>(
       new kernel::XHostThread(kernel_state_, 128 * 1024, 0, [this]() {
-        uint64_t vsync_duration = cvars::vsync ? 16 : 1;
+        uint64_t vsync_duration = cvars::vsync ? std::max<uint64_t>(5, cvars::vsync_interval) : 1;
         uint64_t last_frame_time = Clock::QueryGuestTickCount();
         while (vsync_worker_running_) {
           uint64_t current_time = Clock::QueryGuestTickCount();


### PR DESCRIPTION
vsync_duration is no longer tied to vsync;
Old behavior was to set it to 16 if vsync is enabled, and 1 if disabled.
Default value is 16. (60 frames per second)
The value represents frametime in milliseconds. For example, for 120FPS, 8 would be specified because 1000/120 = ~8.