### PR TITLE
fix user apc/kernel apc mixup

### DIFF
--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.cc
@@ -1178,12 +1178,9 @@ void KfLowerIrql_entry(dword_t new_irql, const ppc_context_t& ctx) {
   }
   kpcr->current_irql = new_irql;
   if (new_irql < 2) {
-    {
-      // this actually calls a function that eventually calls checkapcs.
-      // the called function does a ton of other stuff including changing the
-      // irql and interrupt_related
-      ctx.CurrentXThread()->CheckApcs();
-    }
+    // this actually calls a function that eventually calls checkapcs.
+    // the called function does a ton of other stuff including changing the
+    // irql and interrupt_related 
   }
 }
 DECLARE_XBOXKRNL_EXPORT2(KfLowerIrql, kThreading, kImplemented, kHighFrequency);

--- a/src/xenia/kernel/xthread.h
+++ b/src/xenia/kernel/xthread.h
@@ -259,7 +259,7 @@ class XThread : public XObject, public cpu::Thread {
   void AcquireMutantOnStartup(object_ref<XMutant> mutant) {
     pending_mutant_acquires_.push_back(mutant);
   }
-
+  void SetCurrentThread();
  protected:
   bool AllocateStack(uint32_t size);
   void FreeStack();


### PR DESCRIPTION
This PR allows Prince of Persia classic to go ingame.
Xenia triggers user apcs in places where only kernel apcs are supposed to happen. The two places that were problematic were LeaveCriticalRegion and KfLowerIrql. LeaveCriticalRegion could go into infinite recursion in POP and KfLowerIrql would cause a user callback to dereference a pointer that was null. User callbacks I believe only happen when the thread enters an alertable state via NtTestAlert, NtDelayExecution, or any other alertable wait.

Another APC-related issue was discovered: current_xthread_tls would be null in a user apc callback. This happens because Xenia emulates guest user APCs using host user APCs, and host user APCs execute in a different context that has different tls slots! To work around this, the current xthread is re-set to the value in the user callback lambda and threadstate is rebound as well, but all other thread_local variables are probably broken in user callbacks, and not much can be done about that right now.
