### PR TITLE
[Kernel] Notification ID Changes

### DIFF
--- a/src/xenia/kernel/kernel_state.cc
+++ b/src/xenia/kernel/kernel_state.cc
@@ -764,14 +764,14 @@ void KernelState::RegisterNotifyListener(XNotifyListener* listener) {
   // Games seem to expect a few notifications on startup, only for the first
   // listener.
   // https://cs.rin.ru/forum/viewtopic.php?f=38&t=60668&hilit=resident+evil+5&start=375
-  if (!has_notified_startup_ && listener->mask() & 0x00000001) {
+  if (!has_notified_startup_ && listener->mask() & kXNotifySystem) {
     has_notified_startup_ = true;
     // XN_SYS_UI (on, off)
-    listener->EnqueueNotification(0x00000009, 1);
-    listener->EnqueueNotification(0x00000009, 0);
+    listener->EnqueueNotification(kXNotificationIDSystemUI, 1);
+    listener->EnqueueNotification(kXNotificationIDSystemUI, 0);
     // XN_SYS_SIGNINCHANGED x2
-    listener->EnqueueNotification(0x0000000A, 1);
-    listener->EnqueueNotification(0x0000000A, 1);
+    listener->EnqueueNotification(kXNotificationIDSystemSignInChanged, 1);
+    listener->EnqueueNotification(kXNotificationIDSystemSignInChanged, 1);
   }
 }
 
@@ -1149,12 +1149,12 @@ void KernelState::UpdateUsedUserProfiles() {
 
     if (IsUserSignedIn(i) && !is_used) {
       user_profiles_.erase(i);
-      BroadcastNotification(0x12, 0);
+      BroadcastNotification(kXNotificationIDSystemInputDevicesChanged, 0);
     }
 
     if (!IsUserSignedIn(i) && is_used) {
       user_profiles_.emplace(i, std::make_unique<xam::UserProfile>(i));
-      BroadcastNotification(0x12, 0);
+      BroadcastNotification(kXNotificationIDSystemInputDevicesChanged, 0);
     }
   }
 }

--- a/src/xenia/kernel/xam/apps/xmp_app.cc
+++ b/src/xenia/kernel/xam/apps/xmp_app.cc
@@ -12,6 +12,7 @@
 
 #include "xenia/base/logging.h"
 #include "xenia/base/threading.h"
+#include "xenia/xbox.h"
 
 namespace xe {
 namespace kernel {
@@ -142,7 +143,8 @@ X_HRESULT XmpApp::XMPPlayTitlePlaylist(uint32_t playlist_handle,
   active_song_index_ = 0;
   state_ = State::kPlaying;
   OnStateChanged();
-  kernel_state_->BroadcastNotification(kMsgPlaybackBehaviorChanged, 1);
+  kernel_state_->BroadcastNotification(kNotificationXmpPlaybackBehaviorChanged,
+                                       1);
   return X_E_SUCCESS;
 }
 
@@ -202,7 +204,7 @@ X_HRESULT XmpApp::XMPPrevious() {
 }
 
 void XmpApp::OnStateChanged() {
-  kernel_state_->BroadcastNotification(kMsgStateChanged,
+  kernel_state_->BroadcastNotification(kNotificationXmpStateChanged,
                                        static_cast<uint32_t>(state_));
 }
 
@@ -270,7 +272,8 @@ X_HRESULT XmpApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
       playback_mode_ = static_cast<PlaybackMode>(uint32_t(args->playback_mode));
       repeat_mode_ = static_cast<RepeatMode>(uint32_t(args->repeat_mode));
       unknown_flags_ = args->flags;
-      kernel_state_->BroadcastNotification(kMsgPlaybackBehaviorChanged, 0);
+      kernel_state_->BroadcastNotification(
+          kNotificationXmpPlaybackBehaviorChanged, 0);
       return X_E_SUCCESS;
     }
     case 0x00070009: {
@@ -405,8 +408,8 @@ X_HRESULT XmpApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
              uint32_t(args->controller), uint32_t(args->playback_client));
 
       playback_client_ = PlaybackClient(uint32_t(args->playback_client));
-      kernel_state_->BroadcastNotification(kMsgPlaybackControllerChanged,
-                                           !args->playback_client);
+      kernel_state_->BroadcastNotification(
+          kNotificationXmpPlaybackControllerChanged, !args->playback_client);
       return X_E_SUCCESS;
     }
     case 0x0007001B: {

--- a/src/xenia/kernel/xam/apps/xmp_app.h
+++ b/src/xenia/kernel/xam/apps/xmp_app.h
@@ -92,10 +92,6 @@ class XmpApp : public App {
                                 uint32_t buffer_length) override;
 
  private:
-  static const uint32_t kMsgStateChanged = 0x0A000001;
-  static const uint32_t kMsgPlaybackBehaviorChanged = 0x0A000002;
-  static const uint32_t kMsgPlaybackControllerChanged = 0x0A000003;
-
   void OnStateChanged();
 
   State state_;

--- a/src/xenia/kernel/xam/xam_ui.cc
+++ b/src/xenia/kernel/xam/xam_ui.cc
@@ -79,7 +79,7 @@ X_RESULT xeXamDispatchDialog(T* dialog,
                              uint32_t overlapped) {
   auto pre = []() {
     // Broadcast XN_SYS_UI = true
-    kernel_state()->BroadcastNotification(0x9, true);
+    kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, true);
   };
   auto run = [dialog, close_callback]() -> X_RESULT {
     X_RESULT result;
@@ -103,7 +103,7 @@ X_RESULT xeXamDispatchDialog(T* dialog,
   auto post = []() {
     xe::threading::Sleep(std::chrono::milliseconds(100));
     // Broadcast XN_SYS_UI = false
-    kernel_state()->BroadcastNotification(0x9, false);
+    kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, false);
   };
   if (!overlapped) {
     pre();
@@ -122,7 +122,7 @@ X_RESULT xeXamDispatchDialogEx(
     uint32_t overlapped) {
   auto pre = []() {
     // Broadcast XN_SYS_UI = true
-    kernel_state()->BroadcastNotification(0x9, true);
+    kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, true);
   };
   auto run = [dialog, close_callback](uint32_t& extended_error,
                                       uint32_t& length) -> X_RESULT {
@@ -147,7 +147,7 @@ X_RESULT xeXamDispatchDialogEx(
   auto post = []() {
     xe::threading::Sleep(std::chrono::milliseconds(100));
     // Broadcast XN_SYS_UI = false
-    kernel_state()->BroadcastNotification(0x9, false);
+    kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, false);
   };
   if (!overlapped) {
     pre();
@@ -166,12 +166,12 @@ X_RESULT xeXamDispatchHeadless(std::function<X_RESULT()> run_callback,
                                uint32_t overlapped) {
   auto pre = []() {
     // Broadcast XN_SYS_UI = true
-    kernel_state()->BroadcastNotification(0x9, true);
+    kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, true);
   };
   auto post = []() {
     xe::threading::Sleep(std::chrono::milliseconds(100));
     // Broadcast XN_SYS_UI = false
-    kernel_state()->BroadcastNotification(0x9, false);
+    kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, false);
   };
   if (!overlapped) {
     pre();
@@ -190,12 +190,12 @@ X_RESULT xeXamDispatchHeadlessEx(
     uint32_t overlapped) {
   auto pre = []() {
     // Broadcast XN_SYS_UI = true
-    kernel_state()->BroadcastNotification(0x9, true);
+    kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, true);
   };
   auto post = []() {
     xe::threading::Sleep(std::chrono::milliseconds(100));
     // Broadcast XN_SYS_UI = false
-    kernel_state()->BroadcastNotification(0x9, false);
+    kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, false);
   };
   if (!overlapped) {
     pre();
@@ -215,7 +215,7 @@ template <typename T>
 X_RESULT xeXamDispatchDialogAsync(T* dialog,
                                   std::function<void(T*)> close_callback) {
   // Broadcast XN_SYS_UI = true
-  kernel_state()->BroadcastNotification(0x9, true);
+  kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, true);
   ++xam_dialogs_shown_;
 
   // Important to pass captured vars by value here since we return from this
@@ -229,7 +229,7 @@ X_RESULT xeXamDispatchDialogAsync(T* dialog,
 
     xe::threading::Sleep(std::chrono::milliseconds(100));
     // Broadcast XN_SYS_UI = false
-    kernel_state()->BroadcastNotification(0x9, false);
+    kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, false);
   });
 
   return X_ERROR_SUCCESS;
@@ -237,7 +237,7 @@ X_RESULT xeXamDispatchDialogAsync(T* dialog,
 
 X_RESULT xeXamDispatchHeadlessAsync(std::function<void()> run_callback) {
   // Broadcast XN_SYS_UI = true
-  kernel_state()->BroadcastNotification(0x9, true);
+  kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, true);
   ++xam_dialogs_shown_;
 
   auto display_window = kernel_state()->emulator()->display_window();
@@ -248,7 +248,7 @@ X_RESULT xeXamDispatchHeadlessAsync(std::function<void()> run_callback) {
 
     xe::threading::Sleep(std::chrono::milliseconds(100));
     // Broadcast XN_SYS_UI = false
-    kernel_state()->BroadcastNotification(0x9, false);
+    kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, false);
   });
 
   return X_ERROR_SUCCESS;
@@ -696,8 +696,8 @@ dword_result_t XamShowMarketplaceUI_entry(dword_t user_index, dword_t ui_type,
       if (button == 0) {
         cvars::license_mask = 1;
 
-        // XN_LIVE_CONTENT_INSTALLED
-        kernel_state()->BroadcastNotification(0x2000007, 0);
+        kernel_state()->BroadcastNotification(
+            kXNotificationIDLiveContentInstalled, 0);
       }
     }
   };

--- a/src/xenia/kernel/xam/xam_user.cc
+++ b/src/xenia/kernel/xam/xam_user.cc
@@ -544,7 +544,7 @@ DECLARE_XAM_EXPORT1(XamUserAreUsersFriends, kUserProfiles, kStub);
 
 dword_result_t XamShowSigninUI_entry(dword_t users_needed, dword_t unk_mask) {
   // XN_SYS_UI (on)
-  kernel_state()->BroadcastNotification(0x00000009, 1);
+  kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, 1);
   kernel_state()->UpdateUsedUserProfiles();
   // Mask values vary. Probably matching user types? Local/remote?
   // Games seem to sit and loop until we trigger this notification:
@@ -560,10 +560,11 @@ dword_result_t XamShowSigninUI_entry(dword_t users_needed, dword_t unk_mask) {
   }
 
   // XN_SYS_SIGNINCHANGED (players)
-  kernel_state()->BroadcastNotification(0xA, user_mask);
+  kernel_state()->BroadcastNotification(kXNotificationIDSystemSignInChanged,
+                                        user_mask);
 
   // XN_SYS_UI (off)
-  kernel_state()->BroadcastNotification(0x00000009, 0);
+  kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, 0);
   return X_ERROR_SUCCESS;
 }
 DECLARE_XAM_EXPORT1(XamShowSigninUI, kUserProfiles, kStub);

--- a/src/xenia/xbox.h
+++ b/src/xenia/xbox.h
@@ -259,8 +259,64 @@ struct X_UNICODE_STRING {
 };
 static_assert_size(X_UNICODE_STRING, 8);
 
-// https://pastebin.com/SMypYikG
+// https://github.com/ThirteenAG/Ultimate-ASI-Loader/blob/master/source/xlive/xliveless.h
 typedef uint32_t XNotificationID;
+enum : XNotificationID {
+  // Notification Areas
+  kXNotifySystem = 0x00000001,
+  kXNotifyLive = 0x00000002,
+  kXNotifyFriends = 0x00000004,
+  kXNotifyCustom = 0x00000008,
+  kXNotifyXmp = 0x00000020,
+  kXNotifyMsgr = 0x00000040,
+  kXNotifyParty = 0x00000080,
+  kXNotifyAll = 0x000000EF,
+
+  // XNotification System
+  kXNotificationIDSystemUI = 0x00000009,
+  kXNotificationIDSystemSignInChanged = 0x0000000A,
+  kXNotificationIDSystemStorageDevicesChanged = 0x0000000B,
+  kXNotificationIDSystemProfileSettingChanged = 0x0000000E,
+  kXNotificationIDSystemMuteListChanged = 0x00000011,
+  kXNotificationIDSystemInputDevicesChanged = 0x00000012,
+  kXNotificationIDSystemInputDeviceConfigChanged = 0x00000013,
+  kXNotificationIDSystemPlayerTimerNotice = 0x00000015,
+  kXNotificationIDSystemAvatarChanged = 0x00000017,
+  kXNotificationIDSystemNUIHardwareStatusChanged = 0x00000019,
+  kXNotificationIDSystemNUIPause = 0x0000001A,
+  kXNotificationIDSystemNUIUIApproach = 0x0000001B,
+  kXNotificationIDSystemDeviceRemap = 0x0000001C,
+  kXNotificationIDSystemNUIBindingChanged = 0x0000001D,
+  kXNotificationIDSystemAudioLatencyChanged = 0x0000001E,
+  kXNotificationIDSystemNUIChatBindingChanged = 0x0000001F,
+  kXNotificationIDSystemInputActivityChanged = 0x00000020,
+
+  // XNotification Live
+  kXNotificationIDLiveConnectionChanged = 0x02000001,
+  kXNotificationIDLiveInviteAccepted = 0x02000002,
+  kXNotificationIDLiveLinkStateChanged = 0x02000003,
+  kXNotificationIDLiveContentInstalled = 0x02000007,
+  kXNotificationIDLiveMembershipPurchased = 0x02000008,
+  kXNotificationIDLiveVoicechatAway = 0x02000009,
+  kXNotificationIDLivePresenceChanged = 0x0200000A,
+
+  // XNotification Friends
+  kXNotificationIDFriendsPresenceChanged = 0x04000001,
+  kXNotificationIDFriendsFriendAdded = 0x04000002,
+  kXNotificationIDFriendsFriendRemoved = 0x04000003,
+
+  // XNotification Custom
+  kXNotificationIDCustomActionPressed = 0x06000003,
+  kXNotificationIDCustomGamercard = 0x06000004,
+
+  // XNotification XMP
+  kNotificationXmpStateChanged = 0x0A000001,
+  kNotificationXmpPlaybackBehaviorChanged = 0x0A000002,
+  kNotificationXmpPlaybackControllerChanged = 0x0A000003,
+
+  // XNotification Party
+  kXNotificationIDPartyMembersChanged = 0x0E000002,
+};
 
 // https://github.com/CodeAsm/ffplay360/blob/master/Common/XTLOnPC.h
 struct X_VIDEO_MODE {


### PR DESCRIPTION
Based off of pull request xenia-project#2047. Convert magic numbers to enum to improve readability. Includes currently unused ones for future use.