### PR TITLE
[xam] Added debug-level logging of WSAGetLastError result

### DIFF
--- a/src/xenia/kernel/xam/xam_net.cc
+++ b/src/xenia/kernel/xam/xam_net.cc
@@ -310,7 +310,9 @@ DECLARE_XAM_EXPORT1(NetDll_WSACleanup, kNetworking, kImplemented);
 // Xbox shares space between normal error codes and WSA errors.
 // This under the hood returns directly value received from RtlGetLastError.
 dword_result_t NetDll_WSAGetLastError_entry() {
-  return XThread::GetLastError();
+  uint32_t last_error = XThread::GetLastError();
+  XELOGD("NetDll_WSAGetLastError: {}", last_error);
+  return last_error;
 }
 DECLARE_XAM_EXPORT1(NetDll_WSAGetLastError, kNetworking, kImplemented);
 


### PR DESCRIPTION
Simply logs the result of `NetDll_WSAGetLastError`

Example:
```
d> F8000008 NetDll_recv(00000001, 000000A0, 434EDB00, 0000000C, 00000000)
d> F8000008 NetDll_WSAGetLastError()
i> F8000008 NetDll_WSAGetLastError: 10035
```