### PR TITLE
Guest debugger enhancements

### DIFF
--- a/src/xenia/cpu/processor.cc
+++ b/src/xenia/cpu/processor.cc
@@ -902,8 +902,8 @@ void Processor::Continue() {
     assert_always("cancel stepping not done yet");
   }
   execution_state_ = ExecutionState::kRunning;
-  ResumeAllBreakpoints();
   ResumeAllThreads();
+  ResumeAllBreakpoints();
   if (debug_listener_) {
     debug_listener_->OnExecutionContinued();
   }

--- a/src/xenia/cpu/processor.cc
+++ b/src/xenia/cpu/processor.cc
@@ -447,6 +447,7 @@ bool Processor::Restore(ByteStream* stream) {
   std::vector<uint32_t> to_delete;
   for (auto& it : thread_debug_infos_) {
     if (it.second->state == ThreadDebugInfo::State::kZombie) {
+      it.second->thread_handle = 0;
       to_delete.push_back(it.first);
     }
   }
@@ -481,11 +482,11 @@ void Processor::OnThreadCreated(uint32_t thread_handle,
                                 ThreadState* thread_state, Thread* thread) {
   auto global_lock = global_critical_region_.Acquire();
   auto thread_info = std::make_unique<ThreadDebugInfo>();
-  thread_info->thread_handle = thread_handle;
   thread_info->thread_id = thread_state->thread_id();
   thread_info->thread = thread;
   thread_info->state = ThreadDebugInfo::State::kAlive;
   thread_info->suspended = false;
+  thread_info->thread_handle = thread_handle;
   thread_debug_infos_.emplace(thread_info->thread_id, std::move(thread_info));
 }
 
@@ -501,6 +502,7 @@ void Processor::OnThreadDestroyed(uint32_t thread_id) {
   auto global_lock = global_critical_region_.Acquire();
   auto it = thread_debug_infos_.find(thread_id);
   assert_true(it != thread_debug_infos_.end());
+  it->second->thread_handle = 0;
   thread_debug_infos_.erase(it);
 }
 

--- a/src/xenia/cpu/processor.cc
+++ b/src/xenia/cpu/processor.cc
@@ -447,7 +447,7 @@ bool Processor::Restore(ByteStream* stream) {
   std::vector<uint32_t> to_delete;
   for (auto& it : thread_debug_infos_) {
     if (it.second->state == ThreadDebugInfo::State::kZombie) {
-      it.second->thread_handle = 0;
+      it.second->thread_handle = NULL;
       to_delete.push_back(it.first);
     }
   }
@@ -502,7 +502,7 @@ void Processor::OnThreadDestroyed(uint32_t thread_id) {
   auto global_lock = global_critical_region_.Acquire();
   auto it = thread_debug_infos_.find(thread_id);
   assert_true(it != thread_debug_infos_.end());
-  it->second->thread_handle = 0;
+  it->second->thread_handle = NULL;
   thread_debug_infos_.erase(it);
 }
 

--- a/src/xenia/debug/ui/debug_window.cc
+++ b/src/xenia/debug/ui/debug_window.cc
@@ -307,8 +307,7 @@ void DebugWindow::DrawToolbar() {
       case cpu::ThreadDebugInfo::State::kAlive:
       case cpu::ThreadDebugInfo::State::kExited:
       case cpu::ThreadDebugInfo::State::kWaiting:
-        if (thread_info->thread_handle == NULL ||
-            thread_info->thread == NULL) {
+        if (thread_info->thread_handle == NULL || thread_info->thread == NULL) {
           thread_combo.Append("(invalid)");
         } else {
           thread_combo.Append(thread_info->thread->thread_name());

--- a/src/xenia/debug/ui/debug_window.cc
+++ b/src/xenia/debug/ui/debug_window.cc
@@ -307,7 +307,8 @@ void DebugWindow::DrawToolbar() {
       case cpu::ThreadDebugInfo::State::kAlive:
       case cpu::ThreadDebugInfo::State::kExited:
       case cpu::ThreadDebugInfo::State::kWaiting:
-        if (thread_info->thread_handle == NULL) {
+        if (thread_info->thread_handle == NULL ||
+            thread_info->thread == NULL) {
           thread_combo.Append("(invalid)");
         } else {
           thread_combo.Append(thread_info->thread->thread_name());

--- a/src/xenia/debug/ui/debug_window.cc
+++ b/src/xenia/debug/ui/debug_window.cc
@@ -300,11 +300,24 @@ void DebugWindow::DrawToolbar() {
     if (thread_info == state_.thread_info) {
       current_thread_index = i;
     }
-    if (thread_info->state != cpu::ThreadDebugInfo::State::kZombie) {
-      thread_combo.Append(thread_info->thread->thread_name());
-    } else {
-      thread_combo.Append("(zombie)");
+
+    switch (thread_info->state) {
+      case cpu::ThreadDebugInfo::State::kAlive:
+      case cpu::ThreadDebugInfo::State::kExited:
+      case cpu::ThreadDebugInfo::State::kWaiting:
+        if (thread_info->thread_handle == 0) {
+          thread_combo.Append("(invalid)");
+        } else {
+          thread_combo.Append(thread_info->thread->thread_name());
+        }
+        break;
+      case cpu::ThreadDebugInfo::State::kZombie:
+        thread_combo.Append("(zombie)");
+        break;
+      default:
+        thread_combo.Append("(invalid)");
     }
+
     thread_combo.Append('\0');
     ++i;
   }

--- a/src/xenia/debug/ui/debug_window.cc
+++ b/src/xenia/debug/ui/debug_window.cc
@@ -301,11 +301,12 @@ void DebugWindow::DrawToolbar() {
       current_thread_index = i;
     }
 
+    // threads can be briefly invalid once destroyed and before a cache update. This ensures we are accessing threads that are still valid
     switch (thread_info->state) {
       case cpu::ThreadDebugInfo::State::kAlive:
       case cpu::ThreadDebugInfo::State::kExited:
       case cpu::ThreadDebugInfo::State::kWaiting:
-        if (thread_info->thread_handle == 0) {
+        if (thread_info->thread_handle == NULL) {
           thread_combo.Append("(invalid)");
         } else {
           thread_combo.Append(thread_info->thread->thread_name());

--- a/src/xenia/debug/ui/debug_window.cc
+++ b/src/xenia/debug/ui/debug_window.cc
@@ -301,7 +301,8 @@ void DebugWindow::DrawToolbar() {
       current_thread_index = i;
     }
 
-    // threads can be briefly invalid once destroyed and before a cache update. This ensures we are accessing threads that are still valid
+    // Threads can be briefly invalid once destroyed and before a cache update.
+    // This ensures we are accessing threads that are still valid.
     switch (thread_info->state) {
       case cpu::ThreadDebugInfo::State::kAlive:
       case cpu::ThreadDebugInfo::State::kExited:


### PR DESCRIPTION
Hello, there was a bug whenever using the guest debugger where it was trying to access thread data. but the thread was wiped. The map for the threads does not null the pointer out, as in the comments for thread_debug_infos_ in processor.h.  Unfortunately, I could not find a cleaner way, such as using shared pointers between the cache and the original source to know if the pointer is valid or not. Very open to suggestions, but this bug was keeping me from attaching the debugger for more than 5 seconds.