### PR TITLE
[Emulator] Launch file based on signature instead of file extension

### DIFF
--- a/src/xenia/app/emulator_window.cc
+++ b/src/xenia/app/emulator_window.cc
@@ -1534,6 +1534,11 @@ void EmulatorWindow::DisplayHotKeysConfig() {
                                       msg);
 }
 
+std::string EmulatorWindow::CanonicalizeFileExtension(
+    const std::filesystem::path& path) {
+  return xe::utf8::lower_ascii(xe::path_to_utf8(path.extension()));
+}
+
 xe::X_STATUS EmulatorWindow::RunTitle(std::filesystem::path path_to_file) {
   bool titleExists = !std::filesystem::exists(path_to_file);
 
@@ -1564,6 +1569,20 @@ xe::X_STATUS EmulatorWindow::RunTitle(std::filesystem::path path_to_file) {
   // Prevent crashing the emulator by not loading a game if a game is already
   // loaded.
   auto abs_path = std::filesystem::absolute(path_to_file);
+
+  auto extension = CanonicalizeFileExtension(abs_path);
+
+  if (extension == ".7z" || extension == ".zip" || extension == ".rar" ||
+      extension == ".tar" || extension == ".gz") {
+    xe::ShowSimpleMessageBox(
+        xe::SimpleMessageBoxType::Error,
+        fmt::format(
+            "Unsupported format!\n"
+            "Xenia does not support running software in an archived format."));
+
+    return X_STATUS_UNSUCCESSFUL;
+  }
+
   auto result = emulator_->LaunchPath(abs_path);
 
   imgui_drawer_.get()->ClearDialogs();

--- a/src/xenia/app/emulator_window.h
+++ b/src/xenia/app/emulator_window.h
@@ -228,6 +228,9 @@ class EmulatorWindow {
   bool IsUseNexusForGameBarEnabled();
   void DisplayHotKeysConfig();
 
+  static std::string CanonicalizeFileExtension(
+      const std::filesystem::path& path);
+
   void RunPreviouslyPlayedTitle();
   void FillRecentlyLaunchedTitlesMenu(xe::ui::MenuItem* recent_menu);
   void LoadRecentlyLaunchedTitles();

--- a/src/xenia/emulator.h
+++ b/src/xenia/emulator.h
@@ -181,11 +181,28 @@ class Emulator {
   // Terminates the currently running title.
   X_STATUS TerminateTitle();
 
-  const std::unique_ptr<vfs::Device> CreateVfsDeviceBasedOnPath(
+  const std::unique_ptr<vfs::Device> CreateVfsDevice(
       const std::filesystem::path& path, const std::string_view mount_path);
 
   X_STATUS MountPath(const std::filesystem::path& path,
                      const std::string_view mount_path);
+
+  enum class FileSignatureType {
+    XEX1,
+    XEX2,
+    ELF,
+    CON,
+    LIVE,
+    PIRS,
+    XISO,
+    ZAR,
+    EXE,
+    Unknown
+  };
+
+  // Determine the executable signature
+  FileSignatureType GetFileSignature(const std::filesystem::path& path);
+
   // Launches a game from the given file path.
   // This will attempt to infer the type of the given file (such as an iso, etc)
   // using heuristics.
@@ -233,8 +250,6 @@ class Emulator {
   enum : uint64_t { EmulatorFlagDisclaimerAcknowledged = 1ULL << 0 };
   static uint64_t GetPersistentEmulatorFlags();
   static void SetPersistentEmulatorFlags(uint64_t new_flags);
-  static std::string CanonicalizeFileExtension(
-      const std::filesystem::path& path);
   static bool ExceptionCallbackThunk(Exception* ex, void* data);
   bool ExceptionCallback(Exception* ex);
 

--- a/src/xenia/kernel/user_module.cc
+++ b/src/xenia/kernel/user_module.cc
@@ -126,9 +126,12 @@ X_STATUS UserModule::LoadFromMemory(const void* addr, const size_t length) {
   } else if (magic == xe::cpu::kElfSignature) {
     module_format_ = kModuleFormatElf;
   } else {
-    be<uint16_t> magic16;
-    magic16.value = xe::load<uint16_t>(addr);
-    if (magic16 == 0x4D5A) {
+    uint8_t M = xe::load<uint8_t>(addr);
+    uint8_t Z = xe::load<uint8_t>(reinterpret_cast<void*>(
+        reinterpret_cast<uint64_t>(addr) + sizeof(uint8_t)));
+
+    magic = make_fourcc(M, Z, 0, 0);
+    if (magic == kEXESignature) {
       XELOGE("XNA executables are not yet implemented");
       return X_STATUS_NOT_IMPLEMENTED;
     } else {

--- a/src/xenia/kernel/user_module.h
+++ b/src/xenia/kernel/user_module.h
@@ -31,6 +31,8 @@ class XThread;
 namespace xe {
 namespace kernel {
 
+constexpr fourcc_t kEXESignature = make_fourcc('M', 'Z', 0, 0);
+
 class UserModule : public XModule {
  public:
   UserModule(KernelState* kernel_state);

--- a/src/xenia/vfs/devices/disc_image_device.h
+++ b/src/xenia/vfs/devices/disc_image_device.h
@@ -21,6 +21,8 @@ namespace vfs {
 
 class DiscImageEntry;
 
+constexpr fourcc_t kXSFSignature = make_fourcc(0x58, 0x53, 0x46, 0x1A);
+
 class DiscImageDevice : public Device {
  public:
   DiscImageDevice(const std::string_view mount_path,

--- a/src/xenia/vfs/devices/disc_zarchive_device.h
+++ b/src/xenia/vfs/devices/disc_zarchive_device.h
@@ -21,6 +21,11 @@
 namespace xe {
 namespace vfs {
 
+const fourcc_t kZarMagic = make_fourcc((_ZARCHIVE::Footer::kMagic >> 24 & 0xFF),
+                                       (_ZARCHIVE::Footer::kMagic >> 16 & 0xFF),
+                                       (_ZARCHIVE::Footer::kMagic >> 8 & 0xFF),
+                                       (_ZARCHIVE::Footer::kMagic & 0xFF));
+
 class DiscZarchiveEntry;
 
 class DiscZarchiveDevice : public Device {

--- a/src/xenia/vfs/devices/xcontent_container_device.h
+++ b/src/xenia/vfs/devices/xcontent_container_device.h
@@ -22,6 +22,11 @@
 
 namespace xe {
 namespace vfs {
+
+constexpr fourcc_t kLIVESignature = make_fourcc("LIVE");
+constexpr fourcc_t kCONSignature = make_fourcc("CON ");
+constexpr fourcc_t kPIRSSignature = make_fourcc("PIRS");
+
 class XContentContainerDevice : public Device {
  public:
   const static uint32_t kBlockSize = 0x1000;


### PR DESCRIPTION
If a STFS package is given a file extension `.xex` it will fail to launch switching to signature based fixes this.