### PR TITLE
[XAM] Allow custom profiles - This breaks current content visibility

### DIFF
--- a/src/xenia/app/emulator_window.cc
+++ b/src/xenia/app/emulator_window.cc
@@ -936,13 +936,22 @@ void EmulatorWindow::ShowContentDirectory() {
   std::filesystem::path target_path;
 
   auto content_root = emulator_->content_root();
-  if (!emulator_->is_title_open() || !emulator_->kernel_state()) {
+  if (!emulator_->kernel_state()) {
     target_path = content_root;
+  }
+
+  if (!emulator_->is_title_open()) {
+    auto xuid_str = fmt::format(
+        "{:016X}", emulator_->kernel_state()->user_profile((uint32_t)0)->xuid());
+    auto package_root = content_root / xuid_str;
+    target_path = package_root;
   } else {
     // TODO(gibbed): expose this via ContentManager?
+    auto xuid_str = fmt::format(
+        "{:016X}", emulator_->kernel_state()->user_profile((uint32_t)0)->xuid());
     auto title_id =
         fmt::format("{:08X}", emulator_->kernel_state()->title_id());
-    auto package_root = content_root / title_id;
+    auto package_root = content_root / xuid_str / title_id;
     target_path = package_root;
   }
 

--- a/src/xenia/kernel/kernel_state.cc
+++ b/src/xenia/kernel/kernel_state.cc
@@ -486,7 +486,7 @@ X_RESULT KernelState::ApplyTitleUpdate(const object_ref<UserModule> module) {
   }
 
   std::vector<xam::XCONTENT_AGGREGATE_DATA> tu_list =
-      content_manager()->ListContent(1, xe::XContentType::kInstaller,
+      content_manager()->ListContent(1, 0, xe::XContentType::kInstaller,
                                      module->title_id());
 
   if (tu_list.empty()) {
@@ -500,7 +500,7 @@ X_RESULT KernelState::ApplyTitleUpdate(const object_ref<UserModule> module) {
   // TODO(Gliniak): Support for selecting from multiple TUs
   const xam::XCONTENT_AGGREGATE_DATA& title_update = tu_list.front();
   X_RESULT open_status =
-      content_manager()->OpenContent("UPDATE", title_update, disc_number);
+      content_manager()->OpenContent("UPDATE", 0, title_update, disc_number);
 
   // Use the corresponding patch for the launch module
   std::filesystem::path patch_xexp = fmt::format("{0}.xexp", module->name());

--- a/src/xenia/kernel/kernel_state.h
+++ b/src/xenia/kernel/kernel_state.h
@@ -128,6 +128,13 @@ class KernelState {
   }
 
   xam::UserProfile* user_profile(uint32_t index) const {
+    if (index == 0xFF) {
+      index = 0;
+    }
+    if (index == 0xFE) {
+      index = recently_used_profile_;
+    }
+
     if (!IsUserSignedIn(index)) {
       return nullptr;
     }
@@ -282,6 +289,8 @@ class KernelState {
   std::condition_variable_any dispatch_cond_;
   std::list<std::function<void()>> dispatch_queue_;
 
+  // This should be in ProfileManager, but it is what it is
+  uint8_t recently_used_profile_ = 0;
   BitMap tls_bitmap_;
   uint32_t ke_timestamp_bundle_ptr_ = 0;
   std::unique_ptr<xe::threading::HighResolutionTimer> timestamp_timer_;

--- a/src/xenia/kernel/profile_manager.cc
+++ b/src/xenia/kernel/profile_manager.cc
@@ -1,0 +1,1 @@
+#include "profile_manager.h"

--- a/src/xenia/kernel/profile_manager.h
+++ b/src/xenia/kernel/profile_manager.h
@@ -1,0 +1,69 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2023 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_KERNEL_PROFILE_MANAGER_H_
+#define XENIA_KERNEL_PROFILE_MANAGER_H_
+
+#include <random>
+#include <map>
+#include <vector>
+#include "xenia/kernel/xam/user_profile.h"
+
+namespace xe {
+namespace kernel {
+
+class ProfileIOHandler {
+ public:
+ virtual bool LoadProfile(uint64_t xuid);
+ virtual bool SaveProfile(uint64_t xuid);
+};
+
+class ProfileIOHandlerToml : public ProfileIOHandler {
+ public:
+  bool LoadProfile(uint64_t xuid);
+  bool SaveProfile(uint64_t xuid);
+};
+
+class ProfileManager {
+ public:
+
+  ProfileManager(){};
+  ~ProfileManager(){};
+
+  void CreateProfile();
+  void DeleteProfile(uint64_t xuid);
+
+  void Login(uint64_t xuid, uint32_t user_index);
+  void Logout(uint64_t xuid);
+
+  xam::UserProfile* GetProfile(uint32_t user_index);
+  xam::UserProfile* GetProfile(uint64_t xuid);
+
+ private:
+  static uint64_t GenerateXuid() {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+
+    return ((uint64_t)0xE03 << 52) + (gen() % (1 << 31));
+  }
+
+  void LoadProfile(ProfileIOHandler* io, uint64_t xuid);
+  void SaveProfile(ProfileIOHandler* io, uint64_t xuid);
+
+
+  std::vector<uint32_t> profiles_;
+  std::map<uint8_t, xam::UserProfile*> logged_profile_;
+
+  //KernelState* kernel_state_;
+};
+
+}  // namespace kernel
+}  // namespace xe
+
+#endif  // XENIA_KERNEL_PROFILE_MANAGER_H_

--- a/src/xenia/kernel/xam/content_manager.h
+++ b/src/xenia/kernel/xam/content_manager.h
@@ -93,7 +93,7 @@ struct XCONTENT_DATA {
 static_assert_size(XCONTENT_DATA, 0x134);
 
 struct XCONTENT_AGGREGATE_DATA : XCONTENT_DATA {
-  be<uint64_t> unk134;  // some titles store XUID here?
+  be<uint64_t> xuid;  // some titles store XUID here?
   be<uint32_t> title_id;
 
   XCONTENT_AGGREGATE_DATA() = default;
@@ -103,7 +103,7 @@ struct XCONTENT_AGGREGATE_DATA : XCONTENT_DATA {
     set_display_name(other.display_name());
     set_file_name(other.file_name());
     padding[0] = padding[1] = 0;
-    unk134 = 0;
+    xuid = 0;
     title_id = kCurrentlyRunningTitleId;
   }
 
@@ -141,39 +141,48 @@ class ContentManager {
                  const std::filesystem::path& root_path);
   ~ContentManager();
 
-  std::vector<XCONTENT_AGGREGATE_DATA> ListContent(uint32_t device_id,
-                                                   XContentType content_type,
-                                                   uint32_t title_id = -1);
+  std::vector<XCONTENT_AGGREGATE_DATA> ListContent(
+      const uint32_t device_id, const uint64_t xuid,
+      const XContentType content_type, uint32_t title_id = -1);
 
   std::unique_ptr<ContentPackage> ResolvePackage(
-      const std::string_view root_name, const XCONTENT_AGGREGATE_DATA& data,
-      const uint32_t disc_number = -1);
+      const std::string_view root_name, const uint64_t xuid,
+      const XCONTENT_AGGREGATE_DATA& data, const uint32_t disc_number = -1);
 
-  bool ContentExists(const XCONTENT_AGGREGATE_DATA& data);
-  X_RESULT WriteContentHeaderFile(const XCONTENT_AGGREGATE_DATA* data_raw);
+  bool ContentExists(const uint64_t xuid,
+                     const XCONTENT_AGGREGATE_DATA& data);
+  X_RESULT WriteContentHeaderFile(const uint64_t xuid,
+                                  const XCONTENT_AGGREGATE_DATA* data_raw);
   X_RESULT ReadContentHeaderFile(const std::string_view file_name,
+                                 const uint64_t xuid,
                                  XContentType content_type,
                                  XCONTENT_AGGREGATE_DATA& data,
                                  const uint32_t title_id = -1);
-  X_RESULT CreateContent(const std::string_view root_name,
+  X_RESULT CreateContent(const std::string_view root_name, const uint64_t xuid,
                          const XCONTENT_AGGREGATE_DATA& data);
-  X_RESULT OpenContent(const std::string_view root_name,
+  X_RESULT OpenContent(const std::string_view root_name, const uint64_t xuid,
                        const XCONTENT_AGGREGATE_DATA& data,
                        const uint32_t disc_number = -1);
   X_RESULT CloseContent(const std::string_view root_name);
-  X_RESULT GetContentThumbnail(const XCONTENT_AGGREGATE_DATA& data,
+  X_RESULT GetContentThumbnail(const uint64_t xuid,
+                               const XCONTENT_AGGREGATE_DATA& data,
                                std::vector<uint8_t>* buffer);
-  X_RESULT SetContentThumbnail(const XCONTENT_AGGREGATE_DATA& data,
+  X_RESULT SetContentThumbnail(const uint64_t xuid,
+                               const XCONTENT_AGGREGATE_DATA& data,
                                std::vector<uint8_t> buffer);
-  X_RESULT DeleteContent(const XCONTENT_AGGREGATE_DATA& data);
-  std::filesystem::path ResolveGameUserContentPath();
+  X_RESULT DeleteContent(const uint64_t xuid,
+                         const XCONTENT_AGGREGATE_DATA& data);
+  std::filesystem::path ResolveGameUserContentPath(const uint64_t xuid = 0);
   bool IsContentOpen(const XCONTENT_AGGREGATE_DATA& data) const;
   void CloseOpenedFilesFromContent(const std::string_view root_name);
 
  private:
-  std::filesystem::path ResolvePackageRoot(XContentType content_type,
+  std::filesystem::path ResolvePackageRoot(
+      const uint64_t xuid,
+                                           XContentType content_type,
                                            uint32_t title_id = -1);
-  std::filesystem::path ResolvePackagePath(const XCONTENT_AGGREGATE_DATA& data,
+  std::filesystem::path ResolvePackagePath(const uint64_t xuid,
+                                           const XCONTENT_AGGREGATE_DATA& data,
                                            const uint32_t disc_number = -1);
 
   KernelState* kernel_state_;

--- a/src/xenia/kernel/xam/xam_content_aggregate.cc
+++ b/src/xenia/kernel/xam/xam_content_aggregate.cc
@@ -112,10 +112,15 @@ dword_result_t XamContentAggregateCreateEnumerator_entry(qword_t xuid,
                 std::back_inserter(title_ids));
     }
 
+    auto user = kernel_state()->user_profile(xuid);
+    if (!user) {
+      return X_E_NO_SUCH_USER;
+    }
+
     for (auto& title_id : title_ids) {
       // Get all content data.
       auto content_datas = kernel_state()->content_manager()->ListContent(
-          static_cast<uint32_t>(DummyDeviceId::HDD), content_type_enum,
+          static_cast<uint32_t>(DummyDeviceId::HDD), xuid, content_type_enum,
           title_id);
       for (const auto& content_data : content_datas) {
         auto item = e->AppendItem();

--- a/src/xenia/kernel/xam/xam_user.cc
+++ b/src/xenia/kernel/xam/xam_user.cc
@@ -9,6 +9,7 @@
 
 #include <cstring>
 
+#include "xenia/app/emulator_window.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/math.h"
 #include "xenia/base/string_util.h"
@@ -355,17 +356,6 @@ dword_result_t XamUserWriteProfileSettings_entry(
   if (!setting_count || !settings) {
     return X_ERROR_INVALID_PARAMETER;
   }
-
-  // Skip writing data about users with id != 0 they're not supported
-  if (user_index > 0) {
-    if (overlapped) {
-      kernel_state()->CompleteOverlappedImmediate(
-          kernel_state()->memory()->HostToGuestVirtual(overlapped),
-          X_ERROR_NO_SUCH_USER);
-      return X_ERROR_IO_PENDING;
-    }
-    return X_ERROR_SUCCESS;
-  }
   // Update and save settings.
   const auto& user_profile = kernel_state()->user_profile(user_index);
 
@@ -561,7 +551,7 @@ dword_result_t XamShowSigninUI_entry(dword_t unk, dword_t unk_mask) {
   // Mask values vary. Probably matching user types? Local/remote?
   // Games seem to sit and loop until we trigger this notification:
 
-  for (uint32_t i = 0; i < 4; i++) {
+  for (uint32_t i = 0; i < MAX_USERS; i++) {
     if (kernel_state()->IsUserSignedIn(i)) {
       // XN_SYS_SIGNINCHANGED
       kernel_state()->BroadcastNotification(0xA, i);


### PR DESCRIPTION
How to transfer old savefiles to new content tree.

1. Run Xenia to update config file
2. Close Xenia and open config file then find gamertag_0 it is first player name and also name generates unique XUID
3. Open Xenia again and select "Show Content Directory" to generate content/xuid directory
4. Put all title_id directories there
5. Volia

Disclaimer: Transfer won't work for savefiles that check for XUID or Gamertag