### PR TITLE
Proper 4:3 support

### DIFF
--- a/src/xenia/app/emulator_window.cc
+++ b/src/xenia/app/emulator_window.cc
@@ -161,11 +161,12 @@ const std::string kRecentlyPlayedTitlesFilename = "recent.toml";
 const std::string kBaseTitle = "Xenia-canary";
 
 EmulatorWindow::EmulatorWindow(Emulator* emulator,
-                               ui::WindowedAppContext& app_context)
+                               ui::WindowedAppContext& app_context,
+                               uint32_t width, uint32_t height)
     : emulator_(emulator),
       app_context_(app_context),
       window_listener_(*this),
-      window_(ui::Window::Create(app_context, kBaseTitle, 1280, 720)),
+      window_(ui::Window::Create(app_context, kBaseTitle, width, height)),
       imgui_drawer_(
           std::make_unique<ui::ImGuiDrawer>(window_.get(), kZOrderImGui)),
       display_config_game_config_load_callback_(
@@ -190,10 +191,11 @@ EmulatorWindow::EmulatorWindow(Emulator* emulator,
 }
 
 std::unique_ptr<EmulatorWindow> EmulatorWindow::Create(
-    Emulator* emulator, ui::WindowedAppContext& app_context) {
+    Emulator* emulator, ui::WindowedAppContext& app_context, uint32_t width,
+    uint32_t height) {
   assert_true(app_context.IsInUIThread());
   std::unique_ptr<EmulatorWindow> emulator_window(
-      new EmulatorWindow(emulator, app_context));
+      new EmulatorWindow(emulator, app_context, width, height));
   if (!emulator_window->Initialize()) {
     return nullptr;
   }

--- a/src/xenia/app/emulator_window.h
+++ b/src/xenia/app/emulator_window.h
@@ -54,7 +54,8 @@ class EmulatorWindow {
   virtual ~EmulatorWindow();
 
   static std::unique_ptr<EmulatorWindow> Create(
-      Emulator* emulator, ui::WindowedAppContext& app_context);
+      Emulator* emulator, ui::WindowedAppContext& app_context, uint32_t width,
+      uint32_t height);
 
   std::unique_ptr<xe::threading::Thread> Gamepad_HotKeys_Listener;
 
@@ -183,7 +184,8 @@ class EmulatorWindow {
   };
 
   explicit EmulatorWindow(Emulator* emulator,
-                          ui::WindowedAppContext& app_context);
+                          ui::WindowedAppContext& app_context, uint32_t width,
+                          uint32_t height);
 
   bool Initialize();
 

--- a/src/xenia/app/xenia_main.cc
+++ b/src/xenia/app/xenia_main.cc
@@ -103,6 +103,8 @@ DECLARE_bool(debug);
 
 DEFINE_bool(discord, true, "Enable Discord rich presence", "General");
 
+DECLARE_bool(widescreen);
+
 namespace xe {
 namespace app {
 
@@ -445,8 +447,17 @@ bool EmulatorApp::OnInitialize() {
   emulator_ =
       std::make_unique<Emulator>("", storage_root, content_root, cache_root);
 
+  // Determine window size based on user widescreen setting.
+  uint32_t window_w = 1280;
+  uint32_t window_h = 720;
+  if (!cvars::widescreen) {
+    window_w = 1024;
+    window_h = 768;
+  }
+
   // Main emulator display window.
-  emulator_window_ = EmulatorWindow::Create(emulator_.get(), app_context());
+  emulator_window_ = EmulatorWindow::Create(emulator_.get(), app_context(),
+                                            window_w, window_h);
   if (!emulator_window_) {
     XELOGE("Failed to create the main emulator window");
     return false;

--- a/src/xenia/gpu/d3d12/d3d12_command_processor.cc
+++ b/src/xenia/gpu/d3d12/d3d12_command_processor.cc
@@ -2205,9 +2205,11 @@ void D3D12CommandProcessor::IssueSwap(uint32_t frontbuffer_ptr,
   }
   D3D12_RESOURCE_DESC swap_texture_desc = swap_texture_resource->GetDesc();
 
+  auto aspect = graphics_system_->GetScaledAspectRatio();
+
   presenter->RefreshGuestOutput(
       uint32_t(swap_texture_desc.Width), uint32_t(swap_texture_desc.Height),
-      1280, 720,
+      aspect.first, aspect.second,
       [this, &swap_texture_srv_desc, frontbuffer_format, swap_texture_resource,
        &swap_texture_desc](
           ui::Presenter::GuestOutputRefreshContext& context) -> bool {

--- a/src/xenia/gpu/graphics_system.cc
+++ b/src/xenia/gpu/graphics_system.cc
@@ -67,6 +67,9 @@ X_STATUS GraphicsSystem::Setup(cpu::Processor* processor,
   kernel_state_ = kernel_state;
   app_context_ = app_context;
 
+  scaled_aspect_x_ = 16;
+  scaled_aspect_y_ = 9;
+
   if (provider_) {
     // Safe if either the UI thread call or the presenter creation fails.
     if (app_context_) {

--- a/src/xenia/gpu/graphics_system.h
+++ b/src/xenia/gpu/graphics_system.h
@@ -86,6 +86,14 @@ class GraphicsSystem {
   bool Save(ByteStream* stream);
   bool Restore(ByteStream* stream);
 
+  std::pair<uint32_t, uint32_t> GetScaledAspectRatio() const {
+    return {scaled_aspect_x_, scaled_aspect_y_};
+  };
+  void SetScaledAspectRatio(uint32_t x, uint32_t y) {
+    scaled_aspect_x_ = x;
+    scaled_aspect_y_ = y;
+  };
+
  protected:
   GraphicsSystem();
 
@@ -116,6 +124,9 @@ class GraphicsSystem {
   std::unique_ptr<CommandProcessor> command_processor_;
 
   bool paused_ = false;
+
+  uint32_t scaled_aspect_x_ = 0;
+  uint32_t scaled_aspect_y_ = 0;
 
  private:
   std::unique_ptr<ui::Presenter> presenter_;

--- a/src/xenia/gpu/vulkan/vulkan_command_processor.cc
+++ b/src/xenia/gpu/vulkan/vulkan_command_processor.cc
@@ -1286,8 +1286,11 @@ void VulkanCommandProcessor::IssueSwap(uint32_t frontbuffer_ptr,
     return;
   }
 
+  auto aspect = graphics_system_->GetScaledAspectRatio();
+
   presenter->RefreshGuestOutput(
-      frontbuffer_width_scaled, frontbuffer_height_scaled, 1280, 720,
+      frontbuffer_width_scaled, frontbuffer_height_scaled, aspect.first,
+      aspect.second,
       [this, frontbuffer_width_scaled, frontbuffer_height_scaled,
        frontbuffer_format, swap_texture_view](
           ui::Presenter::GuestOutputRefreshContext& context) -> bool {


### PR DESCRIPTION
This adds proper support for 4:3 aspect ratio.
* Added user setting for toggling widescreen. Xenia's scaler respects the selected display aspect ratio if present_letterbox is enabled. Xenia window size is set to 1024x768 if widescreen is disabled.
* Get the game's scaling parameters from VdInitializeScalerCommandBuffer and use them to calculate the final aspect ratio so that letterboxed games appear correctly (e.g. Sonic 06, Mirror's Edge).
* Added a config option for interlaced video in case it affects behavior in some games.