### PR TITLE
Implement ObCreateObject

### DIFF
--- a/src/xenia/cpu/processor.cc
+++ b/src/xenia/cpu/processor.cc
@@ -1300,12 +1300,12 @@ uint32_t Processor::GuestAtomicIncrement32(ppc::PPCContext* context,
     result = *host_address;
     // todo: should call a processor->backend function that acquires a
     // reservation instead of using host atomics
-    if (xe::atomic_cas(xe::byte_swap(result), xe::byte_swap(result + 1),
+    if (xe::atomic_cas(result, xe::byte_swap(xe::byte_swap(result)+1),
                        host_address)) {
       break;
     }
   }
-  return result;
+  return xe::byte_swap(result);
 }
 uint32_t Processor::GuestAtomicDecrement32(ppc::PPCContext* context,
                                            uint32_t guest_address) {
@@ -1316,31 +1316,31 @@ uint32_t Processor::GuestAtomicDecrement32(ppc::PPCContext* context,
     result = *host_address;
     // todo: should call a processor->backend function that acquires a
     // reservation instead of using host atomics
-    if (xe::atomic_cas(xe::byte_swap(result), xe::byte_swap(result - 1),
+    if (xe::atomic_cas(result,xe::byte_swap( xe::byte_swap(result)-1),
                        host_address)) {
       break;
     }
   }
-  return result;
+  return xe::byte_swap(result);
 }
 
 uint32_t Processor::GuestAtomicOr32(ppc::PPCContext* context,
                                     uint32_t guest_address, uint32_t mask) {
-  return xe::atomic_or(
+  return xe::byte_swap(xe::atomic_or(
       context->TranslateVirtual<volatile int32_t*>(guest_address),
-      xe::byte_swap(mask));
+      xe::byte_swap(mask)));
 }
 uint32_t Processor::GuestAtomicXor32(ppc::PPCContext* context,
                                      uint32_t guest_address, uint32_t mask) {
-  return xe::atomic_xor(
+  return xe::byte_swap(xe::atomic_xor(
       context->TranslateVirtual<volatile int32_t*>(guest_address),
-      xe::byte_swap(mask));
+      xe::byte_swap(mask)));
 }
 uint32_t Processor::GuestAtomicAnd32(ppc::PPCContext* context,
                                      uint32_t guest_address, uint32_t mask) {
-  return xe::atomic_and(
+  return xe::byte_swap(xe::atomic_and(
       context->TranslateVirtual<volatile int32_t*>(guest_address),
-      xe::byte_swap(mask));
+      xe::byte_swap(mask)));
 }
 
 bool Processor::GuestAtomicCAS32(ppc::PPCContext* context, uint32_t old_value,

--- a/src/xenia/kernel/util/object_table.cc
+++ b/src/xenia/kernel/util/object_table.cc
@@ -503,6 +503,19 @@ void ObjectTable::UnmapGuestObjectHostHandle(uint32_t guest_object) {
     guest_to_host_handle_.erase(iter);
   }
 }
+void ObjectTable::FlushGuestToHostMapping(uint32_t base_address,
+                                          uint32_t length) {
+  auto global_lock = global_critical_region_.Acquire();
+  auto iterator = guest_to_host_handle_.lower_bound(base_address);
+
+  while (iterator !=guest_to_host_handle_.end() && iterator->first >= base_address && iterator->first < (base_address + length)) {
+    auto old_mapping = iterator;
+
+    iterator++;
+    auto node_handle = guest_to_host_handle_.extract(old_mapping);
+
+  }
+}
 
 }  // namespace util
 }  // namespace kernel

--- a/src/xenia/kernel/util/object_table.h
+++ b/src/xenia/kernel/util/object_table.h
@@ -83,6 +83,7 @@ class ObjectTable {
   void MapGuestObjectToHostHandle(uint32_t guest_object, X_HANDLE host_handle);
   void UnmapGuestObjectHostHandle(uint32_t guest_object);
   bool HostHandleForGuestObject(uint32_t guest_object, X_HANDLE& out);
+  void FlushGuestToHostMapping(uint32_t base_address, uint32_t length);
  private:
   struct ObjectTableEntry {
     int handle_ref_count = 0;
@@ -110,7 +111,7 @@ class ObjectTable {
   uint32_t last_free_entry_ = 0;
   uint32_t last_free_host_entry_ = 0;
   std::unordered_map<string_key_case, X_HANDLE> name_table_;
-  std::unordered_map<uint32_t, X_HANDLE> guest_to_host_handle_;
+  std::map<uint32_t, X_HANDLE> guest_to_host_handle_;
 };
 
 // Generic lookup

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_ob.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_ob.cc
@@ -11,6 +11,7 @@
 #include "xenia/base/assert.h"
 #include "xenia/base/atomic.h"
 #include "xenia/base/logging.h"
+#include "xenia/base/utf8.h"
 #include "xenia/cpu/processor.h"
 #include "xenia/kernel/kernel_state.h"
 #include "xenia/kernel/util/shim_utils.h"
@@ -23,68 +24,12 @@
 namespace xe {
 namespace kernel {
 namespace xboxkrnl {
+
 void xeObSplitName(X_ANSI_STRING input_string,
                    X_ANSI_STRING* leading_path_component,
                    X_ANSI_STRING* remaining_path_components,
                    PPCContext* context) {
-  leading_path_component->length = 0;
-  leading_path_component->maximum_length = 0;
-
-  leading_path_component->pointer = 0;
-  remaining_path_components->length = 0;
-  remaining_path_components->maximum_length = 0;
-  remaining_path_components->pointer = 0;
-  uint32_t input_length32 = input_string.length;
-  if (!input_length32) {
-    return;
-  }
-  unsigned char* input_string_buffer =
-      context->TranslateVirtual<uint8_t*>(input_string.pointer);
-  unsigned char first_char = *input_string_buffer;
-  // if it begins with a sep, start iterating at index 1
-
-  uint32_t starting_index = first_char == '\\' ? 1U : 0U;
-  // if the string is just a single sep and nothing else, set leading component
-  // to empty string w/ valid pointer and terminate
-  if (starting_index >= input_length32) {
-    leading_path_component->length = 0U;
-    leading_path_component->maximum_length = 0U;
-    leading_path_component->pointer =
-        context->HostToGuestVirtual(&input_string_buffer[starting_index]);
-    return;
-  }
-
-  int32_t decrementer = (-static_cast<int32_t>(starting_index)) -1;
-  unsigned char* current_character_ptr = &input_string_buffer[starting_index];
-  uint32_t leading_path_component_length = 0;
-  uint16_t full_possible_length =
-      static_cast<uint16_t>(input_length32 - starting_index);
-  while (*current_character_ptr != '\\') {
-    ++leading_path_component_length;
-    ++current_character_ptr;
-    int32_t check_done = input_length32 + decrementer - 1;
-    decrementer--;
-    if (check_done == -1) {
-      // hit the end of the string! no remaining path components
-
-      leading_path_component->length = full_possible_length;
-      leading_path_component->maximum_length = full_possible_length;
-      leading_path_component->pointer =
-          context->HostToGuestVirtual(&input_string_buffer[starting_index]);
-      return;
-    }
-  }
-  // hit the end of the current components, but more components remain
-  leading_path_component->length = leading_path_component_length;
-  leading_path_component->maximum_length = leading_path_component_length;
-  leading_path_component->pointer =
-      context->HostToGuestVirtual(&input_string_buffer[starting_index]);
-  uint16_t remainder_length = static_cast<uint16_t>(
-      input_length32 - (first_char == '\\') + ~leading_path_component_length);
-  remaining_path_components->length = remainder_length;
-  remaining_path_components->pointer =
-      context->HostToGuestVirtual(&input_string_buffer[-decrementer]);
-  remaining_path_components->maximum_length = remainder_length;
+  xe::FatalError("xeObSplitName unimplemented!");
 }
 
 uint32_t xeObHashObjectName(X_ANSI_STRING* ElementName, PPCContext* context) {

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_ob.h
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_ob.h
@@ -16,7 +16,15 @@ namespace xe {
 namespace kernel {
 namespace xboxkrnl {
 void xeObDereferenceObject(PPCContext* context, uint32_t native_ptr);
-
+void xeObSplitName(X_ANSI_STRING input_string,
+                   X_ANSI_STRING* leading_path_component,
+                   X_ANSI_STRING* remaining_path_components,
+                   PPCContext* context);
+uint32_t xeObHashObjectName(X_ANSI_STRING* ElementName, PPCContext* context);
+uint32_t xeObCreateObject(X_OBJECT_TYPE* object_factory,
+                          X_OBJECT_ATTRIBUTES* optional_attributes,
+                          uint32_t object_size_sans_headers,
+                          uint32_t* out_object, cpu::ppc::PPCContext* context);
 }  // namespace xboxkrnl
 }  // namespace kernel
 }  // namespace xe

--- a/src/xenia/kernel/xobject.h
+++ b/src/xenia/kernel/xobject.h
@@ -102,9 +102,39 @@ class XObject {
     SymbolicLink,
     Thread,
     Timer,
-	Device
+    Device
   };
 
+  static bool HasDispatcherHeader(Type type) {
+    switch (type) {
+      case Type::Event:
+      case Type::Mutant:
+      case Type::Semaphore:
+      case Type::Thread:
+      case Type::Timer:
+        return true;
+    }
+    return false;
+  }
+
+  static Type MapGuestTypeToHost(uint16_t type) {
+    // todo: this is not fully filled in
+    switch (type) {
+      case 0:
+      case 1:
+        return Type::Event;
+      case 2:
+        return Type::Mutant;
+      case 5:
+        return Type::Semaphore;
+      case 6:
+        return Type::Thread;
+      case 8:
+      case 9:
+        return Type::Timer;
+    }
+    return Type::Undefined;
+  }
   XObject(Type type);
   XObject(KernelState* kernel_state, Type type, bool host_object = false);
   virtual ~XObject();
@@ -188,8 +218,6 @@ class XObject {
   T* CreateNative() {
     return reinterpret_cast<T*>(CreateNative(sizeof(T)));
   }
-
-
 
   static uint32_t TimeoutTicksToMs(int64_t timeout_ticks);
 

--- a/src/xenia/memory.cc
+++ b/src/xenia/memory.cc
@@ -608,13 +608,13 @@ uint32_t Memory::SystemHeapAlloc(uint32_t size, uint32_t alignment,
   return address;
 }
 
-void Memory::SystemHeapFree(uint32_t address) {
+void Memory::SystemHeapFree(uint32_t address, uint32_t* out_region_size) {
   if (!address) {
     return;
   }
   // TODO(benvanik): lightweight pool.
   auto heap = LookupHeap(address);
-  heap->Release(address);
+  heap->Release(address, out_region_size);
 }
 
 void Memory::DumpMap() {

--- a/src/xenia/memory.h
+++ b/src/xenia/memory.h
@@ -511,7 +511,7 @@ class Memory {
                            uint32_t system_heap_flags = kSystemHeapDefault);
 
   // Frees memory allocated with SystemHeapAlloc.
-  void SystemHeapFree(uint32_t address);
+  void SystemHeapFree(uint32_t address, uint32_t* out_region_size=nullptr);
 
   // Gets the heap for the address space containing the given address.
   XE_NOALIAS


### PR DESCRIPTION
Implemented ObCreateObject for non-named objects.
processor->GuestAtomic increment/decrement now properly byteswap (no code uses them yet, so nothing was broken)
SystemHeapFree can now return the region size.
Added helper functions for checking whether an object type has a dispatcher header/translating guest object type to host object type.
Added a helper function for flushing a range of guest->host object mappings, changed the map used for guest->host object mapping to std::map so I could use the more flexible iteration in the flush function
