### PR TITLE
Added taking a screenshot functionality

### DIFF
--- a/src/xenia/app/emulator_window.h
+++ b/src/xenia/app/emulator_window.h
@@ -87,6 +87,11 @@ class EmulatorWindow {
   void ToggleFullscreen();
   void SetInitializingShaderStorage(bool initializing);
 
+  void TakeScreenshot();
+  void ExportScreenshot(const xe::ui::RawImage& image);
+  void SaveImage(const std::filesystem::path& path,
+                 const xe::ui::RawImage& image);
+
   // Types of button functions for hotkeys.
   enum class ButtonFunctions {
     ToggleFullscreen,


### PR DESCRIPTION
Added a screenshot functionality based on this pr https://github.com/xenia-project/xenia/pull/2074 and added some minor adjustments.

GUI wise, "take screenshot" is under the Display menu and the keyboard shortcut to take it is F12.

The screenshot will be saved where xenia.exe or xenia_canary.exe is saved and then creates a screenshots folder which contains game-specific screenshot directories.