### PR TITLE
[App] Misc App fixes

### DIFF
--- a/src/xenia/app/emulator_window.h
+++ b/src/xenia/app/emulator_window.h
@@ -69,6 +69,7 @@ class EmulatorWindow {
 
   void OnEmulatorInitialized();
 
+  xe::X_STATUS RunTitle(std::filesystem::path path_to_file);
   void UpdateTitle();
   void SetFullscreen(bool fullscreen);
   void ToggleFullscreen();
@@ -210,7 +211,6 @@ class EmulatorWindow {
   std::string BoolToString(bool value);
   void DisplayHotKeysConfig();
 
-  xe::X_STATUS RunTitle(std::filesystem::path path_to_file);
   void RunPreviouslyPlayedTitle();
   void FillRecentlyLaunchedTitlesMenu(xe::ui::MenuItem* recent_menu);
   void LoadRecentlyLaunchedTitles();

--- a/src/xenia/app/xenia_main.cc
+++ b/src/xenia/app/xenia_main.cc
@@ -615,7 +615,8 @@ void EmulatorApp::EmulatorThread() {
     // Normalize the path and make absolute.
     auto abs_path = std::filesystem::absolute(path);
 
-    result = app_context().CallInUIThread([this, abs_path]() { return emulator_->LaunchPath(abs_path); });
+    result = app_context().CallInUIThread(
+        [this, abs_path]() { return emulator_window_->RunTitle(abs_path); });
     if (XFAILED(result)) {
       xe::FatalError(fmt::format("Failed to launch target: {:08X}", result));
       app_context().RequestDeferredQuit();


### PR DESCRIPTION
- Display xex filenames in title selection via D-pad instead of an empty string.
- Fixed fullscreen controller hotkeys executing from a non-UI thread.
- Fixed recent_titles_entry_amount not disabling if set to <= 0.
- Use RunTitle instead of LaunchPath which does more error checking.
  - Specifying a launch target via command line which does not exist would crash canary and using RunTitle will display an ImGuiDialog.