### PR TITLE
[Emulator] Removed legacy title re-launching code

### DIFF
--- a/src/xenia/app/xenia_main.cc
+++ b/src/xenia/app/xenia_main.cc
@@ -642,14 +642,7 @@ void EmulatorApp::EmulatorThread() {
   // Now, we're going to use this thread to drive events related to emulation.
   while (!emulator_thread_quit_requested_.load(std::memory_order_relaxed)) {
     xe::threading::Wait(emulator_thread_event_.get(), false);
-    while (true) {
-      emulator_->WaitUntilExit();
-      if (emulator_->TitleRequested()) {
-        emulator_->LaunchNextTitle();
-      } else {
-        break;
-      }
-    }
+    emulator_->WaitUntilExit();
   }
 }
 

--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -905,20 +905,6 @@ bool Emulator::RestoreFromFile(const std::filesystem::path& path) {
   return true;
 }
 
-bool Emulator::TitleRequested() {
-  auto xam = kernel_state()->GetKernelModule<kernel::xam::XamModule>("xam.xex");
-  return xam->loader_data().launch_data_present;
-}
-
-void Emulator::LaunchNextTitle() {
-  auto xam = kernel_state()->GetKernelModule<kernel::xam::XamModule>("xam.xex");
-  auto next_title = xam->loader_data().launch_path;
-
-  // Swap disk doesn't require reloading
-  // This function should be purged?
-  CompleteLaunch("", next_title);
-}
-
 const std::filesystem::path Emulator::GetNewDiscPath(
     std::string window_message) {
   std::filesystem::path path = "";

--- a/src/xenia/emulator.h
+++ b/src/xenia/emulator.h
@@ -248,8 +248,6 @@ class Emulator {
   bool RestoreFromFile(const std::filesystem::path& path);
 
   // The game can request another title to be loaded.
-  bool TitleRequested();
-  void LaunchNextTitle();
   const std::filesystem::path GetNewDiscPath(std::string window_message = "");
 
   void WaitUntilExit();


### PR DESCRIPTION
This removes the old title re-launching code that got carried over from upstream Xenia.
Based on my testing, it doesn't actually work - most of the time a graceful shutdown doesn't happen with `Emulator::WaitUntilExit` looping forever and when it does happen, the old re-launching code crashes in `KernelState::LoadUserModule` since it tries to get the path of the current executable which has already been unloaded by this point.
Furthermore, Canary has its own implementation for handling title re-launching, making this snippet redundant.