### PR TITLE
[App] Allow patched arrays to start with 0x

### DIFF
--- a/src/xenia/app/emulator_window.cc
+++ b/src/xenia/app/emulator_window.cc
@@ -60,7 +60,7 @@ DEFINE_bool(fullscreen, false, "Whether to launch the emulator in fullscreen.",
             "Display");
 
 DEFINE_bool(controller_hotkeys, true,
-            "Toggle hotkeys for Xbox and PS controllers.", "General");
+            "Hotkeys for Xbox and PS controllers.", "General");
 
 DEFINE_string(
     postprocess_antialiasing, "",
@@ -1570,7 +1570,8 @@ void EmulatorWindow::LoadRecentlyLaunchedTitles() {
       std::time_t last_run_time =
           *entry_table->get_as<uint64_t>("last_run_time");
 
-      if (path.empty() || !std::filesystem::exists(path)) {
+      std::error_code ec = {};
+      if (path.empty() || !std::filesystem::exists(path, ec)) {
         continue;
       }
 

--- a/src/xenia/base/string_util.h
+++ b/src/xenia/base/string_util.h
@@ -112,7 +112,11 @@ inline size_t copy_and_swap_maybe_truncating(char16_t* dest,
 }
 
 inline bool hex_string_to_array(std::vector<uint8_t>& output_array,
-                                const std::string_view value) {
+                                std::string_view value) {
+  if (value.rfind("0x", 0) == 0) {
+    value.remove_prefix(2);
+  }
+
   output_array.reserve((value.size() + 1) / 2);
 
   size_t remaining_length = value.size();


### PR DESCRIPTION
Allow patched arrays to optionally start with 0x and fixed a rare crash while attempting to check for file existence.