### PR TITLE
[App] Launch Module fallback

### DIFF
--- a/src/xenia/emulator.h
+++ b/src/xenia/emulator.h
@@ -202,6 +202,8 @@ class Emulator {
   // Launches a game from an STFS container file.
   X_STATUS LaunchStfsContainer(const std::filesystem::path& path);
 
+  X_STATUS LaunchDefaultModule(const std::filesystem::path& path);
+
   // Extract content of package to content specific directory.
   X_STATUS InstallContentPackage(const std::filesystem::path& path);
 


### PR DESCRIPTION
Fallback the custom launch module to `default.xex` if not found.
Remove duplicate of `MountPath` for Zarchive.