### PR TITLE
[Emulator] Better handling of failed device mounting

### DIFF
--- a/src/xenia/app/emulator_window.h
+++ b/src/xenia/app/emulator_window.h
@@ -226,7 +226,6 @@ class EmulatorWindow {
   void GamepadHotKeys();
   void ToggleGPUSetting(gpu_cvar index);
   bool IsUseNexusForGameBarEnabled();
-  std::string BoolToString(bool value);
   void DisplayHotKeysConfig();
 
   void RunPreviouslyPlayedTitle();

--- a/src/xenia/patcher/plugin_loader.cc
+++ b/src/xenia/patcher/plugin_loader.cc
@@ -17,8 +17,8 @@
 
 DEFINE_bool(
     allow_plugins, false,
-    "Allows loading of plugins/trainers from plugins\\title_id\\plugin.xex."
-    "Plugin are homebrew xex modules which can be used for making mods "
+    "Allows loading of plugins/trainers from plugins\\title_id\\plugin.xex. "
+    "Plugin are homebrew xex modules which can be used for making mods. "
     "This feature is experimental.",
     "General");
 


### PR DESCRIPTION
Instead of shutting down the emulator on a failed mounted device handle it. e.g. invalid file or unable to access due to security related errors.