### PR TITLE
[VFS] Clear registered devices if launch failed

### DIFF
--- a/src/xenia/app/emulator_window.cc
+++ b/src/xenia/app/emulator_window.cc
@@ -1740,6 +1740,8 @@ xe::X_STATUS EmulatorWindow::RunTitle(std::filesystem::path path_to_file) {
     xe::ui::ImGuiDialog::ShowMessageBox(
         imgui_drawer_.get(), "Title Launch Failed!",
         "Failed to launch title.\n\nCheck xenia.log for technical details.");
+
+    emulator_->file_system()->Clear();
   } else {
     AddRecentlyLaunchedTitle(path_to_file, emulator_->title_name());
 

--- a/src/xenia/vfs/virtual_file_system.cc
+++ b/src/xenia/vfs/virtual_file_system.cc
@@ -27,6 +27,10 @@ VirtualFileSystem::VirtualFileSystem() {}
 VirtualFileSystem::~VirtualFileSystem() {
   // Delete all devices.
   // This will explode if anyone is still using data from them.
+  Clear();
+}
+
+void VirtualFileSystem::Clear() {
   devices_.clear();
   symlinks_.clear();
 }

--- a/src/xenia/vfs/virtual_file_system.h
+++ b/src/xenia/vfs/virtual_file_system.h
@@ -28,6 +28,8 @@ class VirtualFileSystem {
   VirtualFileSystem();
   ~VirtualFileSystem();
 
+  void Clear();
+
   bool RegisterDevice(std::unique_ptr<Device> device);
   bool UnregisterDevice(const std::string_view path);
 


### PR DESCRIPTION
If a game is successfully mounted but fails to launch then the next title will fail to resolve the launch module causing it to fail launching.

This can be replicated by creating a zar without `default.xex` launching it, and then attempting to launch a zar with `default.xex`.