### PR TITLE
[Vulkan] Update from VK_KHR_maintenance4 to VK_KHR_maintenance7

### DIFF
--- a/src/xenia/ui/vulkan/functions/device_khr_maintenance7.inc
+++ b/src/xenia/ui/vulkan/functions/device_khr_maintenance7.inc
@@ -1,4 +1,4 @@
-// VK_KHR_maintenance4 functions used in Xenia.
+// VK_KHR_maintenance7 functions used in Xenia.
 // Promoted to Vulkan 1.3 core.
 XE_UI_VULKAN_FUNCTION_PROMOTED(vkGetDeviceBufferMemoryRequirementsKHR,
                                vkGetDeviceBufferMemoryRequirements)

--- a/src/xenia/ui/vulkan/vulkan_mem_alloc.cc
+++ b/src/xenia/ui/vulkan/vulkan_mem_alloc.cc
@@ -79,7 +79,7 @@ VmaAllocator CreateVmaAllocator(const VulkanProvider& provider,
       allocator_create_info.flags |= VMA_ALLOCATOR_CREATE_EXT_MEMORY_BUDGET_BIT;
     }
   }
-  if (device_info.ext_1_3_VK_KHR_maintenance4) {
+  if (device_info.ext_1_3_VK_KHR_maintenance7) {
     vma_vulkan_functions.vkGetDeviceBufferMemoryRequirements =
         dfn.vkGetDeviceBufferMemoryRequirements;
     vma_vulkan_functions.vkGetDeviceImageMemoryRequirements =

--- a/src/xenia/ui/vulkan/vulkan_provider.cc
+++ b/src/xenia/ui/vulkan/vulkan_provider.cc
@@ -795,7 +795,7 @@ void VulkanProvider::TryCreateDevice() {
   }
   if (properties.apiVersion >= VK_MAKE_API_VERSION(0, 1, 3, 0)) {
     device_info_.ext_1_3_VK_EXT_shader_demote_to_helper_invocation = true;
-    device_info_.ext_1_3_VK_KHR_maintenance4 = true;
+    device_info_.ext_1_3_VK_KHR_maintenance7 = true;
   }
 
   for (const VkExtensionProperties& extension : extension_properties) {
@@ -855,7 +855,7 @@ void VulkanProvider::TryCreateDevice() {
         EXTENSION_PROMOTED(VK_EXT_shader_demote_to_helper_invocation, 3)
       }
       if (properties.apiVersion >= VK_MAKE_API_VERSION(0, 1, 1, 0)) {
-        EXTENSION_PROMOTED(VK_KHR_maintenance4, 3)
+        EXTENSION_PROMOTED(VK_KHR_maintenance7, 3)
       }
     }
 #undef EXTENSION_PROMOTED
@@ -1339,7 +1339,7 @@ void VulkanProvider::TryCreateDevice() {
 #include "xenia/ui/vulkan/functions/device_khr_get_memory_requirements2.inc"
   }
   if (properties.apiVersion >= VK_MAKE_API_VERSION(0, 1, 3, 0)) {
-#include "xenia/ui/vulkan/functions/device_khr_maintenance4.inc"
+#include "xenia/ui/vulkan/functions/device_khr_maintenance7.inc"
   }
 #undef XE_UI_VULKAN_FUNCTION_PROMOTED
 
@@ -1361,8 +1361,8 @@ void VulkanProvider::TryCreateDevice() {
     }
   }
   if (properties.apiVersion < VK_MAKE_API_VERSION(0, 1, 3, 0)) {
-    if (device_info_.ext_1_3_VK_KHR_maintenance4) {
-#include "xenia/ui/vulkan/functions/device_khr_maintenance4.inc"
+    if (device_info_.ext_1_3_VK_KHR_maintenance7) {
+#include "xenia/ui/vulkan/functions/device_khr_maintenance7.inc"
     }
   }
 #undef XE_UI_VULKAN_FUNCTION_PROMOTED

--- a/src/xenia/ui/vulkan/vulkan_provider.h
+++ b/src/xenia/ui/vulkan/vulkan_provider.h
@@ -200,9 +200,9 @@ class VulkanProvider : public GraphicsProvider {
 
     bool shaderDemoteToHelperInvocation;
 
-    // VK_KHR_maintenance4 (#414, Vulkan 1.3).
+    // VK_KHR_maintenance7 (#414, Vulkan 1.3).
 
-    bool ext_1_3_VK_KHR_maintenance4;
+    bool ext_1_3_VK_KHR_maintenance7;
 
     // VK_EXT_non_seamless_cube_map (#423).
 
@@ -329,7 +329,7 @@ class VulkanProvider : public GraphicsProvider {
 #include "xenia/ui/vulkan/functions/device_1_0.inc"
 #include "xenia/ui/vulkan/functions/device_khr_bind_memory2.inc"
 #include "xenia/ui/vulkan/functions/device_khr_get_memory_requirements2.inc"
-#include "xenia/ui/vulkan/functions/device_khr_maintenance4.inc"
+#include "xenia/ui/vulkan/functions/device_khr_maintenance7.inc"
 #include "xenia/ui/vulkan/functions/device_khr_swapchain.inc"
 #undef XE_UI_VULKAN_FUNCTION_PROMOTED
 #undef XE_UI_VULKAN_FUNCTION


### PR DESCRIPTION
I have updated **VK_KHR_maintenance4** to **VK_KHR_maintenance7**.
This is the latest version I found in **vulkan_core.h** in **Vulkan_Headers**.

Tested on GTA IV:
![Image1](https://github.com/user-attachments/assets/58ce579b-89c3-4ddb-aad2-bff0fd7c10ba)
![Image2](https://github.com/user-attachments/assets/08ddf467-6b7c-47fd-8cfd-dd4ed63c9bcd)