### PR TITLE
[Kernel] Fixed XamShowSigninUI

### DIFF
--- a/src/xenia/kernel/xam/xam_user.cc
+++ b/src/xenia/kernel/xam/xam_user.cc
@@ -542,18 +542,25 @@ dword_result_t XamUserAreUsersFriends_entry(dword_t user_index, dword_t unk1,
 }
 DECLARE_XAM_EXPORT1(XamUserAreUsersFriends, kUserProfiles, kStub);
 
-dword_result_t XamShowSigninUI_entry(dword_t unk, dword_t unk_mask) {
+dword_result_t XamShowSigninUI_entry(dword_t users_needed, dword_t unk_mask) {
+  // XN_SYS_UI (on)
   kernel_state()->BroadcastNotification(0x00000009, 1);
   kernel_state()->UpdateUsedUserProfiles();
   // Mask values vary. Probably matching user types? Local/remote?
   // Games seem to sit and loop until we trigger this notification:
+  uint32_t user_mask = 0;
+  uint32_t active_users = 0;
 
   for (uint32_t i = 0; i < 4; i++) {
     if (kernel_state()->IsUserSignedIn(i)) {
-      // XN_SYS_SIGNINCHANGED
-      kernel_state()->BroadcastNotification(0xA, i);
+      user_mask |= (1 << i);
+      active_users++;
+      if (active_users >= users_needed) break;
     }
   }
+
+  // XN_SYS_SIGNINCHANGED (players)
+  kernel_state()->BroadcastNotification(0xA, user_mask);
 
   // XN_SYS_UI (off)
   kernel_state()->BroadcastNotification(0x00000009, 0);


### PR DESCRIPTION
This updates XamShowSigninUI implementation so it's more accurate to real console.
1. Only one XN_SYS_SIGNINCHANGED should be sent and its parameter is a bitfield of players signed in.
2. The first argument looks like number of players the game wants to sign in.

Fixes splitscreen in Source Engine games (Left 4 Dead, Portal 2, CS:GO).