### PR TITLE
[Kernel] nonintrusive guest to host object mapping

### DIFF
--- a/src/xenia/kernel/util/kernel_fwd.h
+++ b/src/xenia/kernel/util/kernel_fwd.h
@@ -17,9 +17,7 @@ struct XAPC;
 
 struct X_KPCR;
 struct X_KTHREAD;
-struct X_OBJECT_HEADER;
 struct X_OBJECT_CREATE_INFORMATION;
-struct X_OBJECT_TYPE;
 
 }  // namespace xe::kernel
 

--- a/src/xenia/kernel/util/object_table.cc
+++ b/src/xenia/kernel/util/object_table.cc
@@ -479,6 +479,31 @@ X_STATUS ObjectTable::RestoreHandle(X_HANDLE handle, XObject* object) {
   return X_STATUS_SUCCESS;
 }
 
+void ObjectTable::MapGuestObjectToHostHandle(uint32_t guest_object,
+                                             X_HANDLE host_handle) {
+  auto global_lock = global_critical_region_.Acquire();
+  guest_to_host_handle_[guest_object] = host_handle;
+}
+bool ObjectTable::HostHandleForGuestObject(uint32_t guest_object, X_HANDLE& out) {
+  auto global_lock = global_critical_region_.Acquire();
+  auto gobj_iter = guest_to_host_handle_.find(guest_object);
+  if (gobj_iter == guest_to_host_handle_.end()) {
+    return false;
+  }
+  out = gobj_iter->second;
+  return true;
+}
+
+void ObjectTable::UnmapGuestObjectHostHandle(uint32_t guest_object) {
+  auto global_lock = global_critical_region_.Acquire();
+  auto iter = guest_to_host_handle_.find(guest_object);
+  if (iter == guest_to_host_handle_.end()) {
+    return;
+  } else {
+    guest_to_host_handle_.erase(iter);
+  }
+}
+
 }  // namespace util
 }  // namespace kernel
 }  // namespace xe

--- a/src/xenia/kernel/util/object_table.h
+++ b/src/xenia/kernel/util/object_table.h
@@ -80,6 +80,9 @@ class ObjectTable {
   std::vector<object_ref<XObject>> GetAllObjects();
   void PurgeAllObjects();  // Purges the object table of all guest objects
 
+  void MapGuestObjectToHostHandle(uint32_t guest_object, X_HANDLE host_handle);
+  void UnmapGuestObjectHostHandle(uint32_t guest_object);
+  bool HostHandleForGuestObject(uint32_t guest_object, X_HANDLE& out);
  private:
   struct ObjectTableEntry {
     int handle_ref_count = 0;
@@ -107,6 +110,7 @@ class ObjectTable {
   uint32_t last_free_entry_ = 0;
   uint32_t last_free_host_entry_ = 0;
   std::unordered_map<string_key_case, X_HANDLE> name_table_;
+  std::unordered_map<uint32_t, X_HANDLE> guest_to_host_handle_;
 };
 
 // Generic lookup

--- a/src/xenia/kernel/xobject.h
+++ b/src/xenia/kernel/xobject.h
@@ -62,28 +62,6 @@ typedef struct {
 } X_DISPATCH_HEADER;
 static_assert_size(X_DISPATCH_HEADER, 0x10);
 
-// https://www.nirsoft.net/kernel_struct/vista/OBJECT_HEADER.html
-struct X_OBJECT_HEADER {
-  xe::be<uint32_t> pointer_count;
-  union {
-    xe::be<uint32_t> handle_count;
-    xe::be<uint32_t> next_to_free;
-  };
-  uint8_t name_info_offset;
-  uint8_t handle_info_offset;
-  uint8_t quota_info_offset;
-  uint8_t flags;
-  union {
-    xe::be<uint32_t> object_create_info;  // X_OBJECT_CREATE_INFORMATION
-    xe::be<uint32_t> quota_block_charged;
-  };
-  xe::be<uint32_t> object_type_ptr;  // -0x8 POBJECT_TYPE
-  xe::be<uint32_t> unk_04;           // -0x4
-
-  // Object lives after this header.
-  // (There's actually a body field here which is the object itself)
-};
-
 // https://www.nirsoft.net/kernel_struct/vista/OBJECT_CREATE_INFORMATION.html
 struct X_OBJECT_CREATE_INFORMATION {
   xe::be<uint32_t> attributes;                  // 0x0
@@ -97,16 +75,6 @@ struct X_OBJECT_CREATE_INFORMATION {
   xe::be<uint32_t> security_qos_ptr;            // 0x20
 
   // Security QoS here (SECURITY_QUALITY_OF_SERVICE) too!
-};
-
-struct X_OBJECT_TYPE {
-  xe::be<uint32_t> constructor;  // 0x0
-  xe::be<uint32_t> destructor;   // 0x4
-  xe::be<uint32_t> unk_08;       // 0x8
-  xe::be<uint32_t> unk_0C;       // 0xC
-  xe::be<uint32_t> unk_10;       // 0x10
-  xe::be<uint32_t> unk_14;    // 0x14 probably offset from ntobject to keobject
-  xe::be<uint32_t> pool_tag;  // 0x18
 };
 
 class XObject {
@@ -221,11 +189,7 @@ class XObject {
     return reinterpret_cast<T*>(CreateNative(sizeof(T)));
   }
 
-  // Stash native pointer into X_DISPATCH_HEADER
-  static void StashHandle(X_DISPATCH_HEADER* header, uint32_t handle) {
-    header->wait_list_flink = kXObjSignature;
-    header->wait_list_blink = handle;
-  }
+
 
   static uint32_t TimeoutTicksToMs(int64_t timeout_ticks);
 

--- a/src/xenia/vfs/devices/xcontent_devices/stfs_container_device.cc
+++ b/src/xenia/vfs/devices/xcontent_devices/stfs_container_device.cc
@@ -250,7 +250,7 @@ void StfsContainerDevice::UpdateCachedHashTable(
     xe::filesystem::Seek(file, hash_offset + secondary_table_offset, SEEK_SET);
     StfsHashTable table;
     if (fread(&table, sizeof(StfsHashTable), 1, file) != 1) {
-      XELOGE("GetBlockHash failed to read level{} hash table at 0x{X}",
+      XELOGE("GetBlockHash failed to read level{} hash table at 0x{:08X}",
              hash_level, hash_offset + secondary_table_offset);
       return;
     }

--- a/src/xenia/xbox.h
+++ b/src/xenia/xbox.h
@@ -312,12 +312,62 @@ struct X_EX_TITLE_TERMINATE_REGISTRATION {
 };
 static_assert_size(X_EX_TITLE_TERMINATE_REGISTRATION, 16);
 
+
+enum X_OBJECT_HEADER_FLAGS : uint16_t {
+  OBJECT_HEADER_FLAG_NAMED_OBJECT =
+      1,  // if set, has X_OBJECT_HEADER_NAME_INFO prior to X_OBJECT_HEADER
+  OBJECT_HEADER_FLAG_IS_PERMANENT = 2,
+  OBJECT_HEADER_FLAG_CONTAINED_IN_DIRECTORY =
+      4,  // this object resides in an X_OBJECT_DIRECTORY
+  OBJECT_HEADER_IS_TITLE_OBJECT = 0x10,  // used in obcreateobject
+
+};
+
+// https://www.nirsoft.net/kernel_struct/vista/OBJECT_HEADER.html
+struct X_OBJECT_HEADER {
+  xe::be<uint32_t> pointer_count;
+  xe::be<uint32_t> handle_count;
+  xe::be<uint32_t> object_type_ptr;  // -0x8 POBJECT_TYPE
+  xe::be<uint16_t> flags;
+  uint8_t unknownE;
+  uint8_t unknownF;
+  // Object lives after this header.
+  // (There's actually a body field here which is the object itself)
+};
+static_assert_size(X_OBJECT_HEADER, 0x10);
+
+struct X_OBJECT_DIRECTORY {
+  // each is a pointer to X_OBJECT_HEADER_NAME_INFO
+  // i believe offset 0 = pointer to next in bucket
+  xe::be<uint32_t> name_buckets[13];
+};
+static_assert_size(X_OBJECT_DIRECTORY, 0x34);
+
+// https://www.geoffchappell.com/studies/windows/km/ntoskrnl/inc/ntos/ob/object_header_name_info.htm
+// quite different, though
+struct X_OBJECT_HEADER_NAME_INFO {
+  // i think that this is the next link in an X_OBJECT_DIRECTORY's buckets
+  xe::be<uint32_t> next_in_directory;
+  xe::be<uint32_t> object_directory;  // pointer to X_OBJECT_DIRECTORY
+  X_ANSI_STRING name;
+};
 struct X_OBJECT_ATTRIBUTES {
   xe::be<uint32_t> root_directory;  // 0x0
   xe::be<uint32_t> name_ptr;        // 0x4 PANSI_STRING
   xe::be<uint32_t> attributes;      // 0xC
 };
-
+struct X_OBJECT_TYPE {
+  xe::be<uint32_t> allocate_proc;  // 0x0
+  xe::be<uint32_t> free_proc;      // 0x4
+  xe::be<uint32_t> close_proc;     // 0x8
+  xe::be<uint32_t> delete_proc;    // 0xC
+  xe::be<uint32_t> unknown_proc;   // 0x10
+  xe::be<uint32_t>
+      unknown_size_or_object_;  // this seems to be a union, it can be a pointer
+                                // or it can be the size of the object
+  xe::be<uint32_t> pool_tag;    // 0x18
+};
+static_assert_size(X_OBJECT_TYPE, 0x1C);
 // https://msdn.microsoft.com/en-us/library/windows/desktop/aa363082.aspx
 typedef struct {
   // Renamed due to a collision with exception_code from Windows excpt.h.


### PR DESCRIPTION
This PR allow Halo 4 to go ingame (it requires gpu_allow_invalid_fetch_constants=false to render anything though) and fixes the Diablo 4 ROS main menu freeze.

Previously, the handle for a guest object was stored in the guest object's X_DISPATCHER_HEADER, except that it turns out plenty of objects do not have this header (devices, files, xenumerator, symbolic links, etc) so instead we just clobber random data at the start of the object. Now we store them in an unordered_map. 

Added some more object related enums/structures. Fixed the size of X_OBJECT_HEADER, its 16 not 24. No longer allocate X_OBJECT_TYPE every time, or set it at all. It was being stored to the wrong location anyway.
