### PR TITLE
fix XamInputGetCapabilities breaking subtypes

### DIFF
--- a/src/xenia/kernel/xam/xam_input.cc
+++ b/src/xenia/kernel/xam/xam_input.cc
@@ -54,9 +54,6 @@ dword_result_t XamInputGetCapabilities_entry(
   if ((flags & 4) != 0) {
   //should trap
   }
-  if (!flags) {
-    flags = 3;
-  }
 
 
   if ((flags & 0xFF) && (flags & XINPUT_FLAG_GAMEPAD) == 0) {


### PR DESCRIPTION
By forcing the flags value sent to XInputGetCapabilities, the emulator breaks Rock Band and early Guitar Hero games (Guitar Hero II) detecting the controller subtypes (for guitars, drums), causing all controllers to be detected as if they were regular gamepads.

This fixes this and allows guitars, drums, etc connected via XInput to work in those games.