### PR TITLE
fix array index out of bounds crash in EmulatorWindow::ProcessControllerHotkey

### DIFF
--- a/src/xenia/app/emulator_window.cc
+++ b/src/xenia/app/emulator_window.cc
@@ -1304,8 +1304,9 @@ EmulatorWindow::ControllerHotKey EmulatorWindow::ProcessControllerHotkey(
       break;
   }
 
-  if (button_combination.function == ButtonFunctions::IncTitleSelect ||
-      button_combination.function == ButtonFunctions::DecTitleSelect) {
+  if ((button_combination.function == ButtonFunctions::IncTitleSelect ||
+      button_combination.function == ButtonFunctions::DecTitleSelect) &&
+      recently_launched_titles_.size() > 0) {
     selected_title_index = std::clamp(
         selected_title_index, 0, (int)recently_launched_titles_.size() - 1);
 


### PR DESCRIPTION
repro steps:

- start with an empty 'recently launched titles' history. this can be accomplished by deleting the 'recent.toml' file if it exists.
- press a hotkey for IncTitleSelect or DecTitleSelect. i was able to do this with 'shift+w' on my system

![crash](https://github.com/xenia-canary/xenia-canary/assets/8909245/1f41456d-cda4-4603-8f93-3f1909f85b95)
