### PR TITLE
[Kernel] Recording app messages for future reference

### DIFF
--- a/src/xenia/kernel/xam/app_manager.cc
+++ b/src/xenia/kernel/xam/app_manager.cc
@@ -10,6 +10,7 @@
 #include "xenia/kernel/xam/app_manager.h"
 
 #include "xenia/kernel/kernel_state.h"
+#include "xenia/kernel/xam/apps/messenger_app.h"
 #include "xenia/kernel/xam/apps/xam_app.h"
 #include "xenia/kernel/xam/apps/xgi_app.h"
 #include "xenia/kernel/xam/apps/xlivebase_app.h"
@@ -25,6 +26,7 @@ App::App(KernelState* kernel_state, uint32_t app_id)
       app_id_(app_id) {}
 
 void AppManager::RegisterApps(KernelState* kernel_state, AppManager* manager) {
+  manager->RegisterApp(std::make_unique<apps::MessengerApp>(kernel_state));
   manager->RegisterApp(std::make_unique<apps::XmpApp>(kernel_state));
   manager->RegisterApp(std::make_unique<apps::XgiApp>(kernel_state));
   manager->RegisterApp(std::make_unique<apps::XLiveBaseApp>(kernel_state));

--- a/src/xenia/kernel/xam/apps/messenger_app.cc
+++ b/src/xenia/kernel/xam/apps/messenger_app.cc
@@ -1,0 +1,46 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2024 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/kernel/xam/apps/messenger_app.h"
+
+#include "xenia/base/logging.h"
+#include "xenia/base/threading.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+namespace apps {
+
+MessengerApp::MessengerApp(KernelState* kernel_state)
+    : App(kernel_state, 0xF7) {}
+
+X_RESULT MessengerApp::DispatchMessageSync(uint32_t message,
+                                           uint32_t buffer_ptr,
+                                           uint32_t buffer_length) {
+  // NOTE: buffer_length may be zero or valid.
+  auto buffer = memory_->TranslateVirtual(buffer_ptr);
+  switch (message) {
+    case 0x00200002: {
+      // Used on start in blades dashboard v5759 (marketplace update) and
+      // possibly to 6717 with netplay
+      XELOGD("MessengerUnk200002, unimplemented");
+      return X_E_FAIL;
+    }
+  }
+  XELOGE(
+      "Unimplemented Messenger message app=%.8X, msg=%.8X, arg1=%.8X, "
+      "arg2=%.8X",
+      app_id(), message, buffer_ptr, buffer_length);
+  return X_STATUS_UNSUCCESSFUL;
+}
+
+}  // namespace apps
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe

--- a/src/xenia/kernel/xam/apps/messenger_app.h
+++ b/src/xenia/kernel/xam/apps/messenger_app.h
@@ -1,0 +1,34 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2024 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_KERNEL_XAM_APPS_UNKNOWN_F7_APP_H_
+#define XENIA_KERNEL_XAM_APPS_UNKNOWN_F7_APP_H_
+
+#include "xenia/kernel/kernel_state.h"
+#include "xenia/kernel/xam/app_manager.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+namespace apps {
+
+class MessengerApp : public App {
+ public:
+  explicit MessengerApp(KernelState* kernel_state);
+
+  X_RESULT DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
+                               uint32_t buffer_length) override;
+};
+
+}  // namespace apps
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe
+
+#endif  // XENIA_KERNEL_XAM_APPS_UNKNOWN_FE_APP_H_

--- a/src/xenia/kernel/xam/apps/xgi_app.cc
+++ b/src/xenia/kernel/xam/apps/xgi_app.cc
@@ -147,6 +147,34 @@ X_HRESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
       XELOGD("XGI_unknown");
       return X_STATUS_SUCCESS;
     }
+    case 0x000B0021: {
+      struct XLeaderboard {
+        xe::be<uint32_t> titleId;
+        xe::be<uint32_t> xuids_count;
+        xe::be<uint32_t> xuids_guest_address;
+        xe::be<uint32_t> specs_count;
+        xe::be<uint32_t> specs_guest_address;
+        xe::be<uint32_t> results_size;
+        xe::be<uint32_t> results_guest_address;
+      }* data = reinterpret_cast<XLeaderboard*>(buffer);
+
+      if (!data->results_guest_address) {
+        return 1;
+      }
+    }
+    case 0x000B0036: {
+      // Called after opening xbox live arcade and clicking on xbox live v5759
+      // to 5787 and called after clicking xbox live in the game library from
+      // v6683 to v6717
+      XELOGD("XGIUnkB0036, unimplemented");
+      return X_E_FAIL;
+    }
+    case 0x000B003D: {
+      // Games used in:
+      // - 5451082a (netplay build).
+      XELOGD("XGIUnkB003D, unimplemented");
+      return X_E_FAIL;
+    }
     case 0x000B0041: {
       assert_true(!buffer_length || buffer_length == 32);
       // 00000000 2789fecc 00000000 00000000 200491e0 00000000 200491f0 20049340

--- a/src/xenia/kernel/xam/apps/xlivebase_app.cc
+++ b/src/xenia/kernel/xam/apps/xlivebase_app.cc
@@ -28,6 +28,21 @@ X_HRESULT XLiveBaseApp::DispatchMessageSync(uint32_t message,
   // NOTE: buffer_length may be zero or valid.
   auto buffer = memory_->TranslateVirtual(buffer_ptr);
   switch (message) {
+    case 0x0005008C: {
+      // Called on startup of blades dashboard v1888 to v2858
+      XELOGD("XLiveBaseUnk5008C, unimplemented");
+      return X_E_FAIL;
+    }
+    case 0x00050094: {
+      // Called on startup of blades dashboard v4532 to v4552
+      XELOGD("XLiveBaseUnk50094, unimplemented");
+      return X_E_FAIL;
+    }
+    case 0x00058003: {
+      // Called on startup of dashboard (netplay build)
+      XELOGD("XLiveBaseLogonGetHR, unimplemented");
+      return X_E_SUCCESS;
+    }
     case 0x00058004: {
       // Called on startup, seems to just return a bool in the buffer.
       assert_true(!buffer_length || buffer_length == 4);

--- a/src/xenia/kernel/xam/apps/xmp_app.cc
+++ b/src/xenia/kernel/xam/apps/xmp_app.cc
@@ -473,6 +473,12 @@ X_HRESULT XmpApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
       }
       return X_E_SUCCESS;
     }
+    case 0x0007002B: {
+      // Called on the NXE and Kinect dashboard after clicking on the picture,
+      // video, and music library
+      XELOGD("XMPUnk7002B, unimplemented");
+      return X_E_FAIL;
+    }
     case 0x0007002E: {
       assert_true(!buffer_length || buffer_length == 12);
       // Query of size for XamAlloc - the result of the alloc is passed to
@@ -491,10 +497,28 @@ X_HRESULT XmpApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
                                    4 + uint32_t(args->song_count) * 128);
       return X_E_SUCCESS;
     }
+    case 0x0007002F: {
+      // Called on the start up of all dashboard versions before kinect
+      XELOGD("XMPUnk7002F, unimplemented");
+      return X_E_FAIL;
+    }
     case 0x0007003D: {
       // XMPCaptureOutput - not sure how this works :/
       XELOGD("XMPCaptureOutput(...)");
       assert_always("XMP output not unimplemented");
+      return X_E_FAIL;
+    }
+    case 0x00070044: {
+      // Called on the start up of all dashboard versions before kinect
+      // When it returns X_E_FAIL you can access the music player up to version
+      // 5787
+      XELOGD("XMPUnk70044, unimplemented");
+      return X_E_FAIL;
+    }
+    case 0x00070053: {
+      // Called on the blades dashboard after clicking on the picture,
+      // video, and music library
+      XELOGD("XMPUnk70053, unimplemented");
       return X_E_FAIL;
     }
   }


### PR DESCRIPTION
Recording more unknown app messages for future reference.
- Xam message 2B001 is called in Toy Story Mania!

- Xmp messages 7002F and 70044 are called on the start of all dashboard versions before the Kinect update. When 70044 is set to return X_E_FAIL you can access the xbox music player but when it succeeds the emulator locks up and you are forced to close it manually (no crash). The music player can't be access at all past version 5787 and instead goes back to the previous screen as if it is closing itself down. 7002B (NXE and Kinect) and 70053 (Blades) are called when trying to access the music, picture, and video libraries.

- Messenger is only called when using netplay with dashboard versions 5759 to 5787. After that an "xbox live is currently unavailable" messaged is displayed on 3 of the tabs (marketplace, xbox live, and games) blocking any internet related messages from appearing on versions 6683 to 6717. 

- Xlivebase message 5008C is called on the start of dashboard versions 1888 to 2858 and 50094 is called instead from versions 4532 to 4552. LogonGetHR is called on the startup of dashboard (netplay version)

- XGI message B0036 is called after clicking on xbox live in the arcade library (v5759 to 5787) or from the game library (v6683 to v6717). B0021 is sent in the games Fatal Fury Special and Beijing 2008. B003D is used by UFC 2009 (netplay build).