### PR TITLE
[Kernel] Implemented XexLoadImageFromMemory

### DIFF
--- a/src/xenia/kernel/kernel_state.h
+++ b/src/xenia/kernel/kernel_state.h
@@ -258,6 +258,9 @@ class KernelState {
   void SetExecutableModule(object_ref<UserModule> module);
   object_ref<UserModule> LoadUserModule(const std::string_view name,
                                         bool call_entry = true);
+  object_ref<UserModule> LoadUserModuleFromMemory(const std::string_view name,
+                                                  const void* addr,
+                                                  const size_t length);
   X_RESULT FinishLoadingUserModule(const object_ref<UserModule> module,
                                    bool call_entry = true);
   void UnloadUserModule(const object_ref<UserModule>& module,

--- a/src/xenia/kernel/user_module.cc
+++ b/src/xenia/kernel/user_module.cc
@@ -182,6 +182,13 @@ X_STATUS UserModule::LoadFromMemory(const void* addr, const size_t length) {
   return X_STATUS_SUCCESS;
 }
 
+X_STATUS UserModule::LoadFromMemoryNamed(const std::string_view raw_name,
+                                         const void* addr,
+                                         const size_t length) {
+  name_ = std::string(raw_name);
+  return LoadFromMemory(addr, length);
+}
+
 X_STATUS UserModule::LoadContinue() {
   // LoadXexContinue: finishes loading XEX after a patch has been applied (or
   // patch wasn't found)

--- a/src/xenia/kernel/user_module.h
+++ b/src/xenia/kernel/user_module.h
@@ -76,6 +76,8 @@ class UserModule : public XModule {
 
   X_STATUS LoadFromFile(const std::string_view path);
   X_STATUS LoadFromMemory(const void* addr, const size_t length);
+  X_STATUS LoadFromMemoryNamed(const std::string_view name, const void* addr,
+                               const size_t length);
   X_STATUS LoadContinue();
   X_STATUS Unload();
 


### PR DESCRIPTION
This PR implements the `XexLoadImageFromMemory` function from `xboxkrnl`.

Unlike `XexLoadImage`, this function will return an error status if loading a module of the same name, instead of returning a handle to the already loaded module.