### PR TITLE
[XAM] Set license mask for XBLA title content as well

### DIFF
--- a/src/xenia/kernel/xam/xam_content.cc
+++ b/src/xenia/kernel/xam/xam_content.cc
@@ -210,8 +210,9 @@ dword_result_t xeXamContentCreate(dword_t user_index, lpstring_t root_name,
     if (license_mask_ptr && XSUCCEEDED(result)) {
       *license_mask_ptr = 0;  // Stub!
 
-      // Set license only for DLCs
-      if (content_data.content_type == xe::XContentType::kMarketplaceContent) {
+      // Set license only for DLCs and XBLA titles
+      if (content_data.content_type == xe::XContentType::kMarketplaceContent ||
+          content_data.content_type == xe::XContentType::kArcadeTitle) {
         *license_mask_ptr = static_cast<uint32_t>(cvars::license_mask);
       }
     }


### PR DESCRIPTION
This updates XamContentCreate so it sets the license mask for XBLA titles in addition to DLC. Required for Sonic 4: Episode 2 which checks if Sonic 4: Episode 1 is installed and purchased to unlock extra content.