### PR TITLE
[GPU] Add hard FPS limit without vsync

### DIFF
--- a/src/xenia/gpu/gpu_flags.cc
+++ b/src/xenia/gpu/gpu_flags.cc
@@ -20,7 +20,10 @@ DEFINE_path(
 
 DEFINE_bool(vsync, true, "Enable VSYNC.", "GPU");
 
-DEFINE_uint64(vsync_fps, 60, "VSYNC frames per second", "GPU");
+DEFINE_uint64(framerate_limit, 60,
+              "Maximum frames per second. 0 = Unlimited frames.\n"
+              "Defaults to 60, when set to 0, and VSYNC is enabled.",
+              "GPU");
 
 DEFINE_bool(
     gpu_allow_invalid_fetch_constants, true,

--- a/src/xenia/gpu/gpu_flags.h
+++ b/src/xenia/gpu/gpu_flags.h
@@ -18,7 +18,7 @@ DECLARE_path(dump_shaders);
 
 DECLARE_bool(vsync);
 
-DECLARE_uint64(vsync_fps);
+DECLARE_uint64(framerate_limit);
 
 DECLARE_bool(gpu_allow_invalid_fetch_constants);
 

--- a/src/xenia/gpu/graphics_system.h
+++ b/src/xenia/gpu/graphics_system.h
@@ -109,8 +109,8 @@ class GraphicsSystem {
   uint32_t interrupt_callback_ = 0;
   uint32_t interrupt_callback_data_ = 0;
 
-  std::atomic<bool> vsync_worker_running_;
-  kernel::object_ref<kernel::XHostThread> vsync_worker_thread_;
+  std::atomic<bool> frame_limiter_worker_running_;
+  kernel::object_ref<kernel::XHostThread> frame_limiter_worker_thread_;
 
   RegisterFile* register_file_;
   std::unique_ptr<CommandProcessor> command_processor_;


### PR DESCRIPTION
For some reason, games on my PC stutter when using vsync. Here's my proposition, for people who don't care about little tearing here or there.

My commit adds two new cvars:
- `hard_fps_enable` - Enables hard FPS limit (default false)
- `hard_fps` - Hard FPS value (default 60)

Hard FPS limit is ignored when `vsync` is enabled. Disabling hard FPS limit, makes emulator run like it was before, with 1ms delay in `GraphicsSystem::Setup`.

Successfully built and tested with `xb build --config=release`.