### PR TITLE
[Emulator] Change default config value for query_occlusion_fake_sample_count

### DIFF
--- a/src/xenia/base/cvar.h
+++ b/src/xenia/base/cvar.h
@@ -490,7 +490,7 @@ class IConfigVarUpdate {
   // If you're reviewing a pull request with a change here, check if 1) has been
   // done by the submitter before merging.
   static constexpr uint32_t kLastCommittedUpdateDate =
-      MakeConfigVarUpdateDate(2024, 8, 31, 20);
+      MakeConfigVarUpdateDate(2024, 9, 23, 9);
 
   virtual ~IConfigVarUpdate() = default;
 

--- a/src/xenia/gpu/gpu_flags.cc
+++ b/src/xenia/gpu/gpu_flags.cc
@@ -55,9 +55,10 @@ DEFINE_bool(
     "when MSAA is used with fullscreen passes.",
     "GPU");
 
-DEFINE_int32(query_occlusion_fake_sample_count, 1000,
+DEFINE_int32(query_occlusion_fake_sample_count, 100,
              "If set to -1 no sample counts are written, games may hang. Else, "
              "the sample count of every tile will be incremented on every "
              "EVENT_WRITE_ZPD by this number. Setting this to 0 means "
              "everything is reported as occluded.",
              "GPU");
+UPDATE_from_int32(query_occlusion_fake_sample_count, 2024, 9, 23, 9, 1000);


### PR DESCRIPTION
Fixes overbright sun in Forza Motorsport 3 and 4. Probably other games as well.
I didn't see any regressions in the 209 games I tested.