### PR TITLE
Various fixes

### DIFF
--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -643,8 +643,16 @@ X_STATUS Emulator::InstallContentPackage(
 
   vfs::VirtualFileSystem::ExtractContentHeader(device.get(), header_path);
 
-  return vfs::VirtualFileSystem::ExtractContentFiles(device.get(),
-                                                     installation_path);
+  X_STATUS error_code = vfs::VirtualFileSystem::ExtractContentFiles(
+      device.get(), installation_path);
+  if (error_code != X_ERROR_SUCCESS) {
+    return error_code;
+  }
+
+  kernel_state()->BroadcastNotification(kXNotificationIDLiveContentInstalled,
+                                        0);
+
+  return error_code;
 }
 
 X_STATUS Emulator::ExtractZarchivePackage(

--- a/src/xenia/kernel/xam/xam_ui.cc
+++ b/src/xenia/kernel/xam/xam_ui.cc
@@ -78,7 +78,6 @@ X_RESULT xeXamDispatchDialog(T* dialog,
                              std::function<X_RESULT(T*)> close_callback,
                              uint32_t overlapped) {
   auto pre = []() {
-    // Broadcast XN_SYS_UI = true
     kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, true);
   };
   auto run = [dialog, close_callback]() -> X_RESULT {
@@ -102,7 +101,6 @@ X_RESULT xeXamDispatchDialog(T* dialog,
   };
   auto post = []() {
     xe::threading::Sleep(std::chrono::milliseconds(100));
-    // Broadcast XN_SYS_UI = false
     kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, false);
   };
   if (!overlapped) {
@@ -121,7 +119,6 @@ X_RESULT xeXamDispatchDialogEx(
     T* dialog, std::function<X_RESULT(T*, uint32_t&, uint32_t&)> close_callback,
     uint32_t overlapped) {
   auto pre = []() {
-    // Broadcast XN_SYS_UI = true
     kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, true);
   };
   auto run = [dialog, close_callback](uint32_t& extended_error,
@@ -146,7 +143,6 @@ X_RESULT xeXamDispatchDialogEx(
   };
   auto post = []() {
     xe::threading::Sleep(std::chrono::milliseconds(100));
-    // Broadcast XN_SYS_UI = false
     kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, false);
   };
   if (!overlapped) {
@@ -165,12 +161,10 @@ X_RESULT xeXamDispatchDialogEx(
 X_RESULT xeXamDispatchHeadless(std::function<X_RESULT()> run_callback,
                                uint32_t overlapped) {
   auto pre = []() {
-    // Broadcast XN_SYS_UI = true
     kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, true);
   };
   auto post = []() {
     xe::threading::Sleep(std::chrono::milliseconds(100));
-    // Broadcast XN_SYS_UI = false
     kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, false);
   };
   if (!overlapped) {
@@ -189,12 +183,10 @@ X_RESULT xeXamDispatchHeadlessEx(
     std::function<X_RESULT(uint32_t&, uint32_t&)> run_callback,
     uint32_t overlapped) {
   auto pre = []() {
-    // Broadcast XN_SYS_UI = true
     kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, true);
   };
   auto post = []() {
     xe::threading::Sleep(std::chrono::milliseconds(100));
-    // Broadcast XN_SYS_UI = false
     kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, false);
   };
   if (!overlapped) {
@@ -214,7 +206,6 @@ X_RESULT xeXamDispatchHeadlessEx(
 template <typename T>
 X_RESULT xeXamDispatchDialogAsync(T* dialog,
                                   std::function<void(T*)> close_callback) {
-  // Broadcast XN_SYS_UI = true
   kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, true);
   ++xam_dialogs_shown_;
 
@@ -228,7 +219,6 @@ X_RESULT xeXamDispatchDialogAsync(T* dialog,
     --xam_dialogs_shown_;
 
     xe::threading::Sleep(std::chrono::milliseconds(100));
-    // Broadcast XN_SYS_UI = false
     kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, false);
   });
 
@@ -236,7 +226,6 @@ X_RESULT xeXamDispatchDialogAsync(T* dialog,
 }
 
 X_RESULT xeXamDispatchHeadlessAsync(std::function<void()> run_callback) {
-  // Broadcast XN_SYS_UI = true
   kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, true);
   ++xam_dialogs_shown_;
 
@@ -247,7 +236,6 @@ X_RESULT xeXamDispatchHeadlessAsync(std::function<void()> run_callback) {
     --xam_dialogs_shown_;
 
     xe::threading::Sleep(std::chrono::milliseconds(100));
-    // Broadcast XN_SYS_UI = false
     kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, false);
   });
 
@@ -678,7 +666,7 @@ dword_result_t XamShowMarketplaceUI_entry(dword_t user_index, dword_t ui_type,
   // 0 - view all content for the current title
   // 1 - view content specified by offer id
   // content_types:
-  // always -1? check more games
+  // game specific, usually just -1
   if (user_index >= 4) {
     return X_ERROR_INVALID_PARAMETER;
   }

--- a/src/xenia/kernel/xam/xam_ui.cc
+++ b/src/xenia/kernel/xam/xam_ui.cc
@@ -212,14 +212,18 @@ X_RESULT xeXamDispatchDialogAsync(T* dialog,
   // Important to pass captured vars by value here since we return from this
   // without waiting for the dialog to close so the original local vars will be
   // destroyed.
-  // FIXME: Probably not the best idea to call Sleep in UI thread.
   dialog->set_close_callback([dialog, close_callback]() {
     close_callback(dialog);
 
     --xam_dialogs_shown_;
 
-    xe::threading::Sleep(std::chrono::milliseconds(100));
-    kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, false);
+    auto run = []() -> void {
+      xe::threading::Sleep(std::chrono::milliseconds(100));
+      kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, false);
+    };
+
+    std::thread thread(run);
+    thread.detach();
   });
 
   return X_ERROR_SUCCESS;
@@ -235,8 +239,13 @@ X_RESULT xeXamDispatchHeadlessAsync(std::function<void()> run_callback) {
 
     --xam_dialogs_shown_;
 
-    xe::threading::Sleep(std::chrono::milliseconds(100));
-    kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, false);
+    auto run = []() -> void {
+      xe::threading::Sleep(std::chrono::milliseconds(100));
+      kernel_state()->BroadcastNotification(kXNotificationIDSystemUI, false);
+    };
+
+    std::thread thread(run);
+    thread.detach();
   });
 
   return X_ERROR_SUCCESS;


### PR DESCRIPTION
* Send kXNotificationIDSystemUI on a separate thread from UI after closing async XUI dialogs.
* Send kXNotificationIDLiveContentInstalled after installing content package. Some games listen for this, e.g. Portal 2.
* Some comment edits.