### PR TITLE
feat(toggle_fullscreen)-mouse-double-click

### DIFF
--- a/src/xenia/app/emulator_window.cc
+++ b/src/xenia/app/emulator_window.cc
@@ -276,6 +276,14 @@ void EmulatorWindow::EmulatorWindowListener::OnKeyDown(ui::KeyEvent& e) {
   emulator_window_.OnKeyDown(e);
 }
 
+void EmulatorWindow::EmulatorWindowListener::OnMouseDown(ui::MouseEvent& e) {
+  emulator_window_.OnMouseDown(e);
+}
+
+void EmulatorWindow::EmulatorWindowListener::OnMouseUp(ui::MouseEvent& e) {
+  emulator_window_.OnMouseUp(e);
+}
+
 void EmulatorWindow::DisplayConfigGameConfigLoadCallback::PostGameConfigLoad() {
   emulator_window_.ApplyDisplayConfigForCvars();
 }
@@ -862,6 +870,40 @@ void EmulatorWindow::OnKeyDown(ui::KeyEvent& e) {
   }
 
   e.set_handled(true);
+}
+
+void EmulatorWindow::OnMouseDown(const ui::MouseEvent& e) {
+  ToggleFullscreenOnDoubleClick();
+}
+
+void EmulatorWindow::OnMouseUp(const ui::MouseEvent& e) {
+  last_mouse_up = steady_clock::now();
+}
+
+void EmulatorWindow::ToggleFullscreenOnDoubleClick() {
+  // this function tests if user has double clicked.
+  // if double click was achieved the fullscreen gets toggled
+  const auto now = steady_clock::now();  // current mouse event time
+  const int16_t mouse_down_max_threshold = 250;
+  const int16_t mouse_up_max_threshold = 250;
+  const int16_t mouse_up_down_max_delta = 100;
+  // max delta to prevent 'chaining' of double clicks with next mouse events
+
+  const auto last_mouse_down_delta = diff_in_ms(now, last_mouse_down);
+  if (last_mouse_down_delta >= mouse_down_max_threshold) {
+    last_mouse_down = now;
+    return;
+  }
+
+  const auto last_mouse_up_delta = diff_in_ms(now, last_mouse_up);
+  const auto mouse_event_deltas = diff_in_ms(last_mouse_up, last_mouse_down);
+  if (last_mouse_up_delta >= mouse_up_max_threshold) {
+    return;
+  }
+
+  if (mouse_event_deltas < mouse_up_down_max_delta) {
+    ToggleFullscreen();
+  }
 }
 
 void EmulatorWindow::FileDrop(const std::filesystem::path& path) {

--- a/src/xenia/app/emulator_window.h
+++ b/src/xenia/app/emulator_window.h
@@ -38,6 +38,8 @@ struct RecentTitleEntry {
 
 class EmulatorWindow {
  public:
+  using steady_clock = std::chrono::steady_clock;  // stdlib steady clock
+
   enum : size_t {
     // The UI is on top of the game and is open in special cases, so
     // lowest-priority.
@@ -57,7 +59,17 @@ class EmulatorWindow {
   std::unique_ptr<xe::threading::Thread> Gamepad_HotKeys_Listener;
 
   int32_t selected_title_index = -1;
-  
+
+  static constexpr int64_t diff_in_ms(
+    const steady_clock::time_point t1,
+    const steady_clock::time_point t2) noexcept {
+    using ms = std::chrono::milliseconds;
+    return std::chrono::duration_cast<ms>(t1 - t2).count();
+  }
+
+  steady_clock::time_point last_mouse_up = steady_clock::now();
+  steady_clock::time_point last_mouse_down = steady_clock::now();
+
   Emulator* emulator() const { return emulator_; }
   ui::WindowedAppContext& app_context() const { return app_context_; }
   ui::Window* window() const { return window_.get(); }
@@ -131,6 +143,9 @@ class EmulatorWindow {
 
     void OnKeyDown(ui::KeyEvent& e) override;
 
+    void OnMouseDown(ui::MouseEvent& e) override;
+    void OnMouseUp(ui::MouseEvent& e) override;
+
    private:
     EmulatorWindow& emulator_window_;
   };
@@ -184,7 +199,10 @@ class EmulatorWindow {
   void ApplyDisplayConfigForCvars();
 
   void OnKeyDown(ui::KeyEvent& e);
+  void OnMouseDown(const ui::MouseEvent& e);
+  void ToggleFullscreenOnDoubleClick();
   void FileDrop(const std::filesystem::path& filename);
+  void OnMouseUp(const ui::MouseEvent& e);
   void FileOpen();
   void FileClose();
   void InstallContent();


### PR DESCRIPTION
first time contributor to this project.

- added members to EmulatorWindow & EmulatorListener to track mouse events
- created new fns for the above class(es) to toggle fullscreen on double click

used chrono from std because it doesn't seem like in-house chrono (src/app/base/chrono.h) can measure miliseconds.  questions comments?

these changes are in regards to issue #2141 (feature request, labeled "good first issue")