### PR TITLE
implement dynamically allocateable guest to host callbacks

### DIFF
--- a/src/xenia/base/bit_map.h
+++ b/src/xenia/base/bit_map.h
@@ -32,7 +32,7 @@ class BitMap {
   // (threadsafe) Acquires an entry and returns its index. Returns -1 if there
   // are no more free entries.
   size_t Acquire();
-
+  size_t AcquireFromBack();
   // (threadsafe) Releases an entry by an index.
   void Release(size_t index);
 
@@ -49,6 +49,7 @@ class BitMap {
   const static size_t kDataSize = 8;
   const static size_t kDataSizeBits = kDataSize * 8;
   std::vector<uint64_t> data_;
+  inline size_t TryAcquireAt(size_t i);
 };
 
 }  // namespace xe

--- a/src/xenia/cpu/backend/backend.h
+++ b/src/xenia/cpu/backend/backend.h
@@ -38,7 +38,9 @@ struct GuestPseudoStackTrace {
 };
 class Assembler;
 class CodeCache;
-
+using GuestTrampolineProc = void (*)(ppc::PPCContext* context, void* userarg1,
+                                     void* userarg2);
+using SimpleGuestTrampolineProc = void (*)(ppc::PPCContext*);
 class Backend {
  public:
   explicit Backend();
@@ -95,10 +97,73 @@ class Backend {
   virtual bool PopulatePseudoStacktrace(GuestPseudoStackTrace* st) {
     return false;
   }
+
+  virtual uint32_t CreateGuestTrampoline(GuestTrampolineProc proc,
+                                         void* userdata1, void* userdata2,
+                                         bool long_term = false) {
+    return 0;
+  }
+  uint32_t CreateGuestTrampoline(void (*func)(ppc::PPCContext*),
+                                 bool long_term = false) {
+    return CreateGuestTrampoline(
+        reinterpret_cast<GuestTrampolineProc>(reinterpret_cast<void*>(func)),
+        nullptr, nullptr);
+  }
+  // if long-term, allocate towards the back of bitset to make allocating short
+  // term ones faster
+  uint32_t CreateLongTermGuestTrampoline(void (*func)(ppc::PPCContext*)) {
+    return CreateGuestTrampoline(
+        reinterpret_cast<GuestTrampolineProc>(reinterpret_cast<void*>(func)),
+        nullptr, nullptr, true);
+  }
+  virtual void FreeGuestTrampoline(uint32_t trampoline_addr) {}
+
  protected:
   Processor* processor_ = nullptr;
   MachineInfo machine_info_;
   CodeCache* code_cache_ = nullptr;
+};
+/*
+ * a set of guest trampolines that all have shared ownership.
+ */
+struct GuestTrampolineGroup
+    : public std::map<SimpleGuestTrampolineProc, uint32_t> {
+  Backend* const m_backend;
+  xe_mutex m_mutex;
+
+  uint32_t _NewTrampoline(SimpleGuestTrampolineProc proc, bool longterm) {
+    uint32_t result;
+    m_mutex.lock();
+    auto iter = this->find(proc);
+    if (iter == this->end()) {
+      uint32_t new_entry = longterm
+                               ? m_backend->CreateLongTermGuestTrampoline(proc)
+                               : m_backend->CreateGuestTrampoline(proc);
+      this->emplace_hint(iter, proc, new_entry);
+      result = new_entry;
+    } else {
+      result = iter->second;
+    }
+    m_mutex.unlock();
+    return result;
+  }
+
+ public:
+  GuestTrampolineGroup(Backend* backend) : m_backend(backend) {}
+  ~GuestTrampolineGroup() {
+    m_mutex.lock();
+    for (auto&& entry : *this) {
+      m_backend->FreeGuestTrampoline(entry.second);
+    }
+    m_mutex.unlock();
+  }
+
+  uint32_t NewLongtermTrampoline(SimpleGuestTrampolineProc proc) {
+    return _NewTrampoline(proc, true);
+  }
+  uint32_t NewTrampoline(SimpleGuestTrampolineProc proc) {
+    return _NewTrampoline(proc, false);
+  }
 };
 
 }  // namespace backend


### PR DESCRIPTION
This PR adds two methods that cpu backends need to implement: CreateGuestTrampoline and FreeGuestTrampoline. CreateGuestTrampoline returns a guest-callable address that transfers execution to a host function. The host function receives the current PPCContext along with two optional additional arguments. The caller of CreateGuestTrampoline can specify that the trampoline will remain allocated for a very long period of time by passing true for the argument long_term.

The implementation for the X64Backend uses the hypervisor memory range's indirection table entries as the callback addresses.  It uses a Bitmap to represent which slots of the indirection table range have been allocated. If longterm is passed, indices are allocated starting from the back of the bitmap, otherwise they start at the front.

The thunks support both ms fastcall and system-v abis. 

This functionality is vital for properly/conveniently implementing kernel functionality like object type callbacks, device objects, APCs, DPCs.