### PR TITLE
xb & build improvements, store recent.toml in storage root

### DIFF
--- a/src/xenia/app/emulator_window.cc
+++ b/src/xenia/app/emulator_window.cc
@@ -1137,7 +1137,7 @@ void EmulatorWindow::FillRecentlyLaunchedTitlesMenu(
 }
 
 void EmulatorWindow::ReadRecentlyLaunchedTitles() {
-  std::ifstream file("recent.toml");
+  std::ifstream file(emulator()->storage_root() / "recent.toml");
   if (!file.is_open()) {
     return;
   }
@@ -1198,7 +1198,8 @@ void EmulatorWindow::AddRecentlyLaunchedTitle(
   toml_table->end();
 
   // Open and write serialized data.
-  std::ofstream file("recent.toml", std::ofstream::trunc);
+  std::ofstream file(emulator()->storage_root() / "recent.toml",
+                     std::ofstream::trunc);
   file << *toml_table;
   file.close();
 }

--- a/xb.bat
+++ b/xb.bat
@@ -40,7 +40,8 @@ SET "CANDIDATE_PATHS[1]=C:\python39\python.exe"
 SET "CANDIDATE_PATHS[2]=C:\python38\python.exe"
 SET "CANDIDATE_PATHS[3]=C:\python37\python.exe"
 SET "CANDIDATE_PATHS[4]=C:\python%PYTHON_MINIMUM_VERSION[0]%%PYTHON_MINIMUM_VERSION[1]%\python.exe"
-SET OUTPUT_INDEX=5
+SET "CANDIDATE_PATHS[5]=C:\Windows\py.exe"
+SET OUTPUT_INDEX=6
 
 FOR /F "usebackq delims=" %%L IN (`2^>NUL where python3`) DO (
   IF %%~zL NEQ 0 (

--- a/xenia-build
+++ b/xenia-build
@@ -47,6 +47,7 @@ def import_subprocess_environment(args):
         'systemroot',
         'temp',
         'tmp',
+        'vcinstalldir',
         'windowssdkdir',
         )
     for line in variables.splitlines():
@@ -436,6 +437,8 @@ def get_clang_format_binary():
         'clang-format-13',
         'clang-format',
         ]
+    if 'VCINSTALLDIR' in os.environ:
+        attempts.append(os.path.join(os.environ['VCINSTALLDIR'], 'Tools', 'Llvm', 'bin', 'clang-format.exe'))
     for binary in attempts:
         if has_bin(binary):
             return binary


### PR DESCRIPTION
## Thanks to Bo98 for these improvements, I am just bringing them upstream.

## 6c5423ceed84e609e5c56eba2090c91f76919d78
xb additionally now checks the `C:\Windows\py.exe` location for a python installation.

## df368691cda75ddd2b3e7f55976381ec7de30286
xenia-build now also checks `VCINSTALLDIR` for clang-format.

## 6c5423ceed84e609e5c56eba2090c91f76919d78
xenia-app now stores recent.toml in the configured storage root, alongside config.toml.