### PR TITLE
Implement kernel processes

### DIFF
--- a/src/xenia/apu/audio_system.cc
+++ b/src/xenia/apu/audio_system.cc
@@ -21,6 +21,7 @@
 #include "xenia/base/string_buffer.h"
 #include "xenia/base/threading.h"
 #include "xenia/cpu/thread_state.h"
+#include "xenia/kernel/kernel_state.h"
 
 // As with normal Microsoft, there are like twelve different ways to access
 // the audio APIs. Early games use XMA*() methods almost exclusively to touch
@@ -79,7 +80,7 @@ X_STATUS AudioSystem::Setup(kernel::KernelState* kernel_state) {
       new kernel::XHostThread(kernel_state, 128 * 1024, 0, [this]() {
         WorkerThreadMain();
         return 0;
-      }));
+      }, kernel_state->GetSystemProcess()));
   // As we run audio callbacks the debugger must be able to suspend us.
   worker_thread_->set_can_debugger_suspend(true);
   worker_thread_->set_name("Audio Worker");

--- a/src/xenia/apu/xma_decoder.cc
+++ b/src/xenia/apu/xma_decoder.cc
@@ -19,7 +19,7 @@
 #include "xenia/cpu/processor.h"
 #include "xenia/cpu/thread_state.h"
 #include "xenia/kernel/xthread.h"
-
+#include "xenia/kernel/kernel_state.h"
 extern "C" {
 #include "third_party/FFmpeg/libavutil/log.h"
 }  // extern "C"
@@ -145,7 +145,7 @@ X_STATUS XmaDecoder::Setup(kernel::KernelState* kernel_state) {
       new kernel::XHostThread(kernel_state, 128 * 1024, 0, [this]() {
         WorkerThreadMain();
         return 0;
-      }));
+      }, kernel_state->GetIdleProcess()));//this one doesnt need any process actually. never calls any guest code
   worker_thread_->set_name("XMA Decoder");
   worker_thread_->set_can_debugger_suspend(true);
   worker_thread_->Create();

--- a/src/xenia/cpu/processor.cc
+++ b/src/xenia/cpu/processor.cc
@@ -432,50 +432,6 @@ uint64_t Processor::Execute(ThreadState* thread_state, uint32_t address,
   return context->r[3];
 }
 
-uint64_t Processor::ExecuteInterrupt(ThreadState* thread_state,
-                                     uint32_t address, uint64_t args[],
-                                     size_t arg_count) {
-  SCOPE_profile_cpu_f("cpu");
-
-  // Hold the global lock during interrupt dispatch.
-  // This will block if any code is in a critical region (has interrupts
-  // disabled) or if any other interrupt is executing.
-  auto global_lock = global_critical_region_.Acquire();
-
-  auto context = thread_state->context();
-  assert_true(arg_count <= 5);
-  for (size_t i = 0; i < arg_count; ++i) {
-    context->r[3 + i] = args[i];
-  }
-
-  // TLS ptr must be zero during interrupts. Some games check this and
-  // early-exit routines when under interrupts.
-  auto pcr_address =
-      memory_->TranslateVirtual(static_cast<uint32_t>(context->r[13]));
-  uint32_t old_tls_ptr = xe::load_and_swap<uint32_t>(pcr_address);
-  xe::store_and_swap<uint32_t>(pcr_address, 0);
-
-  if (!Execute(thread_state, address)) {
-    return 0xDEADBABE;
-  }
-
-  // Restores TLS ptr.
-  xe::store_and_swap<uint32_t>(pcr_address, old_tls_ptr);
-
-  return context->r[3];
-}
-
-Irql Processor::RaiseIrql(Irql new_value) {
-  return static_cast<Irql>(
-      xe::atomic_exchange(static_cast<uint32_t>(new_value),
-                          reinterpret_cast<volatile uint32_t*>(&irql_)));
-}
-
-void Processor::LowerIrql(Irql old_value) {
-  xe::atomic_exchange(static_cast<uint32_t>(old_value),
-                      reinterpret_cast<volatile uint32_t*>(&irql_));
-}
-
 bool Processor::Save(ByteStream* stream) {
   stream->Write(kProcessorSaveSignature);
   return true;

--- a/src/xenia/cpu/processor.h
+++ b/src/xenia/cpu/processor.h
@@ -123,11 +123,6 @@ class Processor {
   bool ExecuteRaw(ThreadState* thread_state, uint32_t address);
   uint64_t Execute(ThreadState* thread_state, uint32_t address, uint64_t args[],
                    size_t arg_count);
-  uint64_t ExecuteInterrupt(ThreadState* thread_state, uint32_t address,
-                            uint64_t args[], size_t arg_count);
-
-  Irql RaiseIrql(Irql new_value);
-  void LowerIrql(Irql old_value);
 
   bool Save(ByteStream* stream);
   bool Restore(ByteStream* stream);

--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -268,7 +268,13 @@ X_STATUS Emulator::Setup(
 
   // Shared kernel state.
   kernel_state_ = std::make_unique<xe::kernel::KernelState>(this);
-
+#define LOAD_KERNEL_MODULE(t) \
+  static_cast<void>(kernel_state_->LoadKernelModule<kernel::t>())
+  // HLE kernel modules.
+  LOAD_KERNEL_MODULE(xboxkrnl::XboxkrnlModule);
+  LOAD_KERNEL_MODULE(xam::XamModule);
+  LOAD_KERNEL_MODULE(xbdm::XbdmModule);
+#undef LOAD_KERNEL_MODULE
   plugin_loader_ = std::make_unique<xe::patcher::PluginLoader>(
       kernel_state_.get(), storage_root() / "plugins");
 
@@ -288,13 +294,6 @@ X_STATUS Emulator::Setup(
     }
   }
 
-#define LOAD_KERNEL_MODULE(t) \
-  static_cast<void>(kernel_state_->LoadKernelModule<kernel::t>())
-  // HLE kernel modules.
-  LOAD_KERNEL_MODULE(xboxkrnl::XboxkrnlModule);
-  LOAD_KERNEL_MODULE(xam::XamModule);
-  LOAD_KERNEL_MODULE(xbdm::XbdmModule);
-#undef LOAD_KERNEL_MODULE
 
   // Initialize emulator fallback exception handling last.
   ExceptionHandler::Install(Emulator::ExceptionCallbackThunk, this);

--- a/src/xenia/gpu/command_processor.cc
+++ b/src/xenia/gpu/command_processor.cc
@@ -104,7 +104,7 @@ bool CommandProcessor::Initialize() {
       new kernel::XHostThread(kernel_state_, 128 * 1024, 0, [this]() {
         WorkerThreadMain();
         return 0;
-      }));
+      }, kernel_state_->GetIdleProcess()));
   worker_thread_->set_name("GPU Commands");
   worker_thread_->Create();
 

--- a/src/xenia/kernel/kernel_state.h
+++ b/src/xenia/kernel/kernel_state.h
@@ -48,33 +48,41 @@ constexpr fourcc_t kKernelSaveSignature = make_fourcc("KRNL");
 
 // (?), used by KeGetCurrentProcessType
 constexpr uint32_t X_PROCTYPE_IDLE = 0;
-constexpr uint32_t X_PROCTYPE_USER = 1;
+constexpr uint32_t X_PROCTYPE_TITLE = 1;
 constexpr uint32_t X_PROCTYPE_SYSTEM = 2;
 
 struct X_KPROCESS {
-  xe::be<uint32_t> unk_00;
-  xe::be<uint32_t> unk_04;  // blink
-  xe::be<uint32_t> unk_08;  // flink
+  X_KSPINLOCK thread_list_spinlock;
+  // list of threads in this process, guarded by the spinlock above
+  X_LIST_ENTRY thread_list;
+
   xe::be<uint32_t> unk_0C;
-  xe::be<uint32_t> unk_10;
+  // kernel sets this to point to a section of size 0x2F700 called CLRDATAA,
+  // except it clears bit 31 of the pointer. in 17559 the address is 0x801C0000,
+  // so it sets this ptr to 0x1C0000
+  xe::be<uint32_t> clrdataa_masked_ptr;
   xe::be<uint32_t> thread_count;
   uint8_t unk_18;
   uint8_t unk_19;
   uint8_t unk_1A;
   uint8_t unk_1B;
   xe::be<uint32_t> kernel_stack_size;
-  xe::be<uint32_t> unk_20;
+  xe::be<uint32_t> tls_static_data_address;
   xe::be<uint32_t> tls_data_size;
   xe::be<uint32_t> tls_raw_data_size;
   xe::be<uint16_t> tls_slot_size;
-  uint8_t unk_2E;
+  // ExCreateThread calls a subfunc references this field, returns
+  // X_STATUS_PROCESS_IS_TERMINATING if true
+  uint8_t is_terminating;
+  // one of X_PROCTYPE_
   uint8_t process_type;
-  xe::be<uint32_t> bitmap[0x20 / 4];
+  xe::be<uint32_t> bitmap[8];
   xe::be<uint32_t> unk_50;
-  xe::be<uint32_t> unk_54;  // blink
-  xe::be<uint32_t> unk_58;  // flink
+  X_LIST_ENTRY unk_54;
   xe::be<uint32_t> unk_5C;
 };
+static_assert_size(X_KPROCESS, 0x60);
+
 
 struct TerminateNotification {
   uint32_t guest_routine;
@@ -92,6 +100,16 @@ struct X_TIME_STAMP_BUNDLE {
   uint32_t padding;
 };
 
+struct KernelGuestGlobals {
+  X_KPROCESS idle_process;    // X_PROCTYPE_IDLE. runs in interrupt contexts. is also the context the kernel starts in?
+  X_KPROCESS title_process;   // X_PROCTYPE_TITLE
+  X_KPROCESS system_process;  // X_PROCTYPE_SYSTEM. no idea when this runs. can
+                              // create threads in this process with
+                              // ExCreateThread and the thread flag 0x2
+};
+struct DPCImpersonationScope {
+  uint8_t previous_irql_;
+};
 class KernelState {
  public:
   explicit KernelState(Emulator* emulator);
@@ -147,10 +165,16 @@ class KernelState {
   // Access must be guarded by the global critical region.
   util::ObjectTable* object_table() { return &object_table_; }
 
-  uint32_t process_type() const;
-  void set_process_type(uint32_t value);
-  uint32_t process_info_block_address() const {
-    return process_info_block_address_;
+  uint32_t GetSystemProcess() const {
+    return kernel_guest_globals_ + offsetof(KernelGuestGlobals, system_process);
+  }
+
+  uint32_t GetTitleProcess() const {
+    return kernel_guest_globals_ + offsetof(KernelGuestGlobals, title_process);
+  }
+  // also the "interrupt" process
+  uint32_t GetIdleProcess() const {
+    return kernel_guest_globals_ + offsetof(KernelGuestGlobals, idle_process);
   }
 
   uint32_t AllocateTLS();
@@ -246,9 +270,20 @@ class KernelState {
   uint32_t CreateKeTimestampBundle();
   void UpdateKeTimestampBundle();
 
+  void BeginDPCImpersonation(cpu::ppc::PPCContext* context, DPCImpersonationScope& scope);
+  void EndDPCImpersonation(cpu::ppc::PPCContext* context,
+                           DPCImpersonationScope& end_scope);
+
+  void EmulateCPInterruptDPC(uint32_t interrupt_callback,uint32_t interrupt_callback_data, uint32_t source,
+                             uint32_t cpu);
+
  private:
   void LoadKernelModule(object_ref<KernelModule> kernel_module);
-
+  void InitializeProcess(X_KPROCESS* process, uint32_t type, char unk_18,
+                         char unk_19, char unk_1A);
+  void SetProcessTLSVars(X_KPROCESS* process, int num_slots, int tls_data_size,
+                         int tls_static_data_address);
+  void InitializeKernelGuestGlobals();
   Emulator* emulator_;
   Memory* memory_;
   cpu::Processor* processor_;
@@ -267,13 +302,11 @@ class KernelState {
   std::vector<object_ref<XNotifyListener>> notify_listeners_;
   bool has_notified_startup_ = false;
 
-  uint32_t process_type_ = X_PROCTYPE_USER;
   object_ref<UserModule> executable_module_;
   std::vector<object_ref<KernelModule>> kernel_modules_;
   std::vector<object_ref<UserModule>> user_modules_;
   std::vector<TerminateNotification> terminate_notifications_;
-
-  uint32_t process_info_block_address_ = 0;
+  uint32_t kernel_guest_globals_ = 0;
 
   std::atomic<bool> dispatch_thread_running_;
   object_ref<XHostThread> dispatch_thread_;

--- a/src/xenia/kernel/xam/xam_task.cc
+++ b/src/xenia/kernel/xam/xam_task.cc
@@ -68,7 +68,7 @@ dword_result_t XamTaskSchedule_entry(lpvoid_t callback,
 
   auto thread =
       object_ref<XThread>(new XThread(kernel_state(), stack_size, 0, callback,
-                                      message.guest_address(), 0, true));
+                                      message.guest_address(), 0, true, false, kernel_state()->GetSystemProcess()));
 
   X_STATUS result = thread->Create();
 

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.h
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_threading.h
@@ -63,13 +63,15 @@ uint32_t xeNtQueueApcThread(uint32_t thread_handle, uint32_t apc_routine,
 void xeKfLowerIrql(PPCContext* ctx, unsigned char new_irql);
 unsigned char xeKfRaiseIrql(PPCContext* ctx, unsigned char new_irql);
 
-void xeKeKfReleaseSpinLock(PPCContext* ctx, X_KSPINLOCK* lock, dword_t old_irql, bool change_irql=true);
-uint32_t xeKeKfAcquireSpinLock(PPCContext* ctx, X_KSPINLOCK* lock, bool change_irql=true);
+void xeKeKfReleaseSpinLock(PPCContext* ctx, X_KSPINLOCK* lock, uint32_t old_irql, bool change_irql=true);
+uint32_t xeKeKfAcquireSpinLock(PPCContext* ctx, X_KSPINLOCK* lock,
+                               bool change_irql = true);
 
 X_STATUS xeProcessUserApcs(PPCContext* ctx);
 
 void xeRundownApcs(PPCContext* ctx);
-
+uint32_t xeKeGetCurrentProcessType(PPCContext* context);
+void xeKeSetCurrentProcessType(uint32_t type, PPCContext* context);
 }  // namespace xboxkrnl
 }  // namespace kernel
 }  // namespace xe

--- a/src/xenia/xbox.h
+++ b/src/xenia/xbox.h
@@ -71,6 +71,7 @@ typedef uint32_t X_STATUS;
 #define X_STATUS_INVALID_PARAMETER_1                    ((X_STATUS)0xC00000EFL)
 #define X_STATUS_INVALID_PARAMETER_2                    ((X_STATUS)0xC00000F0L)
 #define X_STATUS_INVALID_PARAMETER_3                    ((X_STATUS)0xC00000F1L)
+#define X_STATUS_PROCESS_IS_TERMINATING                 ((X_STATUS)0xC000010AL)
 #define X_STATUS_DLL_NOT_FOUND                          ((X_STATUS)0xC0000135L)
 #define X_STATUS_ENTRYPOINT_NOT_FOUND                   ((X_STATUS)0xC0000139L)
 #define X_STATUS_MAPPED_ALIGNMENT                       ((X_STATUS)0xC0000220L)


### PR DESCRIPTION
Fixes the game "Neo-geo Bat Colliseum" 🦇
Also fixes a regression introduced in APC changes that would cause the game Meincraft to crash.


This is only an initial implementation, there is still much more to do. Kernel processes do not run in different address spaces, but they do have different TLS slots, and different code paths are taken in titles depending on the current process type.

There are 3 processes: Title, System, and Idle. 

Interrupts execute in idle process. Graphics interrupts execute in a DPC context that pretends to be the title process, but is really idle process.
Audio driver callbacks execute in system process. 
Passing flag 2 for ExCreateThread creates a thread in the system process (many games do this)
Xam tasks execute in system process.

Other Xenia-specific threads were assigned to processes based on whether they emulated hardware (idle process) or software ( system process). 
