### PR TITLE
Support for multiple user profiles

### DIFF
--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -60,6 +60,8 @@
 #include "xenia/cpu/backend/x64/x64_backend.h"
 #endif  // XE_ARCH
 
+DECLARE_string(user_profile);
+
 DEFINE_double(time_scalar, 1.0,
               "Scalar used to speed or slow time (1x, 2x, 1/2x, etc).",
               "General");
@@ -82,6 +84,7 @@ DECLARE_int32(user_language);
 DECLARE_bool(allow_plugins);
 
 namespace xe {
+
 using namespace xe::literals;
 
 Emulator::GameConfigLoadCallback::GameConfigLoadCallback(Emulator& emulator)
@@ -491,11 +494,13 @@ X_STATUS Emulator::InstallContentPackage(const std::filesystem::path& path) {
       (vfs::XContentContainerDevice*)device.get();
 
   std::filesystem::path installation_path =
-      content_root() / fmt::format("{:08X}", dev->title_id()) /
+      content_root() / cvars::user_profile /
+      fmt::format("{:08X}", dev->title_id()) /
       fmt::format("{:08X}", dev->content_type()) / path.filename();
 
   std::filesystem::path header_path =
-      content_root() / fmt::format("{:08X}", dev->title_id()) / "Headers" /
+      content_root() / cvars::user_profile /
+      fmt::format("{:08X}", dev->title_id()) / "Headers" /
       fmt::format("{:08X}", dev->content_type()) / path.filename();
 
   if (std::filesystem::exists(installation_path)) {

--- a/src/xenia/kernel/xam/user_profile.cc
+++ b/src/xenia/kernel/xam/user_profile.cc
@@ -15,6 +15,8 @@
 #include "xenia/kernel/kernel_state.h"
 #include "xenia/kernel/util/shim_utils.h"
 
+DEFINE_string(user_profile, "User", "The name of your user profile.", "General");
+
 namespace xe {
 namespace kernel {
 namespace xam {
@@ -24,9 +26,14 @@ UserProfile::UserProfile(uint8_t index) {
   // if non-zero, it prevents the user from playing the game.
   // "You do not have permissions to perform this operation."
   xuid_ = 0xB13EBABEBABEBABE + index;
-  name_ = "User";
+
+  if (cvars::user_profile.empty()) {
+    OVERRIDE_string(user_profile, "User");
+  }
+  
+  name_ = cvars::user_profile;
   if (index) {
-    name_ = "User_" + std::to_string(index);
+    name_ = fmt::format("{0}_{1}", cvars::user_profile, std::to_string(index));
   }
 
   // https://cs.rin.ru/forum/viewtopic.php?f=38&t=60668&hilit=gfwl+live&start=195


### PR DESCRIPTION
This PR adds support for basic multiple user profiles, this unfortunately breaks the current folder structure for savefiles. To transfer your current savefiles to a profile put all the files from `Xenia/content` into `Xenia/content/User`.

You can change your user profile name in the config like so `user_profile = "User"`

<table>
<tr>
<th>New Structure</th>
<th>Old Structure</th>
</tr>
<tr>
<td>
<pre>

```
└───content
    └───User
        └───415608CB
            ├───00000001
            ├───Headers
            │   └───00000001
            └───profile
                └───User
```
</pre>
</td>
<td>

```
└───content
    └───415608CB
        ├───00000001
        ├───Headers
        │   └───00000001
        └───profile
            └───User
```

</td>
</tr>
</table>