### PR TITLE
frsqrte approximation

### DIFF
--- a/src/xenia/cpu/backend/x64/x64_backend.h
+++ b/src/xenia/cpu/backend/x64/x64_backend.h
@@ -193,6 +193,7 @@ class X64Backend : public Backend {
   void* reserved_store_64_helper = nullptr;
   void* vrsqrtefp_vector_helper = nullptr;
   void* vrsqrtefp_scalar_helper = nullptr;
+  void* frsqrtefp_helper = nullptr;
  private:
 #if XE_X64_PROFILER_AVAILABLE == 1
   GuestProfilerData profiler_data_;

--- a/src/xenia/cpu/backend/x64/x64_sequences.cc
+++ b/src/xenia/cpu/backend/x64/x64_sequences.cc
@@ -2110,13 +2110,9 @@ struct RSQRT_F64 : Sequence<RSQRT_F64, I<OPCODE_RSQRT, F64Op, F64Op>> {
   static void Emit(X64Emitter& e, const EmitArgType& i) {
     e.ChangeMxcsrMode(MXCSRMode::Fpu);
     Xmm src1 = GetInputRegOrConstant(e, i.src1, e.xmm3);
-    if (e.IsFeatureEnabled(kX64EmitAVX512Ortho)) {
-      e.vrsqrt14sd(i.dest, src1, src1);
-    } else {
-      e.vmovapd(e.xmm0, e.GetXmmConstPtr(XMMOnePD));
-      e.vsqrtsd(e.xmm1, src1, src1);
-      e.vdivsd(i.dest, e.xmm0, e.xmm1);
-    }
+    e.vmovsd(e.xmm0, src1);
+    e.call(e.backend()->frsqrtefp_helper);
+    e.vmovsd(i.dest, e.xmm0);
   }
 };
 struct RSQRT_V128 : Sequence<RSQRT_V128, I<OPCODE_RSQRT, V128Op, V128Op>> {


### PR DESCRIPTION
This PR implements frsqrte, based off of this public domain implementation: https://github.com/disjtqz/ppc_approximations/blob/main/frsqrte.hpp

This instruction is far simpler and inaccurate than the vector version, so not as many games use it. Non-IEEE mode is "supported", but not tested. The outputs of this instruction differ somewhat if certain FPSCR exception enable flags are on; this has not been emulated. 