### PR TITLE
Dynamic TU patch

### DIFF
--- a/src/xenia/kernel/kernel_state.cc
+++ b/src/xenia/kernel/kernel_state.cc
@@ -483,10 +483,13 @@ X_RESULT KernelState::ApplyTitleUpdate(const object_ref<UserModule> module) {
   X_RESULT open_status =
       content_manager()->OpenContent("UPDATE", title_update, disc_number);
 
+  // Use the corresponding patch for the launch module
+  std::filesystem::path patch_xexp = fmt::format("{0}.xexp", module->name());
+
   std::string resolved_path = "";
   file_system()->FindSymbolicLink("UPDATE:", resolved_path);
   xe::vfs::Entry* patch_entry = kernel_state()->file_system()->ResolvePath(
-      resolved_path + "default.xexp");
+      resolved_path + patch_xexp.generic_string());
 
   if (patch_entry) {
     const std::string patch_path = patch_entry->absolute_path();


### PR DESCRIPTION
The patch for an installed title update always defaults to `default.xexp`, even if the launch module is set to `default_mp.xex` which should load `default_mp.xexp`. However `default.xexp` is attempted to patch against `default_mp.xex` which causes the patch to fail and crashes canary.

This PR resolves this by loading the patch based on the loaded module and also prevents the need to replace `default.xexp` with `default_mp.xexp` to load a specific module with its corresponding patch.