### PR TITLE
[XAM] Added storage device select UI

### DIFF
--- a/src/xenia/kernel/xam/xam_content_device.cc
+++ b/src/xenia/kernel/xam/xam_content_device.cc
@@ -59,6 +59,20 @@ const DummyDeviceInfo* GetDummyDeviceInfo(uint32_t device_id) {
   return it == end ? nullptr : *it;
 }
 
+std::vector<const DummyDeviceInfo*> ListStorageDevices(bool include_readonly) {
+  // FIXME: Should probably check content flags here instead.
+  std::vector<const DummyDeviceInfo*> devices;
+
+  for (const auto& device_info : dummy_device_infos_) {
+    if (!include_readonly && device_info->device_type == DeviceType::ODD) {
+      continue;
+    }
+    devices.emplace_back(device_info);
+  }
+
+  return devices;
+}
+
 dword_result_t XamContentGetDeviceName_entry(dword_t device_id,
                                              lpu16string_t name_buffer,
                                              dword_t name_capacity) {

--- a/src/xenia/kernel/xam/xam_content_device.h
+++ b/src/xenia/kernel/xam/xam_content_device.h
@@ -35,6 +35,8 @@ struct DummyDeviceInfo {
 };
 
 const DummyDeviceInfo* GetDummyDeviceInfo(uint32_t device_id);
+std::vector<const DummyDeviceInfo*> ListStorageDevices(
+    bool include_readonly = false);
 
 }  // namespace xam
 }  // namespace kernel


### PR DESCRIPTION
This adds a basic device selector dialog for XamShowDeviceSelectorUI. Largely pointless for the end user since there's just a dummy HDD right now so it's disabled by default. Mainly useful for debugging although this should fix infinite loop issue in Operation: Darkness.