### PR TITLE
RADV bug fix

### DIFF
--- a/src/xenia/app/xenia_main.cc
+++ b/src/xenia/app/xenia_main.cc
@@ -613,8 +613,7 @@ void EmulatorApp::EmulatorThread() {
 
   if (!path.empty()) {
     // Normalize the path and make absolute.
-    auto abs_path = std::filesystem::absolute(path);
-    result = emulator_->LaunchPath(abs_path);
+    result = app_context().CallInUIThread([this, path]() { return emulator_->LaunchPath(std::filesystem::absolute(path)); });
     if (XFAILED(result)) {
       xe::FatalError(fmt::format("Failed to launch target: {:08X}", result));
       app_context().RequestDeferredQuit();

--- a/src/xenia/app/xenia_main.cc
+++ b/src/xenia/app/xenia_main.cc
@@ -613,7 +613,9 @@ void EmulatorApp::EmulatorThread() {
 
   if (!path.empty()) {
     // Normalize the path and make absolute.
-    result = app_context().CallInUIThread([this, path]() { return emulator_->LaunchPath(std::filesystem::absolute(path)); });
+    auto abs_path = std::filesystem::absolute(path);
+
+    result = app_context().CallInUIThread([this, abs_path]() { return emulator_->LaunchPath(abs_path); });
     if (XFAILED(result)) {
       xe::FatalError(fmt::format("Failed to launch target: {:08X}", result));
       app_context().RequestDeferredQuit();

--- a/src/xenia/gpu/vulkan/vulkan_render_target_cache.cc
+++ b/src/xenia/gpu/vulkan/vulkan_render_target_cache.cc
@@ -2289,7 +2289,7 @@ VkShaderModule VulkanRenderTargetCache::GetTransferShader(
         builder.addCapability(spv::CapabilityStencilExportEXT);
         output_fragment_stencil_ref =
             builder.createVariable(spv::NoPrecision, spv::StorageClassOutput,
-                                   type_int, "gl_FragStencilRefARB");
+                                   type_uint, "gl_FragStencilRefARB");
         builder.addDecoration(output_fragment_stencil_ref,
                               spv::DecorationBuiltIn,
                               spv::BuiltInFragStencilRefEXT);


### PR DESCRIPTION
This fixes a bug where a stencil reference had the wrong type. Other driver implementations seem not to care, however, RADV does.

I tested this on Windows 10 (with a 1050 ti, to verify the changes don't break on other platforms:tm:) and Arch Linux (with a Vega 8) with Sonic Unleashed.