### PR TITLE
Total APC rewrite

### DIFF
--- a/src/xenia/guest_pointers.h
+++ b/src/xenia/guest_pointers.h
@@ -1,0 +1,51 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2020 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_GUEST_POINTERS_H_
+#define XENIA_GUEST_POINTERS_H_
+
+namespace xe {
+template <typename TBase, typename TAdj, size_t offset>
+struct ShiftedPointer {
+  using this_type = ShiftedPointer<TBase, TAdj, offset>;
+  TBase* m_base;
+  inline TBase* operator->() { return m_base; }
+
+  inline TBase& operator*() { return *m_base; }
+  inline this_type& operator=(TBase* base) {
+    m_base = base;
+    return *this;
+  }
+
+  inline this_type& operator=(this_type other) {
+    m_base = other.m_base;
+    return *this;
+  }
+
+  TAdj* GetAdjacent() {
+    return reinterpret_cast<TAdj*>(
+        &reinterpret_cast<uint8_t*>(m_base)[-static_cast<ptrdiff_t>(offset)]);
+  }
+};
+
+template <typename T>
+struct TypedGuestPointer {
+  xe::be<uint32_t> m_ptr;
+  inline TypedGuestPointer<T>& operator=(uint32_t ptr) {
+    m_ptr = ptr;
+    return *this;
+  }
+  inline bool operator==(uint32_t ptr) const { return m_ptr == ptr; }
+  inline bool operator!=(uint32_t ptr) const { return m_ptr != ptr; }
+  // use value directly, no endian swap needed
+  inline bool operator!() const { return !m_ptr.value; }
+};
+}  // namespace xe
+
+#endif  // XENIA_GUEST_POINTERS_H_

--- a/src/xenia/kernel/kernel_state.cc
+++ b/src/xenia/kernel/kernel_state.cc
@@ -138,13 +138,13 @@ util::XdbfGameData KernelState::module_xdbf(
 
 uint32_t KernelState::process_type() const {
   auto pib =
-      memory_->TranslateVirtual<ProcessInfoBlock*>(process_info_block_address_);
+      memory_->TranslateVirtual<X_KPROCESS*>(process_info_block_address_);
   return pib->process_type;
 }
 
 void KernelState::set_process_type(uint32_t value) {
   auto pib =
-      memory_->TranslateVirtual<ProcessInfoBlock*>(process_info_block_address_);
+      memory_->TranslateVirtual<X_KPROCESS*>(process_info_block_address_);
   pib->process_type = uint8_t(value);
 }
 
@@ -328,7 +328,7 @@ void KernelState::SetExecutableModule(object_ref<UserModule> module) {
   process_info_block_address_ = memory_->SystemHeapAlloc(0x60);
 
   auto pib =
-      memory_->TranslateVirtual<ProcessInfoBlock*>(process_info_block_address_);
+      memory_->TranslateVirtual<X_KPROCESS*>(process_info_block_address_);
   // TODO(benvanik): figure out what this list is.
   pib->unk_04 = pib->unk_08 = 0;
   pib->unk_0C = 0x0000007F;
@@ -343,7 +343,7 @@ void KernelState::SetExecutableModule(object_ref<UserModule> module) {
   xex2_opt_tls_info* tls_header = nullptr;
   executable_module_->GetOptHeader(XEX_HEADER_TLS_INFO, &tls_header);
   if (tls_header) {
-    auto pib = memory_->TranslateVirtual<ProcessInfoBlock*>(
+    auto pib = memory_->TranslateVirtual<X_KPROCESS*>(
         process_info_block_address_);
     pib->tls_data_size = tls_header->data_size;
     pib->tls_raw_data_size = tls_header->raw_data_size;

--- a/src/xenia/kernel/kernel_state.h
+++ b/src/xenia/kernel/kernel_state.h
@@ -51,7 +51,7 @@ constexpr uint32_t X_PROCTYPE_IDLE = 0;
 constexpr uint32_t X_PROCTYPE_USER = 1;
 constexpr uint32_t X_PROCTYPE_SYSTEM = 2;
 
-struct ProcessInfoBlock {
+struct X_KPROCESS {
   xe::be<uint32_t> unk_00;
   xe::be<uint32_t> unk_04;  // blink
   xe::be<uint32_t> unk_08;  // flink

--- a/src/xenia/kernel/util/kernel_fwd.h
+++ b/src/xenia/kernel/util/kernel_fwd.h
@@ -9,7 +9,7 @@ class XModule;
 class XNotifyListener;
 class XThread;
 class UserModule;
-struct ProcessInfoBlock;
+struct X_KPROCESS;
 struct TerminateNotification;
 struct X_TIME_STAMP_BUNDLE;
 class KernelState;

--- a/src/xenia/kernel/util/native_list.h
+++ b/src/xenia/kernel/util/native_list.h
@@ -50,7 +50,134 @@ class NativeList {
   Memory* memory_ = nullptr;
   uint32_t head_;
 };
+template <typename VirtualTranslator>
+static X_LIST_ENTRY* XeHostList(uint32_t ptr, VirtualTranslator context) {
+  return context->TranslateVirtual<X_LIST_ENTRY*>(ptr);
+}
+template <typename VirtualTranslator>
+static uint32_t XeGuestList(X_LIST_ENTRY* ptr, VirtualTranslator context) {
+  return context->HostToGuestVirtual(ptr);
+}
 
+// can either pass an object that adheres to the
+// HostToGuestVirtual/TranslateVirtual interface, or the original guest ptr for
+// arg 2
+template <typename VirtualTranslator>
+static void XeInitializeListHead(X_LIST_ENTRY* entry,
+                                 VirtualTranslator context) {
+  // is just a guest ptr?
+  if constexpr (std::is_unsigned_v<VirtualTranslator>) {
+    entry->blink_ptr = context;
+    entry->flink_ptr = context;
+  } else {
+    uint32_t orig_ptr = XeGuestList(entry, context);
+    entry->blink_ptr = orig_ptr;
+    entry->flink_ptr = orig_ptr;
+  }
+}
+
+template <typename VirtualTranslator>
+static bool XeIsListEmpty(X_LIST_ENTRY* entry, VirtualTranslator context) {
+  return XeHostList(entry->flink_ptr, context) == entry;
+}
+template <typename VirtualTranslator>
+static void XeRemoveEntryList(X_LIST_ENTRY* entry, VirtualTranslator context) {
+  uint32_t front = entry->flink_ptr;
+  uint32_t back = entry->blink_ptr;
+  XeHostList(back, context)->flink_ptr = front;
+  XeHostList(front, context)->blink_ptr = back;
+}
+template <typename VirtualTranslator>
+static void XeRemoveEntryList(uint32_t entry, VirtualTranslator context) {
+  XeRemoveEntryList(XeHostList(entry, context), context);
+}
+template <typename VirtualTranslator>
+static uint32_t XeRemoveHeadList(X_LIST_ENTRY* entry,
+                                 VirtualTranslator context) {
+  uint32_t result = entry->flink_ptr;
+  XeRemoveEntryList(result, context);
+  return result;
+}
+template <typename VirtualTranslator>
+static uint32_t XeRemoveTailList(X_LIST_ENTRY* entry,
+                                 VirtualTranslator context) {
+  uint32_t result = entry->blink_ptr;
+  XeRemoveEntryList(result, context);
+  return result;
+}
+template <typename VirtualTranslator>
+static void XeInsertTailList(X_LIST_ENTRY* list_head, uint32_t list_head_guest,
+                             X_LIST_ENTRY* host_entry, uint32_t entry,
+                             VirtualTranslator context) {
+  uint32_t old_tail = list_head->blink_ptr;
+  host_entry->flink_ptr = list_head_guest;
+  host_entry->blink_ptr = old_tail;
+  XeHostList(old_tail, context)->flink_ptr = entry;
+  list_head->blink_ptr = entry;
+}
+template <typename VirtualTranslator>
+static void XeInsertTailList(uint32_t list_head, uint32_t entry,
+                             VirtualTranslator context) {
+  XeInsertTailList(XeHostList(list_head, context), list_head,
+                   XeHostList(entry, context), entry, context);
+}
+template <typename VirtualTranslator>
+static void XeInsertTailList(X_LIST_ENTRY* list_head, uint32_t entry,
+                             VirtualTranslator context) {
+  XeInsertTailList(list_head, XeGuestList(list_head, context),
+                   XeHostList(entry, context), entry, context);
+}
+
+template <typename VirtualTranslator>
+static void XeInsertTailList(X_LIST_ENTRY* list_head, X_LIST_ENTRY* entry,
+                             VirtualTranslator context) {
+  XeInsertTailList(list_head, XeGuestList(list_head, context), entry,
+                   XeGuestList(entry, context), context);
+}
+
+template <typename VirtualTranslator>
+static void XeInsertHeadList(X_LIST_ENTRY* list_head, uint32_t list_head_guest,
+                             X_LIST_ENTRY* host_entry, uint32_t entry,
+                             VirtualTranslator context) {
+  uint32_t old_list_head_flink = list_head->flink_ptr;
+  host_entry->flink_ptr = old_list_head_flink;
+  host_entry->blink_ptr = list_head_guest;
+  XeHostList(old_list_head_flink, context)->blink_ptr = entry;
+  list_head->flink_ptr = entry;
+}
+
+template <typename VirtualTranslator>
+static void XeInsertHeadList(uint32_t list_head, uint32_t entry,
+                             VirtualTranslator context) {
+  XeInsertHeadList(XeHostList(list_head, context), list_head,
+                   XeHostList(entry, context), entry, context);
+}
+template <typename VirtualTranslator>
+static void XeInsertHeadList(X_LIST_ENTRY* list_head, uint32_t entry,
+                             VirtualTranslator context) {
+  XeInsertHeadList(list_head, XeGuestList(list_head, context),
+                   XeHostList(entry, context), entry, context);
+}
+template <typename TObject, size_t EntryListOffset>
+struct X_TYPED_LIST : public X_LIST_ENTRY {
+ public:
+  X_LIST_ENTRY* ObjectListEntry(TObject* obj) {
+    return reinterpret_cast<X_LIST_ENTRY*>(
+        &reinterpret_cast<char*>(obj)[static_cast<ptrdiff_t>(EntryListOffset)]);
+  }
+  TObject* ListEntryObject(X_LIST_ENTRY* entry) {
+    return reinterpret_cast<TObject*>(&reinterpret_cast<char*>(
+        entry)[-static_cast<ptrdiff_t>(EntryListOffset)]);
+  }
+  template <typename VirtualTranslator>
+  void Initialize(VirtualTranslator* translator) {
+    XeInitializeListHead(this, translator);
+  }
+  template <typename VirtualTranslator>
+  void InsertHead(TObject* entry, VirtualTranslator* translator) {
+    XeInsertHeadList(this, ObjectListEntry(entry), translator);
+  }
+};
 }  // namespace util
 }  // namespace kernel
 }  // namespace xe

--- a/src/xenia/kernel/xam/xam_info.cc
+++ b/src/xenia/kernel/xam/xam_info.cc
@@ -435,12 +435,12 @@ dword_result_t RtlSleep_entry(dword_t dwMilliseconds, dword_t bAlertable) {
                        : static_cast<LONGLONG>(-10000) * dwMilliseconds;
 
   X_STATUS result = xboxkrnl::KeDelayExecutionThread(MODE::UserMode, bAlertable,
-                                                     (uint64_t*)&delay);
+                                                     (uint64_t*)&delay, nullptr);
 
   // If the delay was interrupted by an APC, keep delaying the thread
   while (bAlertable && result == X_STATUS_ALERTED) {
     result = xboxkrnl::KeDelayExecutionThread(MODE::UserMode, bAlertable,
-                                              (uint64_t*)&delay);
+                                              (uint64_t*)&delay, nullptr);
   }
 
   return result == X_STATUS_SUCCESS ? X_STATUS_SUCCESS : X_STATUS_USER_APC;

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_misc.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_misc.cc
@@ -26,8 +26,8 @@ void KeEnableFpuExceptions_entry(
   // has to be saved to kthread, the irql changes, the machine state register is
   // changed to enable exceptions
 
-  X_KTHREAD* kthread = ctx->TranslateVirtual<X_KTHREAD*>(
-      ctx->TranslateVirtualGPR<X_KPCR*>(ctx->r[13])->current_thread);
+  X_KTHREAD* kthread = ctx->TranslateVirtual(
+      ctx->TranslateVirtualGPR<X_KPCR*>(ctx->r[13])->prcb_data.current_thread);
   kthread->fpu_exceptions_on = static_cast<uint32_t>(ctx->r[3]) != 0;
 }
 DECLARE_XBOXKRNL_EXPORT1(KeEnableFpuExceptions, kNone, kStub);

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.h
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.h
@@ -50,6 +50,16 @@ uint32_t ExTerminateThread(uint32_t exit_code);
 uint32_t NtResumeThread(uint32_t handle, uint32_t* suspend_count_ptr);
 
 uint32_t NtClose(uint32_t handle);
+void xeKeInitializeApc(XAPC* apc, uint32_t thread_ptr, uint32_t kernel_routine,
+                       uint32_t rundown_routine, uint32_t normal_routine,
+                       uint32_t apc_mode, uint32_t normal_context);
+
+void xeKfLowerIrql(PPCContext* ctx, unsigned char new_irql);
+unsigned char xeKfRaiseIrql(PPCContext* ctx, unsigned char new_irql);
+
+void xeKeKfReleaseSpinLock(PPCContext* ctx, X_KSPINLOCK* lock, dword_t old_irql, bool change_irql=true);
+uint32_t xeKeKfAcquireSpinLock(PPCContext* ctx, X_KSPINLOCK* lock, bool change_irql=true);
+
 
 }  // namespace xboxkrnl
 }  // namespace kernel

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.h
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.h
@@ -38,7 +38,8 @@ uint32_t NtWaitForSingleObjectEx(uint32_t object_handle, uint32_t wait_mode,
 uint32_t xeKeSetEvent(X_KEVENT* event_ptr, uint32_t increment, uint32_t wait);
 
 uint32_t KeDelayExecutionThread(uint32_t processor_mode, uint32_t alertable,
-                                uint64_t* interval_ptr);
+                                uint64_t* interval_ptr,
+                                cpu::ppc::PPCContext* ctx);
 
 uint32_t ExCreateThread(xe::be<uint32_t>* handle_ptr, uint32_t stack_size,
                         xe::be<uint32_t>* thread_id_ptr,
@@ -53,13 +54,21 @@ uint32_t NtClose(uint32_t handle);
 void xeKeInitializeApc(XAPC* apc, uint32_t thread_ptr, uint32_t kernel_routine,
                        uint32_t rundown_routine, uint32_t normal_routine,
                        uint32_t apc_mode, uint32_t normal_context);
-
+uint32_t xeKeInsertQueueApc(XAPC* apc, uint32_t arg1, uint32_t arg2,
+                            uint32_t priority_increment,
+                            cpu::ppc::PPCContext* context);
+uint32_t xeNtQueueApcThread(uint32_t thread_handle, uint32_t apc_routine,
+                            uint32_t apc_routine_context, uint32_t arg1,
+                            uint32_t arg2, cpu::ppc::PPCContext* context);
 void xeKfLowerIrql(PPCContext* ctx, unsigned char new_irql);
 unsigned char xeKfRaiseIrql(PPCContext* ctx, unsigned char new_irql);
 
 void xeKeKfReleaseSpinLock(PPCContext* ctx, X_KSPINLOCK* lock, dword_t old_irql, bool change_irql=true);
 uint32_t xeKeKfAcquireSpinLock(PPCContext* ctx, X_KSPINLOCK* lock, bool change_irql=true);
 
+X_STATUS xeProcessUserApcs(PPCContext* ctx);
+
+void xeRundownApcs(PPCContext* ctx);
 
 }  // namespace xboxkrnl
 }  // namespace kernel

--- a/src/xenia/kernel/xsemaphore.h
+++ b/src/xenia/kernel/xsemaphore.h
@@ -13,15 +13,9 @@
 #include "xenia/base/threading.h"
 #include "xenia/kernel/xobject.h"
 #include "xenia/xbox.h"
-
+#include "xenia/kernel/xthread.h"
 namespace xe {
 namespace kernel {
-
-struct X_KSEMAPHORE {
-  X_DISPATCH_HEADER header;
-  xe::be<uint32_t> limit;
-};
-static_assert_size(X_KSEMAPHORE, 0x14);
 
 class XSemaphore : public XObject {
  public:

--- a/src/xenia/kernel/xthread.h
+++ b/src/xenia/kernel/xthread.h
@@ -207,7 +207,8 @@ struct X_KTHREAD {
   TypedGuestPointer<X_KPROCESS> process;  // 0x84
   uint8_t unk_88[0x3];                    // 0x88
   uint8_t apc_related;                    // 0x8B
-  uint8_t unk_8C[0x10];                   // 0x8C
+  X_KSPINLOCK apc_lock;                   // 0x8C
+  uint8_t unk_90[0xC];                    // 0x90
   xe::be<uint32_t> msr_mask;              // 0x9C
   uint8_t unk_A0[4];                      // 0xA0
   uint8_t unk_A4;                         // 0xA4
@@ -313,13 +314,7 @@ class XThread : public XObject, public cpu::Thread {
 
   void EnterCriticalRegion();
   void LeaveCriticalRegion();
-  uint32_t RaiseIrql(uint32_t new_irql);
-  void LowerIrql(uint32_t new_irql);
 
-  void CheckApcs();
-  void LockApc();
-  void UnlockApc(bool queue_delivery);
-  util::NativeList* apc_list() { return &apc_list_; }
   void EnqueueApc(uint32_t normal_routine, uint32_t normal_context,
                   uint32_t arg1, uint32_t arg2);
 
@@ -388,10 +383,6 @@ class XThread : public XObject, public cpu::Thread {
   bool running_ = false;
 
   int32_t priority_ = 0;
-
-  xe::global_critical_region global_critical_region_;
-  std::atomic<uint32_t> irql_ = {0};
-  util::NativeList apc_list_;
 };
 
 class XHostThread : public XThread {

--- a/src/xenia/memory.h
+++ b/src/xenia/memory.h
@@ -20,7 +20,7 @@
 #include "xenia/base/memory.h"
 #include "xenia/base/mutex.h"
 #include "xenia/cpu/mmio_handler.h"
-
+#include "xenia/guest_pointers.h"
 namespace xe {
 class ByteStream;
 }  // namespace xe
@@ -368,6 +368,10 @@ class Memory {
     return reinterpret_cast<T>(host_address);
 
 #endif
+  }
+  template <typename T>
+  inline T* TranslateVirtual(TypedGuestPointer<T> guest_address) {
+    return TranslateVirtual<T*>(guest_address.m_ptr);
   }
 
   // Base address of physical memory in the host address space.

--- a/src/xenia/xbox.h
+++ b/src/xenia/xbox.h
@@ -329,6 +329,10 @@ typedef struct {
 } X_EXCEPTION_RECORD;
 static_assert_size(X_EXCEPTION_RECORD, 0x50);
 
+struct X_KSPINLOCK {
+  xe::be<uint32_t> prcb_of_owner;
+};
+static_assert_size(X_KSPINLOCK, 4);
 #pragma pack(pop)
 
 // Found by dumping the kSectionStringTable sections of various games:


### PR DESCRIPTION
This PR is what I hope will be part of a larger push to rewrite much of the kernel and shifting data/logic from the host wrapper objects like "XThread" and "XEvent" to their guest counterparts "X_KTHREAD" 

Allows the game "Things on Wheels" to reach the main menu, and sometimes go ingame (there seems to be another issue there, most of the time the menu fails to respond to input). This game used APCs recursively.

Now native win32 APCs are only used to wake up an alertable thread in order to process the guest APC queue. No guest code is executed in win32 APCs at all. This is also more portable.

This PR also adds a number of helper functions for additional kernel stuff, like operating on linked lists, translating linked list entries to their containing record, spinlocks, irql, etc.

This PR also defines a ton of X_KTHREAD and X_KPCR fields through reverse engineering, and cleans up some ancient xthread code.


