### PR TITLE
bit-perfect vrsqrtefp

### DIFF
--- a/src/xenia/cpu/backend/x64/x64_emitter.cc
+++ b/src/xenia/cpu/backend/x64/x64_emitter.cc
@@ -982,6 +982,16 @@ static inline vec128_t v128_setr_bytes(unsigned char v0, unsigned char v1,
   return result;
 }
 
+static inline vec128_t v128_setr_words(uint32_t v0, uint32_t v1, uint32_t v2,
+    uint32_t v3) {
+  vec128_t result;
+  result.u32[0] = v0;
+  result.u32[1] = v1;
+  result.u32[2] = v2;
+  result.u32[3] = v3;
+  return result;
+}
+
 static const vec128_t xmm_consts[] = {
     /* XMMZero                */ vec128f(0.0f),
     /* XMMByteSwapMask        */
@@ -1151,7 +1161,19 @@ static const vec128_t xmm_consts[] = {
     vec128b((uint8_t)0x83), /*XMMVSRShlByteshuf*/
     v128_setr_bytes(13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3, 0x80),
     // XMMVSRMask
-    vec128b(1)};
+    vec128b(1),
+    //XMMVRsqrteTableStart
+    v128_setr_words(0x568B4FD, 0x4F3AF97, 0x48DAAA5, 0x435A618),
+    v128_setr_words(0x3E7A1E4, 0x3A29DFE, 0x3659A5C, 0x32E96F8),
+    v128_setr_words(0x2FC93CA, 0x2D090CE, 0x2A88DFE, 0x2838B57),
+    v128_setr_words(0x26188D4, 0x2438673, 0x2268431, 0x20B820B),
+    v128_setr_words(0x3D27FFA, 0x3807C29, 0x33878AA, 0x2F97572),
+    v128_setr_words(0x2C27279, 0x2926FB7, 0x2666D26, 0x23F6AC0),
+    v128_setr_words(0x21D6881, 0x1FD6665, 0x1E16468, 0x1C76287),
+    v128_setr_words(0x1AF60C1, 0x1995F12, 0x1855D79, 0x1735BF4),
+    //XMMVRsqrteTableBase
+    vec128i(0) //filled in later
+};
 
 void* X64Emitter::FindByteConstantOffset(unsigned bytevalue) {
   for (auto& vec : xmm_consts) {
@@ -1223,7 +1245,17 @@ uintptr_t X64Emitter::PlaceConstData() {
 
   // The pointer must not be greater than 31 bits.
   assert_zero(reinterpret_cast<uintptr_t>(mem) & ~0x7FFFFFFF);
+
   std::memcpy(mem, xmm_consts, sizeof(xmm_consts));
+  /*
+    set each 32-bit element of the constant XMMVRsqrteTableBase to be the address of the start of the constant XMMVRsqrteTableStart
+    this 
+  */
+  vec128_t* deferred_constants = reinterpret_cast<vec128_t*>(mem);
+  vec128_t* vrsqrte_table_base = &deferred_constants[XMMVRsqrteTableBase];
+  uint32_t ptr_to_vrsqrte_table32 = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&deferred_constants[XMMVRsqrteTableStart]));
+  *vrsqrte_table_base = vec128i(ptr_to_vrsqrte_table32);
+
   memory::Protect(mem, kConstDataSize, memory::PageAccess::kReadOnly, nullptr);
 
   return reinterpret_cast<uintptr_t>(mem);
@@ -1237,8 +1269,9 @@ void X64Emitter::FreeConstData(uintptr_t data) {
 Xbyak::Address X64Emitter::GetXmmConstPtr(XmmConst id) {
   // Load through fixed constant table setup by PlaceConstData.
   // It's important that the pointer is not signed, as it will be sign-extended.
-  return ptr[reinterpret_cast<void*>(backend_->emitter_data() +
-                                     sizeof(vec128_t) * id)];
+  void* emitter_data_ptr = backend_->LookupXMMConstantAddress(static_cast<unsigned>(id));
+  xenia_assert(reinterpret_cast<uintptr_t>(emitter_data_ptr) < (1ULL << 31));//must not have signbit set
+  return ptr[emitter_data_ptr];
 }
 // Implies possible StashXmm(0, ...)!
 void X64Emitter::LoadConstantXmm(Xbyak::Xmm dest, const vec128_t& v) {
@@ -1634,9 +1667,9 @@ bool X64Emitter::ChangeMxcsrMode(MXCSRMode new_mode, bool already_set) {
     } else {  // even if already set, we still need to update flags to reflect
               // our mode
       if (new_mode == MXCSRMode::Fpu) {
-        btr(GetBackendFlagsPtr(), 0);
+        btr(GetBackendFlagsPtr(), kX64BackendMXCSRModeBit);
       } else if (new_mode == MXCSRMode::Vmx) {
-        bts(GetBackendFlagsPtr(), 0);
+        bts(GetBackendFlagsPtr(), kX64BackendMXCSRModeBit);
       } else {
         assert_unhandled_case(new_mode);
       }
@@ -1646,11 +1679,11 @@ bool X64Emitter::ChangeMxcsrMode(MXCSRMode new_mode, bool already_set) {
     if (!already_set) {
       if (new_mode == MXCSRMode::Fpu) {
         LoadFpuMxcsrDirect();
-        btr(GetBackendFlagsPtr(), 0);
+        btr(GetBackendFlagsPtr(), kX64BackendMXCSRModeBit);
         return true;
       } else if (new_mode == MXCSRMode::Vmx) {
         LoadVmxMxcsrDirect();
-        bts(GetBackendFlagsPtr(), 0);
+        bts(GetBackendFlagsPtr(), kX64BackendMXCSRModeBit);
         return true;
       } else {
         assert_unhandled_case(new_mode);

--- a/src/xenia/cpu/backend/x64/x64_emitter.h
+++ b/src/xenia/cpu/backend/x64/x64_emitter.h
@@ -174,7 +174,9 @@ enum XmmConst {
   XMMSTVLShuffle,
   XMMSTVRSwapMask,  // swapwordmask with bit 7 set
   XMMVSRShlByteshuf,
-  XMMVSRMask
+  XMMVSRMask,
+  XMMVRsqrteTableStart,
+  XMMVRsqrteTableBase = XMMVRsqrteTableStart + (32 / 4), //32 4-byte elements in table, 4 4-byte elements fit in each xmm
 
 };
 using amdfx::xopcompare_e;
@@ -308,7 +310,7 @@ class X64Emitter : public Xbyak::CodeGenerator {
 
   size_t stack_size() const { return stack_size_; }
   SimdDomain DeduceSimdDomain(const hir::Value* for_value);
-
+ 
   void ForgetMxcsrMode() { mxcsr_mode_ = MXCSRMode::Unknown; }
   /*
         returns true if had to load mxcsr. DOT_PRODUCT can use this to skip

--- a/src/xenia/cpu/hir/value.cc
+++ b/src/xenia/cpu/hir/value.cc
@@ -1805,6 +1805,86 @@ bool Value::AllUsesByOneInsn() const {
   }
   return true;
 }
+bool Value::AllFloatVectorLanesSameValue(const hir::Value* for_value,
+                                              uint32_t current_depth) {
+  // limit recursion, otherwise this function will slow down emission
+  if (current_depth == 16) {
+    return false;
+  }
+  using namespace hir;
+  hir::Instr* definition;
+  Opcode definition_opcode_number;
+re_enter:
+  definition = for_value->def;
+  if (!definition) {
+    xenia_assert(for_value->IsConstant());
+
+    auto&& constant_value = for_value->constant.v128;
+    for (unsigned constant_lane_index = 1; constant_lane_index < 4; ++constant_lane_index) {
+      if (constant_value.u32[0] != constant_value.u32[constant_lane_index]) {
+        return false;
+      }
+    }
+    return true;
+  }
+  definition_opcode_number = definition->GetOpcodeNum();
+
+  if (definition_opcode_number == OPCODE_ASSIGN) {
+    for_value = definition->src1.value;
+    goto re_enter;
+  }
+
+  if (definition_opcode_number == OPCODE_VECTOR_DENORMFLUSH) {
+    for_value = definition->src1.value;
+    goto re_enter;
+  }
+  /*
+    vmsum propagates its result to every lane
+  */
+  if (definition_opcode_number == OPCODE_DOT_PRODUCT_4 ||
+      definition_opcode_number == OPCODE_DOT_PRODUCT_3) {
+    return true;
+  }
+  //if splat of 32-bit value type, return true
+  //technically a splat of int16 or int8 would also produce the same "float" in all lanes
+  //but i think its best to keep this function focused on specifically float data
+  if (definition_opcode_number == OPCODE_SPLAT) {
+    if (definition->dest->type == VEC128_TYPE) {
+      auto splat_src_value_type = definition->src1.value->type;
+      if (splat_src_value_type == INT32_TYPE ||
+          splat_src_value_type == FLOAT32_TYPE) {
+        return true;
+      }
+    }
+  }
+
+  switch (definition_opcode_number) { 
+      //all of these opcodes produce the same value for the same input
+  case OPCODE_RSQRT:
+  case OPCODE_RECIP:
+  case OPCODE_POW2:
+  case OPCODE_LOG2:
+      for_value = definition->src1.value;
+      goto re_enter;
+
+    //binary opcodes
+  case OPCODE_ADD:
+  case OPCODE_SUB:
+  case OPCODE_MUL:
+      if (!AllFloatVectorLanesSameValue(definition->src1.value,
+                                        current_depth + 1)) {
+        return false;
+      }
+      for_value = definition->src2.value;
+      goto re_enter;
+  default:
+      break;
+  }
+
+  return false;
+}
+
+
 }  // namespace hir
 }  // namespace cpu
 }  // namespace xe

--- a/src/xenia/cpu/hir/value.h
+++ b/src/xenia/cpu/hir/value.h
@@ -618,8 +618,16 @@ class Value {
   bool MaybeFloaty() const {
     return type == FLOAT32_TYPE || type == FLOAT64_TYPE || type == VEC128_TYPE;
   }
-
+  bool AllFloatVectorLanesSameValue() const {
+    return Value::AllFloatVectorLanesSameValue(this);
+  }
  private:
+  /*
+returns true if for_value (which must be VEC128_TYPE) has the same value in
+every float
+*/
+  static bool AllFloatVectorLanesSameValue(const hir::Value* for_value,
+                                           uint32_t current_depth = 0);
   static bool CompareInt8(Opcode opcode, Value* a, Value* b);
   static bool CompareInt16(Opcode opcode, Value* a, Value* b);
   static bool CompareInt32(Opcode opcode, Value* a, Value* b);


### PR DESCRIPTION
Added a few backend features to help with SW fp versions of certain approximation functions

Scalar vrsqrtefp helper function only at the moment. Most games only use vrsqrtefp with results that come from vmsum3/4, which has the same value in every lane, so I added a compile time check that detects that are emits a scalar operation + broadcast of result, and a runtime one that detects if every element of the lane is zero. Otherwise it falls back to looping over the vector elements, calling the scalar helper on each. It's unlikely this causes any real performance impact. AVX2/AVX512 versions have not been done due to time constraints; this PR has already taken a very long time.

This function has been tested on all possible float bit patterns with NJM on both settings, this PR is based off of this C++ version of the algorithm, which is public domain: https://github.com/disjtqz/ppc_approximations/blob/main/vrsqrtefp.hpp

