### PR TITLE
Add nullptr check in CheckScalarConstCmp

### DIFF
--- a/src/xenia/cpu/compiler/passes/simplification_pass.cc
+++ b/src/xenia/cpu/compiler/passes/simplification_pass.cc
@@ -795,7 +795,10 @@ bool SimplificationPass::CheckScalarConstCmp(hir::Instr* i,
 
   if (var_definition) {
     var_definition = var_definition->GetDestDefSkipAssigns();
-    def_opcode = var_definition->opcode->num;
+    if (var_definition != NULL)
+    {
+      def_opcode = var_definition->opcode->num;
+    }
   }
   // x == 0 -> !x
   if (cmpop == OPCODE_COMPARE_EQ && constant_unpacked == 0) {


### PR DESCRIPTION
Added a null check in SimplificationPass::CheckScalarConstCmp where var_definition can be returned as null causing a read access violation exception in some games.