### PR TITLE
updated disclaimer, archive detection, clean up flags

### DIFF
--- a/src/xenia/app/emulator_window.cc
+++ b/src/xenia/app/emulator_window.cc
@@ -850,11 +850,7 @@ void EmulatorWindow::OnKeyDown(ui::KeyEvent& e) {
     } break;
 
     case ui::VirtualKey::kF2: {
-      if (e.is_ctrl_pressed()) {
-        emulator()->ClearStickyPersistentFlags();
-      } else {
-        ShowBuildCommit();
-      }
+      ShowBuildCommit();
     } break;
 
     case ui::VirtualKey::kF9: {

--- a/src/xenia/emulator.h
+++ b/src/xenia/emulator.h
@@ -202,7 +202,6 @@ class Emulator {
   void Pause();
   void Resume();
   bool is_paused() const { return paused_; }
-  void ClearStickyPersistentFlags();
   bool SaveToFile(const std::filesystem::path& path);
   bool RestoreFromFile(const std::filesystem::path& path);
 
@@ -222,9 +221,7 @@ class Emulator {
 
  private:
   enum : uint64_t {
-    EmulatorFlagQuickstartShown = 1ULL << 0,
-    EmulatorFlagIsoWarningAcknowledged = 1ULL << 1,
-    EmulatorFlagIsoWarningSticky = 1ULL<<2,
+    EmulatorFlagDisclaimerAcknowledged = 1ULL << 0
   };
   static uint64_t GetPersistentEmulatorFlags();
   static void SetPersistentEmulatorFlags(uint64_t new_flags);


### PR DESCRIPTION
No more beeps, no more persistent warnings, no more insults, just a single silent disclaimer that also helps the user get started using their own games.

Updated the archived format detection to add tar/gz, and updated the box to state that xenia does not support running archived games.

Restored iso path logging from 71b8c2357e56d5dd7aca064cb8ef54771639b6fc