### PR TITLE
[VFS] Fixed allow_game_relative_writes to write invalid cached entries

### DIFF
--- a/src/xenia/vfs/devices/host_path_entry.cc
+++ b/src/xenia/vfs/devices/host_path_entry.cc
@@ -103,9 +103,10 @@ bool HostPathEntry::DeleteEntryInternal(Entry* entry) {
     auto removed = std::filesystem::remove_all(full_path, ec);
     return removed >= 1 && removed != static_cast<std::uintmax_t>(-1);
   } else {
-    // Delete file.
+    // Delete file only if it exists.
     return !std::filesystem::is_directory(full_path) &&
-           std::filesystem::remove(full_path, ec);
+           (!std::filesystem::exists(full_path) ||
+            std::filesystem::remove(full_path, ec));
   }
 }
 

--- a/src/xenia/vfs/devices/host_path_entry.h
+++ b/src/xenia/vfs/devices/host_path_entry.h
@@ -30,7 +30,7 @@ class HostPathEntry : public Entry {
                                const std::filesystem::path& full_path,
                                xe::filesystem::FileInfo file_info);
 
-  const std::filesystem::path& host_path() { return host_path_; }
+  const std::filesystem::path& host_path() const { return host_path_; }
 
   X_STATUS Open(uint32_t desired_access, File** out_file) override;
 


### PR DESCRIPTION
This PR fixes https://github.com/xenia-canary/xenia-canary/issues/123 a bug where files would not write to the host if they were deleted from the host filesystem during runtime.