### PR TITLE
[XAM] Plugins Functions

### DIFF
--- a/src/xenia/app/emulator_window.cc
+++ b/src/xenia/app/emulator_window.cc
@@ -1191,7 +1191,7 @@ const std::map<int, EmulatorWindow::ControllerHotKey> controller_hotkey_map = {
     {X_INPUT_GAMEPAD_BACK | X_INPUT_GAMEPAD_START,
      EmulatorWindow::ControllerHotKey(
          EmulatorWindow::ButtonFunctions::ToggleLogging,
-         "Back + Start = Close Window", false, false)},
+         "Back + Start = Toggle between loglevel set in config and the 'Disabled' loglevel.", false, false)},
     {X_INPUT_GAMEPAD_DPAD_DOWN,
      EmulatorWindow::ControllerHotKey(
          EmulatorWindow::ButtonFunctions::IncTitleSelect,

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_modules.h
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_modules.h
@@ -1,0 +1,26 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2023 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_KERNEL_XBOXKRNL_XBOXKRNL_MODULES_H_
+#define XENIA_KERNEL_XBOXKRNL_XBOXKRNL_MODULES_H_
+
+#include "xenia/kernel/util/shim_utils.h"
+
+namespace xe {
+namespace kernel {
+namespace xboxkrnl {
+
+dword_result_t XexGetModuleHandle(std::string module_name,
+                                  xe::be<uint32_t>* hmodule_ptr);
+
+}  // namespace xboxkrnl
+}  // namespace kernel
+}  // namespace xe
+
+#endif  // XENIA_KERNEL_XBOXKRNL_XBOXKRNL_MODULES_H_

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_ob.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_ob.cc
@@ -250,9 +250,11 @@ dword_result_t NtDuplicateObject_entry(dword_t handle, lpdword_t new_handle_ptr,
 }
 DECLARE_XBOXKRNL_EXPORT1(NtDuplicateObject, kNone, kImplemented);
 
-dword_result_t NtClose_entry(dword_t handle) {
+uint32_t NtClose(uint32_t handle) {
   return kernel_state()->object_table()->ReleaseHandle(handle);
 }
+
+dword_result_t NtClose_entry(dword_t handle) { return NtClose(handle); }
 DECLARE_XBOXKRNL_EXPORT1(NtClose, kNone, kImplemented);
 
 }  // namespace xboxkrnl

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.h
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.h
@@ -20,6 +20,7 @@ struct X_KEVENT;
 namespace xboxkrnl {
 
 uint32_t xeNtSetEvent(uint32_t handle, xe::be<uint32_t>* previous_state_ptr);
+
 uint32_t xeNtClearEvent(uint32_t handle);
 
 uint32_t xeNtWaitForMultipleObjectsEx(uint32_t count, xe::be<uint32_t>* handles,
@@ -30,11 +31,25 @@ uint32_t xeNtWaitForMultipleObjectsEx(uint32_t count, xe::be<uint32_t>* handles,
 uint32_t xeKeWaitForSingleObject(void* object_ptr, uint32_t wait_reason,
                                  uint32_t processor_mode, uint32_t alertable,
                                  uint64_t* timeout_ptr);
+
+uint32_t NtWaitForSingleObjectEx(uint32_t object_handle, uint32_t wait_mode,
+                                 uint32_t alertable, uint64_t* timeout_ptr);
+
 uint32_t xeKeSetEvent(X_KEVENT* event_ptr, uint32_t increment, uint32_t wait);
 
-uint32_t KeDelayExecutionThread(uint32_t processor_mode,
-                                      uint32_t alertable,
-                                      uint64_t* interval_ptr);
+uint32_t KeDelayExecutionThread(uint32_t processor_mode, uint32_t alertable,
+                                uint64_t* interval_ptr);
+
+uint32_t ExCreateThread(xe::be<uint32_t>* handle_ptr, uint32_t stack_size,
+                        xe::be<uint32_t>* thread_id_ptr,
+                        uint32_t xapi_thread_startup, uint32_t start_address,
+                        uint32_t start_context, uint32_t creation_flags);
+
+uint32_t ExTerminateThread(uint32_t exit_code);
+
+uint32_t NtResumeThread(uint32_t handle, uint32_t* suspend_count_ptr);
+
+uint32_t NtClose(uint32_t handle);
 
 }  // namespace xboxkrnl
 }  // namespace kernel


### PR DESCRIPTION
Implemented:

- XNotifyQueueUI - Basic ImGui Dialog
- XapipCreateThread
- CreateThread -> XapipCreateThread
- GetCurrentThreadId
- ResumeThread
- ExitThread
- CloseHandle
- GetModuleHandleA - Improved Implementation
- WaitForSingleObject -> WaitForSingleObjectEx -> XapiFormatTimeOut
- RtlSetLastNTError
- RtlGetLastError
- GetLastError -> RtlGetLastError
- XexLoadExecutable - Sketchy Implementation
- lstrlenW

`XNotifyQueueUI` is used by many plugins by implementing a stub i was able to load 12 plugins for **GTA V**, and some for **MW3** that would otherwise crash. Dashboards also use `XNotifyQueueUI` such as Xbox 360 Dashboard 17559 and Aurora.

Since these XAM functions are mostly wrappers for kernel functions that are already implemented, they are easy to "implement" so plugins can use them.

`XNotifyQueueUI` will display a basic ImGui dialog, however a proper implementation would require: `XNotifyQueueUI -> XNotifyQueueUIEx -> XMsgProcessRequest -> (XMsgStartIORequestEx & XMsgInProcessCall)`.

Notifications (XNotify) could be rendered similar to achievement notifications once properly implemented.