### PR TITLE
Fixed three crashes and refactored

### DIFF
--- a/src/xenia/app/emulator_window.h
+++ b/src/xenia/app/emulator_window.h
@@ -152,8 +152,8 @@ class EmulatorWindow {
   void ShowFAQ();
   void ShowBuildCommit();
 
+  xe::X_STATUS RunTitle(std::filesystem::path path);
   void RunPreviouslyPlayedTitle();
-  void RunRecentlyPlayedTitle(std::filesystem::path path_to_file);
   void FillRecentlyLaunchedTitlesMenu(xe::ui::MenuItem* recent_menu);
   void ReadRecentlyLaunchedTitles();
   void AddRecentlyLaunchedTitle(std::filesystem::path path_to_file,


### PR DESCRIPTION
While a title is running any attempt to open another title will result in a crash this commit prevents these crashes via File->Open and File->Open Recent->Title

Opening a recent title with an invalid path caused a crash.