### PR TITLE
[Kernel] Make KeEnter/LeaveCriticalRegion only affect the caller thread

### DIFF
--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
@@ -960,14 +960,15 @@ void KeReleaseSpinLockFromRaisedIrql(lpdword_t lock_ptr) {
 DECLARE_XBOXKRNL_EXPORT2(KeReleaseSpinLockFromRaisedIrql, kThreading,
                          kImplemented, kHighFrequency);
 
-void KeEnterCriticalRegion() { XThread::EnterCriticalRegion(); }
+void KeEnterCriticalRegion() {
+  XThread::GetCurrentThread()->EnterCriticalRegion();
+}
 DECLARE_XBOXKRNL_EXPORT2(KeEnterCriticalRegion, kThreading, kImplemented,
                          kHighFrequency);
 
 void KeLeaveCriticalRegion() {
-  XThread::LeaveCriticalRegion();
-
-  XThread::GetCurrentThread()->CheckApcs();
+  auto thread = XThread::GetCurrentThread();
+  thread->LeaveCriticalRegion();
 }
 DECLARE_XBOXKRNL_EXPORT2(KeLeaveCriticalRegion, kThreading, kImplemented,
                          kHighFrequency);

--- a/src/xenia/kernel/xthread.cc
+++ b/src/xenia/kernel/xthread.cc
@@ -578,11 +578,15 @@ void XThread::Reenter(uint32_t address) {
 }
 
 void XThread::EnterCriticalRegion() {
-  xe::global_critical_region::mutex().lock();
+  guest_object<X_KTHREAD>()->apc_disable_count--;
 }
 
 void XThread::LeaveCriticalRegion() {
-  xe::global_critical_region::mutex().unlock();
+  auto kthread = guest_object<X_KTHREAD>();
+  auto apc_disable_count = ++kthread->apc_disable_count;
+  if (apc_disable_count == 0) {
+    CheckApcs();
+  }
 }
 
 uint32_t XThread::RaiseIrql(uint32_t new_irql) {
@@ -593,11 +597,11 @@ void XThread::LowerIrql(uint32_t new_irql) { irql_ = new_irql; }
 
 void XThread::CheckApcs() { DeliverAPCs(); }
 
-void XThread::LockApc() { EnterCriticalRegion(); }
+void XThread::LockApc() { global_critical_region_.mutex().lock(); }
 
 void XThread::UnlockApc(bool queue_delivery) {
   bool needs_apc = apc_list_.HasPending();
-  LeaveCriticalRegion();
+  global_critical_region_.mutex().unlock();
   if (needs_apc && queue_delivery) {
     thread_->QueueUserCallback([this]() { DeliverAPCs(); });
   }
@@ -632,7 +636,8 @@ void XThread::DeliverAPCs() {
   // https://www.drdobbs.com/inside-nts-asynchronous-procedure-call/184416590?pgno=7
   auto processor = kernel_state()->processor();
   LockApc();
-  while (apc_list_.HasPending()) {
+  auto kthread = guest_object<X_KTHREAD>();
+  while (apc_list_.HasPending() && kthread->apc_disable_count == 0) {
     // Get APC entry (offset for LIST_ENTRY offset) and cache what we need.
     // Calling the routine may delete the memory/overwrite it.
     uint32_t apc_ptr = apc_list_.Shift() - 8;

--- a/src/xenia/kernel/xthread.h
+++ b/src/xenia/kernel/xthread.h
@@ -111,7 +111,9 @@ struct X_KTHREAD {
   uint8_t unk_8B;                     // 0x8B
   uint8_t unk_8C[0x10];               // 0x8C
   xe::be<uint32_t> unk_9C;            // 0x9C
-  uint8_t unk_A0[0x1C];               // 0xA0
+  uint8_t unk_A0[0x10];               // 0xA0
+  int32_t apc_disable_count;          // 0xB0
+  uint8_t unk_B4[0x8];                // 0xB4
   uint8_t suspend_count;              // 0xBC
   uint8_t unk_BD;                     // 0xBD
   uint8_t unk_BE;                     // 0xBE
@@ -190,8 +192,8 @@ class XThread : public XObject, public cpu::Thread {
 
   virtual void Reenter(uint32_t address);
 
-  static void EnterCriticalRegion();
-  static void LeaveCriticalRegion();
+  void EnterCriticalRegion();
+  void LeaveCriticalRegion();
   uint32_t RaiseIrql(uint32_t new_irql);
   void LowerIrql(uint32_t new_irql);
 


### PR DESCRIPTION
This adds a new `X_KTHREAD::apc_disable_count` field at 0xB0 into X_KTHREAD based on where 360 kernel seems to store it, and changes the KeEnter/LeaveCriticalRegion funcs to act on that, instead of locking the `XThread::global_critical_region_` shared between all threads, and changes `XThread::DeliverAPCs` to check that field before running the APCs.

From what I can find online about CriticalRegion stuff it seems this isn't meant to be used as a lock between threads at all, sounds like the CriticalRegion funcs are only really for preventing APCs from being ran on the caller thread, https://github.com/xenia-project/xenia/issues/1748 has some more details about it, looking at other NT/Xbox reimpls they also seem to work this way too.

This change is needed to allow `XamTaskSchedule` to run tasks in a different thread, as games seem to use an EnterCrit -> XamTaskSchedule -> LeaveCrit pattern to call it, unfortunately the old method of locking `XThread::global_critical_region_` would prevent code from running in any other thread until LeaveCrit unlocked it, as the XThread execution code depends on DeliverAPCs() which also tries to lock `XThread::global_critical_region_`, causing a deadlock between threads.

`XThread::LockApc/UnlockApc` were also updated too, previously these called into EnterCrit/LeaveCrit to work, but AFAIK the code that uses LockApc/UnlockApc do have an actual need for locking between threads, so changed them to work on `XThread::global_critical_region_` directly instead.

(originally I also included LockApc/UnlockApc calls inside XThread::EnterCriticalRegion & XThread::LeaveCriticalRegion so that apc_disable_count couldn't be changed while LockApc was locked by DeliverAPCs, but looking into it more it seems unneeded, since only the single XThread that owns apc_disable_count would be running any of these functions, doesn't seem like there's any chance of DeliverAPCs running simultaneously.
Using LockApc/UnlockApc there could probably cause a deadlock itself, eg. if an APC being ran by DeliverAPCs needed to use the CriticalRegion funcs, LockApc would have already been locked by DeliverAPCs...)

---

From my own quick testing this doesn't seem to cause any problems - though I haven't really noticed any improvements neither besides helping with future XamTaskSchedule stuff (needed for cache partition fixes and maybe other things), but who knows, hoping that adding it to canary-experimental and letting people try it will let us know if there are any differences from it, good or bad.