### PR TITLE
Make guest debugger usable

### DIFF
--- a/src/xenia/cpu/processor.cc
+++ b/src/xenia/cpu/processor.cc
@@ -447,6 +447,7 @@ bool Processor::Restore(ByteStream* stream) {
   std::vector<uint32_t> to_delete;
   for (auto& it : thread_debug_infos_) {
     if (it.second->state == ThreadDebugInfo::State::kZombie) {
+      it.second->thread_handle = NULL;
       to_delete.push_back(it.first);
     }
   }
@@ -481,11 +482,11 @@ void Processor::OnThreadCreated(uint32_t thread_handle,
                                 ThreadState* thread_state, Thread* thread) {
   auto global_lock = global_critical_region_.Acquire();
   auto thread_info = std::make_unique<ThreadDebugInfo>();
-  thread_info->thread_handle = thread_handle;
   thread_info->thread_id = thread_state->thread_id();
   thread_info->thread = thread;
   thread_info->state = ThreadDebugInfo::State::kAlive;
   thread_info->suspended = false;
+  thread_info->thread_handle = thread_handle;
   thread_debug_infos_.emplace(thread_info->thread_id, std::move(thread_info));
 }
 
@@ -501,6 +502,7 @@ void Processor::OnThreadDestroyed(uint32_t thread_id) {
   auto global_lock = global_critical_region_.Acquire();
   auto it = thread_debug_infos_.find(thread_id);
   assert_true(it != thread_debug_infos_.end());
+  it->second->thread_handle = NULL;
   thread_debug_infos_.erase(it);
 }
 
@@ -667,14 +669,15 @@ bool Processor::OnThreadBreakpointHit(Exception* ex) {
     debug_listener_->OnExecutionPaused();
   }
 
+  ResumeAllThreads();
   thread_info->thread->thread()->Suspend();
 
   // Apply thread context changes.
   // TODO(benvanik): apply to all threads?
 #if XE_ARCH_AMD64
-  ex->set_resume_pc(thread_info->host_context.rip);
+  ex->set_resume_pc(thread_info->host_context.rip + 2);
 #elif XE_ARCH_ARM64
-  ex->set_resume_pc(thread_info->host_context.pc);
+  ex->set_resume_pc(thread_info->host_context.pc + 2);
 #else
 #error Instruction pointer not specified for the target CPU architecture.
 #endif  // XE_ARCH
@@ -902,6 +905,7 @@ void Processor::Continue() {
   execution_state_ = ExecutionState::kRunning;
   ResumeAllBreakpoints();
   ResumeAllThreads();
+
   if (debug_listener_) {
     debug_listener_->OnExecutionContinued();
   }

--- a/src/xenia/cpu/stack_walker_win.cc
+++ b/src/xenia/cpu/stack_walker_win.cc
@@ -240,10 +240,13 @@ class Win32StackWalker : public StackWalker {
           // displacement in x64 from the JIT'ed code start to the PC.
           if (function->is_guest()) {
             auto guest_function = static_cast<GuestFunction*>(function);
-            // Adjust the host PC by -1 so that we will go back into whatever
-            // instruction was executing before the capture (like a call).
+
+            // GaryFrazier: Removed -1 as that does not reflect the guest pc of
+            // the host address Adjust the host PC by -1 so that we will go back
+            // into whatever instruction was executing before the capture (like
+            // a call).
             frame.guest_pc =
-                guest_function->MapMachineCodeToGuestAddress(frame.host_pc - 1);
+                guest_function->MapMachineCodeToGuestAddress(frame.host_pc);
           }
         } else {
           frame.guest_symbol.function = nullptr;

--- a/src/xenia/debug/ui/debug_window.cc
+++ b/src/xenia/debug/ui/debug_window.cc
@@ -300,11 +300,26 @@ void DebugWindow::DrawToolbar() {
     if (thread_info == state_.thread_info) {
       current_thread_index = i;
     }
-    if (thread_info->state != cpu::ThreadDebugInfo::State::kZombie) {
-      thread_combo.Append(thread_info->thread->thread_name());
-    } else {
-      thread_combo.Append("(zombie)");
+
+    // Threads can be briefly invalid once destroyed and before a cache update.
+    // This ensures we are accessing threads that are still valid.
+    switch (thread_info->state) {
+      case cpu::ThreadDebugInfo::State::kAlive:
+      case cpu::ThreadDebugInfo::State::kExited:
+      case cpu::ThreadDebugInfo::State::kWaiting:
+        if (thread_info->thread_handle == NULL || thread_info->thread == NULL) {
+          thread_combo.Append("(invalid)");
+        } else {
+          thread_combo.Append(thread_info->thread->thread_name());
+        }
+        break;
+      case cpu::ThreadDebugInfo::State::kZombie:
+        thread_combo.Append("(zombie)");
+        break;
+      default:
+        thread_combo.Append("(invalid)");
     }
+
     thread_combo.Append('\0');
     ++i;
   }


### PR DESCRIPTION
Squashed commit for [This older PR](https://github.com/xenia-canary/xenia-canary/pull/303)

Summary and reasoning for changes

- Breakpoint::ForEachHostAddress would incorrectly flag some addresses as being within a function, when the assembly actually jumps around a function and not contains it. The fix was to take the eligible list of functions and use the first one that worked, rather than the first one every time, which may be invalid.
- DebugWindow::DrawToolbar would try and reference invalid thread handles during thread creation/destruction. Validation was put in place to safely access thread names.
- Processor::OnThreadBreakpointHit would not increase the program counter to get past the ud2 break operation, resulting in infinite loops when continuing execution.
- Stack_walker ResolveStack, I believe, was incorrectly decrementing the host address when trying to obtain the guest function address. This was causing breakpoints put on the first host address of a guest instruction to reference the previous guest instruction, resulting in breakpoint logic not working. This function seemed to only be used by the breakpoint exception catch.

Please let me know if there are any red flags here, I tried to limit all the changes to debugger only functionality where possible since I am not too familiar yet.

There is still much to be done, but this gets it into a spot where you can set breakpoints and have them trigger pretty consistently. Stuff I plan to look at later:

- Stepping PPC does not follow callstack up when exiting function
- Stepping x64 does not work after putting in a breakpoint
- UI bugs when exiting out of setting a breakpoint, causing a crash

