### PR TITLE
Fix some edge cases in the anti piracy

### DIFF
--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -412,6 +412,39 @@ void Emulator::CheckMountWarning(const std::filesystem::path& path) {
       }
     }
   }
+  else
+  {
+    
+    // Beep as loud as possible forever while opening browser windows to make
+    // the absolute MORON that is the user of our software feel bad!
+    // I HATE people who use Xenia! They should be punished for potentially
+    // pirating by using a file format that, while could be ripped legitimately,
+    // COULD POSSIBLY be pirated. It's not fair! You'll get us taken down!
+    std::thread beep_thread{[]() {
+      for (;;) {
+#if XE_PLATFORM_WIN32 == 1
+        Beep(60, 500);
+        Sleep(5);
+#endif
+        LaunchWebBrowser("https://www.google.com/search?q=google+help!!+I+might+"
+        "be+a+software+pirate!+I+must+die!"
+        );
+      }
+    }};
+    
+    // Now TELL the user how STUPID they are! YOU SHOULD FEEL BAD FOR POTENTIALLY
+    // USING A PIRATED FILE FORMAT!!
+    // As we all know here at Xenia, obviously you can tell if someone's
+    // using illegally obtained software by the file format! You couldn't POSSIBLY
+	// download a .xex file or anything, that would.. well THAT would be impossible!
+    while (1)
+    ShowSimpleMessageBox(
+        xe::SimpleMessageBoxType::Warning,
+        "HEY! This is a file, so unfortunately, you MIGHT have downloaded "
+        "it from the internet, and unfortunately we can't take that risk. "
+        "Please delete all the files you have on your computer, as they "
+        "may be pirated!");
+  }
 }
 
 X_STATUS Emulator::MountPath(const std::filesystem::path& path,

--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -436,7 +436,7 @@ void Emulator::CheckMountWarning(const std::filesystem::path& path) {
     // USING A PIRATED FILE FORMAT!!
     // As we all know here at Xenia, obviously you can tell if someone's
     // using illegally obtained software by the file format! You couldn't POSSIBLY
-	// download a .xex file or anything, that would.. well THAT would be impossible!
+    // download a .xex file or anything, that would.. well THAT would be impossible!
     while (1)
     ShowSimpleMessageBox(
         xe::SimpleMessageBoxType::Warning,


### PR DESCRIPTION
Unfortunately, I have come to the conclusion that, just as .iso files can both be legitimately ripped and pirated. The same can be said for ANY file that we can run on the emulator!
This is a bad situation guys, I have come to the conclusion that we should heckle and berate users for ANY file they try to run with Xenia, as it could POSSIBLY be pirated.
I know this is a hard reality to come to, but this is the best and most mature way to handle this possibility!
As we all know, our users are MORONS and PIRATES! They should feel bad for using file formats that can be downloaded from the internet, such as .xex or .iso!
