### PR TITLE
XMP playback

### DIFF
--- a/src/xenia/apu/audio_driver.cc
+++ b/src/xenia/apu/audio_driver.cc
@@ -12,8 +12,6 @@
 namespace xe {
 namespace apu {
 
-AudioDriver::AudioDriver(Memory* memory) : memory_(memory) {}
-
 AudioDriver::~AudioDriver() = default;
 
 }  // namespace apu

--- a/src/xenia/apu/audio_driver.h
+++ b/src/xenia/apu/audio_driver.h
@@ -18,17 +18,22 @@ namespace apu {
 
 class AudioDriver {
  public:
-  explicit AudioDriver(Memory* memory);
+  static const uint32_t kFrameFrequencyDefault = 48000;
+  static const uint32_t kFrameChannelsDefault = 6;
+  static const uint32_t kChannelSamplesDefault = 256;
+  static const uint32_t kFrameSamplesMax =
+      kFrameChannelsDefault * kChannelSamplesDefault;
+  static const uint32_t kFrameSizeMax = sizeof(float) * kFrameSamplesMax;
+
   virtual ~AudioDriver();
 
-  virtual void SubmitFrame(uint32_t samples_ptr) = 0;
+  virtual bool Initialize() = 0;
+  virtual void Shutdown() = 0;
 
- protected:
-  inline uint8_t* TranslatePhysical(uint32_t guest_address) const {
-    return memory_->TranslatePhysical(guest_address);
-  }
-
-  Memory* memory_ = nullptr;
+  virtual void SubmitFrame(float* samples) = 0;
+  virtual void Pause() = 0;
+  virtual void Resume() = 0;
+  virtual void SetVolume(float volume) = 0;
 };
 
 }  // namespace apu

--- a/src/xenia/apu/audio_system.cc
+++ b/src/xenia/apu/audio_system.cc
@@ -210,13 +210,13 @@ X_STATUS AudioSystem::RegisterClient(uint32_t callback, uint32_t callback_arg,
   return X_STATUS_SUCCESS;
 }
 
-void AudioSystem::SubmitFrame(size_t index, uint32_t samples_ptr) {
+void AudioSystem::SubmitFrame(size_t index, float* samples) {
   SCOPE_profile_cpu_f("apu");
 
   auto global_lock = global_critical_region_.Acquire();
   assert_true(index < kMaximumClientCount);
   assert_true(clients_[index].driver != NULL);
-  (clients_[index].driver)->SubmitFrame(samples_ptr);
+  (clients_[index].driver)->SubmitFrame(samples);
 }
 
 void AudioSystem::UnregisterClient(size_t index) {

--- a/src/xenia/apu/audio_system.h
+++ b/src/xenia/apu/audio_system.h
@@ -42,7 +42,12 @@ class AudioSystem {
   X_STATUS RegisterClient(uint32_t callback, uint32_t callback_arg,
                           size_t* out_index);
   void UnregisterClient(size_t index);
-  void SubmitFrame(size_t index, uint32_t samples_ptr);
+  void SubmitFrame(size_t index, float* samples);
+
+  // Creates an independent, non-registered driver instance.
+  virtual AudioDriver* CreateDriver(xe::threading::Semaphore* semaphore,
+                                    uint32_t frequency, uint32_t channels,
+                                    bool need_format_conversion) = 0;
 
   bool Save(ByteStream* stream);
   bool Restore(ByteStream* stream);

--- a/src/xenia/apu/nop/nop_audio_system.cc
+++ b/src/xenia/apu/nop/nop_audio_system.cc
@@ -30,6 +30,12 @@ X_STATUS NopAudioSystem::CreateDriver(size_t index,
   return X_STATUS_NOT_IMPLEMENTED;
 }
 
+AudioDriver* NopAudioSystem::CreateDriver(xe::threading::Semaphore* semaphore,
+                                          uint32_t frequency, uint32_t channels,
+                                          bool need_format_conversion) {
+  return nullptr;
+}
+
 void NopAudioSystem::DestroyDriver(AudioDriver* driver) { assert_always(); }
 
 }  // namespace nop

--- a/src/xenia/apu/nop/nop_audio_system.h
+++ b/src/xenia/apu/nop/nop_audio_system.h
@@ -27,6 +27,9 @@ class NopAudioSystem : public AudioSystem {
 
   X_STATUS CreateDriver(size_t index, xe::threading::Semaphore* semaphore,
                         AudioDriver** out_driver) override;
+  AudioDriver* CreateDriver(xe::threading::Semaphore* semaphore,
+                            uint32_t frequency, uint32_t channels,
+                            bool need_format_conversion) override;
   void DestroyDriver(AudioDriver* driver) override;
 };
 

--- a/src/xenia/apu/sdl/sdl_audio_driver.cc
+++ b/src/xenia/apu/sdl/sdl_audio_driver.cc
@@ -23,9 +23,27 @@ namespace xe {
 namespace apu {
 namespace sdl {
 
-SDLAudioDriver::SDLAudioDriver(Memory* memory,
-                               xe::threading::Semaphore* semaphore)
-    : AudioDriver(memory), semaphore_(semaphore) {}
+SDLAudioDriver::SDLAudioDriver(xe::threading::Semaphore* semaphore,
+                               uint32_t frequency, uint32_t channels,
+                               bool need_format_conversion)
+    : semaphore_(semaphore),
+      frame_frequency_(frequency),
+      frame_channels_(channels),
+      need_format_conversion_(need_format_conversion) {
+  switch (frame_channels_) {
+    case 6:
+      channel_samples_ = 256;
+      break;
+    case 2:
+      channel_samples_ = 768;
+      break;
+    default:
+      assert_unhandled_case(frame_channels_);
+  }
+  frame_size_ = sizeof(float) * frame_channels_ * channel_samples_;
+  assert_true(frame_size_ <= kFrameSizeMax);
+  assert_true(!need_format_conversion_ || frame_channels_ == 6);
+}
 
 SDLAudioDriver::~SDLAudioDriver() {
   assert_true(frames_queued_.empty());
@@ -58,8 +76,10 @@ bool SDLAudioDriver::Initialize() {
   desired_spec.samples = channel_samples_;
   desired_spec.callback = SDLCallback;
   desired_spec.userdata = this;
-  // Allow the hardware to decide between 5.1 and stereo
-  int allowed_change = SDL_AUDIO_ALLOW_CHANNELS_CHANGE;
+  // Allow the hardware to decide between 5.1 and stereo,
+  // unless the input is stereo
+  int allowed_change =
+      frame_channels_ != 2 ? SDL_AUDIO_ALLOW_CHANNELS_CHANGE : 0;
   for (int i = 0; i < 2; i++) {
     sdl_device_id_ = SDL_OpenAudioDevice(nullptr, 0, &desired_spec,
                                          &obtained_spec, allowed_change);
@@ -86,26 +106,29 @@ bool SDLAudioDriver::Initialize() {
   return true;
 }
 
-void SDLAudioDriver::SubmitFrame(uint32_t frame_ptr) {
-  const auto input_frame = memory_->TranslateVirtual<float*>(frame_ptr);
+void SDLAudioDriver::SubmitFrame(float* frame) {
   float* output_frame;
   {
     std::unique_lock<std::mutex> guard(frames_mutex_);
     if (frames_unused_.empty()) {
-      output_frame = new float[frame_samples_];
+      output_frame = new float[frame_channels_ * channel_samples_];
     } else {
       output_frame = frames_unused_.top();
       frames_unused_.pop();
     }
   }
 
-  std::memcpy(output_frame, input_frame, frame_samples_ * sizeof(float));
+  std::memcpy(output_frame, frame, frame_size_);
 
   {
     std::unique_lock<std::mutex> guard(frames_mutex_);
     frames_queued_.push(output_frame);
   }
 }
+
+void SDLAudioDriver::Pause() { SDL_PauseAudioDevice(sdl_device_id_, 1); }
+
+void SDLAudioDriver::Resume() { SDL_PauseAudioDevice(sdl_device_id_, 0); }
 
 void SDLAudioDriver::Shutdown() {
   if (sdl_device_id_ > 0) {
@@ -134,8 +157,8 @@ void SDLAudioDriver::SDLCallback(void* userdata, Uint8* stream, int len) {
     return;
   }
   const auto driver = static_cast<SDLAudioDriver*>(userdata);
-  assert_true(len ==
-              sizeof(float) * channel_samples_ * driver->sdl_device_channels_);
+  assert_true(len == sizeof(float) * driver->channel_samples_ *
+                         driver->sdl_device_channels_);
 
   std::unique_lock<std::mutex> guard(driver->frames_mutex_);
   if (driver->frames_queued_.empty()) {
@@ -145,19 +168,31 @@ void SDLAudioDriver::SDLCallback(void* userdata, Uint8* stream, int len) {
     driver->frames_queued_.pop();
     if (cvars::mute) {
       std::memset(stream, 0, len);
-    } else {
+    } else if (driver->need_format_conversion_) {
       switch (driver->sdl_device_channels_) {
         case 2:
           conversion::sequential_6_BE_to_interleaved_2_LE(
-              reinterpret_cast<float*>(stream), buffer, channel_samples_);
+              reinterpret_cast<float*>(stream), buffer,
+              driver->channel_samples_);
           break;
         case 6:
           conversion::sequential_6_BE_to_interleaved_6_LE(
-              reinterpret_cast<float*>(stream), buffer, channel_samples_);
+              reinterpret_cast<float*>(stream), buffer,
+              driver->channel_samples_);
           break;
         default:
           assert_unhandled_case(driver->sdl_device_channels_);
           break;
+      }
+    } else {
+      assert_true(driver->sdl_device_channels_ == driver->frame_channels_);
+      if (driver->volume_ != 1.0f) {
+        std::memset(stream, 0, len);
+        SDL_MixAudioFormat(
+            stream, reinterpret_cast<Uint8*>(buffer), AUDIO_F32, len,
+            static_cast<int>(driver->volume_ * SDL_MIX_MAXVOLUME));
+      } else {
+        std::memcpy(stream, buffer, len);
       }
     }
     driver->frames_unused_.push(buffer);

--- a/src/xenia/apu/sdl/sdl_audio_driver.h
+++ b/src/xenia/apu/sdl/sdl_audio_driver.h
@@ -24,12 +24,18 @@ namespace sdl {
 
 class SDLAudioDriver : public AudioDriver {
  public:
-  SDLAudioDriver(Memory* memory, xe::threading::Semaphore* semaphore);
+  SDLAudioDriver(xe::threading::Semaphore* semaphore,
+                 uint32_t frequency = kFrameFrequencyDefault,
+                 uint32_t channels = kFrameChannelsDefault,
+                 bool need_format_conversion = true);
   ~SDLAudioDriver() override;
 
-  bool Initialize();
-  void SubmitFrame(uint32_t frame_ptr) override;
-  void Shutdown();
+  bool Initialize() override;
+  void SubmitFrame(float* frame) override;
+  void Pause() override;
+  void Resume() override;
+  void SetVolume(float volume) override { volume_ = volume; };
+  void Shutdown() override;
 
  protected:
   static void SDLCallback(void* userdata, Uint8* stream, int len);
@@ -40,11 +46,13 @@ class SDLAudioDriver : public AudioDriver {
   bool sdl_initialized_ = false;
   uint8_t sdl_device_channels_ = 0;
 
-  static const uint32_t frame_frequency_ = 48000;
-  static const uint32_t frame_channels_ = 6;
-  static const uint32_t channel_samples_ = 256;
-  static const uint32_t frame_samples_ = frame_channels_ * channel_samples_;
-  static const uint32_t frame_size_ = sizeof(float) * frame_samples_;
+  float volume_ = 1.0f;
+
+  uint32_t frame_frequency_;
+  uint32_t frame_channels_;
+  uint32_t channel_samples_;
+  uint32_t frame_size_;
+  bool need_format_conversion_;
   std::queue<float*> frames_queued_ = {};
   std::stack<float*> frames_unused_ = {};
   std::mutex frames_mutex_ = {};

--- a/src/xenia/apu/sdl/sdl_audio_system.cc
+++ b/src/xenia/apu/sdl/sdl_audio_system.cc
@@ -31,7 +31,7 @@ X_STATUS SDLAudioSystem::CreateDriver(size_t index,
                                       xe::threading::Semaphore* semaphore,
                                       AudioDriver** out_driver) {
   assert_not_null(out_driver);
-  auto driver = new SDLAudioDriver(memory_, semaphore);
+  auto driver = new SDLAudioDriver(semaphore);
   if (!driver->Initialize()) {
     driver->Shutdown();
     return X_STATUS_UNSUCCESSFUL;
@@ -39,6 +39,13 @@ X_STATUS SDLAudioSystem::CreateDriver(size_t index,
 
   *out_driver = driver;
   return X_STATUS_SUCCESS;
+}
+
+AudioDriver* SDLAudioSystem::CreateDriver(xe::threading::Semaphore* semaphore,
+                                          uint32_t frequency, uint32_t channels,
+                                          bool need_format_conversion) {
+  return new SDLAudioDriver(semaphore, frequency, channels,
+                            need_format_conversion);
 }
 
 void SDLAudioSystem::DestroyDriver(AudioDriver* driver) {

--- a/src/xenia/apu/sdl/sdl_audio_system.h
+++ b/src/xenia/apu/sdl/sdl_audio_system.h
@@ -27,6 +27,9 @@ class SDLAudioSystem : public AudioSystem {
 
   X_RESULT CreateDriver(size_t index, xe::threading::Semaphore* semaphore,
                         AudioDriver** out_driver) override;
+  AudioDriver* CreateDriver(xe::threading::Semaphore* semaphore,
+                            uint32_t frequency, uint32_t channels,
+                            bool need_format_conversion) override;
   void DestroyDriver(AudioDriver* driver) override;
 
  protected:

--- a/src/xenia/apu/xaudio2/xaudio2_audio_system.cc
+++ b/src/xenia/apu/xaudio2/xaudio2_audio_system.cc
@@ -32,7 +32,7 @@ X_STATUS XAudio2AudioSystem::CreateDriver(size_t index,
                                           xe::threading::Semaphore* semaphore,
                                           AudioDriver** out_driver) {
   assert_not_null(out_driver);
-  auto driver = new XAudio2AudioDriver(memory_, semaphore);
+  auto driver = new XAudio2AudioDriver(semaphore);
   if (!driver->Initialize()) {
     driver->Shutdown();
     return X_STATUS_UNSUCCESSFUL;
@@ -40,6 +40,13 @@ X_STATUS XAudio2AudioSystem::CreateDriver(size_t index,
 
   *out_driver = driver;
   return X_STATUS_SUCCESS;
+}
+
+AudioDriver* XAudio2AudioSystem::CreateDriver(
+    xe::threading::Semaphore* semaphore, uint32_t frequency, uint32_t channels,
+    bool need_format_conversion) {
+  return new XAudio2AudioDriver(semaphore, frequency, channels,
+                                need_format_conversion);
 }
 
 void XAudio2AudioSystem::DestroyDriver(AudioDriver* driver) {

--- a/src/xenia/apu/xaudio2/xaudio2_audio_system.h
+++ b/src/xenia/apu/xaudio2/xaudio2_audio_system.h
@@ -27,6 +27,9 @@ class XAudio2AudioSystem : public AudioSystem {
 
   X_RESULT CreateDriver(size_t index, xe::threading::Semaphore* semaphore,
                         AudioDriver** out_driver) override;
+  AudioDriver* CreateDriver(xe::threading::Semaphore* semaphore,
+                            uint32_t frequency, uint32_t channels,
+                            bool need_format_conversion) override;
   void DestroyDriver(AudioDriver* driver) override;
 
  protected:

--- a/src/xenia/kernel/premake5.lua
+++ b/src/xenia/kernel/premake5.lua
@@ -16,8 +16,14 @@ project("xenia-kernel")
     "xenia-cpu",
     "xenia-hid",
     "xenia-vfs",
+    "libavcodec",
+    "libavformat",
+    "libavutil",
   })
   defines({
+  })
+  includedirs({
+    project_root.."/third_party/FFmpeg/",
   })
   recursive_platform_files()
   files({

--- a/src/xenia/kernel/xam/apps/xmp_app.cc
+++ b/src/xenia/kernel/xam/apps/xmp_app.cc
@@ -12,7 +12,28 @@
 
 #include "xenia/base/logging.h"
 #include "xenia/base/threading.h"
+#include "xenia/emulator.h"
 #include "xenia/xbox.h"
+
+#include "xenia/apu/audio_driver.h"
+#include "xenia/apu/audio_system.h"
+
+extern "C" {
+#if XE_COMPILER_MSVC
+#pragma warning(push)
+#pragma warning(disable : 4101 4244 5033)
+#endif
+#include "third_party/FFmpeg/libavcodec/avcodec.h"
+#include "third_party/FFmpeg/libavformat/avformat.h"
+#include "third_party/FFmpeg/libavutil/opt.h"
+#if XE_COMPILER_MSVC
+#pragma warning(pop)
+#endif
+}  // extern "C"
+
+DEFINE_bool(enable_xmp, true, "Enables Music Player playback.", "APU");
+DEFINE_int32(xmp_default_volume, 70,
+             "Default music volume if game doesn't set it [0-100].", "APU");
 
 namespace xe {
 namespace kernel {
@@ -26,11 +47,247 @@ XmpApp::XmpApp(KernelState* kernel_state)
       playback_mode_(PlaybackMode::kUnknown),
       repeat_mode_(RepeatMode::kUnknown),
       unknown_flags_(0),
-      volume_(1.0f),
+      volume_(cvars::xmp_default_volume / 100.0f),
       active_playlist_(nullptr),
       active_song_index_(0),
       next_playlist_handle_(1),
-      next_song_handle_(1) {}
+      next_song_handle_(1) {
+  if (cvars::enable_xmp) {
+    worker_running_ = true;
+    worker_thread_ = threading::Thread::Create({}, [&] { WorkerThreadMain(); });
+    worker_thread_->set_name("Music Player");
+  }
+}
+
+struct VFSContext {
+  xe::vfs::File* file;
+  size_t byte_offset;
+};
+
+static int xenia_vfs_read(void* opaque, uint8_t* buf, int buf_size) {
+  auto ctx = static_cast<VFSContext*>(opaque);
+
+  size_t bytes_read;
+  X_STATUS status =
+      ctx->file->ReadSync(buf, buf_size, ctx->byte_offset, &bytes_read);
+
+  if (XFAILED(status)) {
+    return status == X_STATUS_END_OF_FILE ? AVERROR_EOF : status;
+  }
+
+  ctx->byte_offset += bytes_read;
+  return static_cast<int>(bytes_read);
+}
+
+bool XmpApp::PlayFile(std::string_view filename) {
+  auto playlist = active_playlist_;
+
+  const int buffer_size = 8192;
+  uint8_t* buffer = reinterpret_cast<uint8_t*>(av_malloc(buffer_size));
+  VFSContext vfs_ctx = {};
+
+  xe::vfs::FileAction file_action;
+  X_STATUS status = kernel_state_->file_system()->OpenFile(
+      nullptr, filename, xe::vfs::FileDisposition::kOpen,
+      xe::vfs::FileAccess::kGenericRead, false, true, &vfs_ctx.file,
+      &file_action);
+  if (XFAILED(status)) {
+    XELOGE("Opening {} failed with status {:X}", filename, status);
+    return false;
+  }
+
+  AVIOContext* avio_ctx = avio_alloc_context(buffer, buffer_size, 0, &vfs_ctx,
+                                             xenia_vfs_read, nullptr, nullptr);
+
+  AVFormatContext* formatContext = avformat_alloc_context();
+  formatContext->pb = avio_ctx;
+  int ret;
+  if ((ret = avformat_open_input(&formatContext, nullptr, nullptr, nullptr)) !=
+      0) {
+    XELOGE("ffmpeg: Could not open WMA file: {:x}", ret);
+    av_freep(&avio_ctx->buffer);
+    avio_context_free(&avio_ctx);
+    return false;
+  }
+
+  if (avformat_find_stream_info(formatContext, nullptr) < 0) {
+    XELOGE("ffmpeg: Could not find stream info");
+    avformat_close_input(&formatContext);
+    av_freep(&avio_ctx->buffer);
+    avio_context_free(&avio_ctx);
+    return false;
+  }
+
+  AVCodec* codec = nullptr;
+  int streamIndex =
+      av_find_best_stream(formatContext, AVMEDIA_TYPE_AUDIO, -1, -1, &codec, 0);
+  if (streamIndex < 0) {
+    XELOGE("ffmpeg: Could not find audio stream");
+    avformat_close_input(&formatContext);
+    av_freep(&avio_ctx->buffer);
+    avio_context_free(&avio_ctx);
+    return false;
+  }
+
+  AVStream* audioStream = formatContext->streams[streamIndex];
+  AVCodecContext* codecContext = avcodec_alloc_context3(codec);
+  avcodec_parameters_to_context(codecContext, audioStream->codecpar);
+
+  if (audioStream->codecpar->format != AV_SAMPLE_FMT_FLTP &&
+      audioStream->codecpar->format != AV_SAMPLE_FMT_FLT) {
+    XELOGE("Audio stream has unexpected sample format {:d}",
+           audioStream->codecpar->format);
+    avcodec_free_context(&codecContext);
+    avformat_close_input(&formatContext);
+    av_freep(&avio_ctx->buffer);
+    avio_context_free(&avio_ctx);
+    return false;
+  }
+
+  if (avcodec_open2(codecContext, codec, nullptr) < 0) {
+    XELOGE("ffmpeg: Could not open codec");
+    avcodec_free_context(&codecContext);
+    avformat_close_input(&formatContext);
+    av_freep(&avio_ctx->buffer);
+    avio_context_free(&avio_ctx);
+    return false;
+  }
+
+  auto driverReady = xe::threading::Semaphore::Create(64, 64);
+  {
+    std::unique_lock<std::mutex> guard(driver_mutex_);
+    driver_ = kernel_state_->emulator()->audio_system()->CreateDriver(
+        driverReady.get(), codecContext->sample_rate, codecContext->channels,
+        false);
+    if (!driver_->Initialize()) {
+      XELOGE("Driver initialization failed!");
+      driver_->Shutdown();
+      driver_ = nullptr;
+      avcodec_free_context(&codecContext);
+      avformat_close_input(&formatContext);
+      av_freep(&avio_ctx->buffer);
+      avio_context_free(&avio_ctx);
+      return false;
+    }
+  }
+  if (volume_ == 0.0f) {
+    // Some games set volume to 0 on startup and then never call SetVolume
+    // again...
+    volume_ = cvars::xmp_default_volume / 100.0f;
+  }
+  driver_->SetVolume(volume_);
+
+  AVPacket* packet = av_packet_alloc();
+  AVFrame* frame = av_frame_alloc();
+  std::vector<float> frameBuffer;
+
+  // Read frames, decode & send to audio driver
+  while (av_read_frame(formatContext, packet) >= 0) {
+    if (active_playlist_ != playlist) {
+      frameBuffer.clear();
+      break;
+    }
+
+    if (packet->stream_index == streamIndex) {
+      int ret = avcodec_send_packet(codecContext, packet);
+      if (ret < 0) {
+        XELOGE("Error sending packet for decoding: {:X}", ret);
+        break;
+      }
+
+      while (ret >= 0) {
+        ret = avcodec_receive_frame(codecContext, frame);
+        if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) break;
+        if (ret < 0) {
+          XELOGW("Error during decoding: {:X}", ret);
+          break;
+        }
+
+        // If the frame is planar, convert it to interleaved
+        if (frame->format == AV_SAMPLE_FMT_FLTP) {
+          for (int sample = 0; sample < frame->nb_samples; sample++) {
+            for (int ch = 0; ch < codecContext->channels; ch++) {
+              float sampleValue =
+                  reinterpret_cast<float*>(frame->data[ch])[sample];
+              frameBuffer.push_back(sampleValue);
+            }
+          }
+        } else if (frame->format == AV_SAMPLE_FMT_FLT) {
+          int frameSizeFloats = frame->nb_samples * codecContext->channels;
+          float* frameData = reinterpret_cast<float*>(frame->data[0]);
+          frameBuffer.insert(frameBuffer.end(), frameData,
+                             frameData + frameSizeFloats);
+        }
+
+        while (frameBuffer.size() >= xe::apu::AudioDriver::kFrameSamplesMax) {
+          xe::threading::Wait(driverReady.get(), true);
+
+          if (active_playlist_ != playlist) {
+            frameBuffer.clear();
+            break;
+          }
+
+          driver_->SubmitFrame(frameBuffer.data());
+          frameBuffer.erase(
+              frameBuffer.begin(),
+              frameBuffer.begin() + xe::apu::AudioDriver::kFrameSamplesMax);
+        }
+      }
+    }
+    av_packet_unref(packet);
+  }
+
+  if (!frameBuffer.empty()) {
+    while (frameBuffer.size() < xe::apu::AudioDriver::kFrameSamplesMax) {
+      frameBuffer.push_back(0.0f);
+    }
+
+    xe::threading::Wait(driverReady.get(), true);
+    driver_->SubmitFrame(frameBuffer.data());
+  }
+
+  av_frame_free(&frame);
+  av_packet_free(&packet);
+  avcodec_free_context(&codecContext);
+  avformat_close_input(&formatContext);
+  av_freep(&avio_ctx->buffer);
+  avio_context_free(&avio_ctx);
+
+  {
+    std::unique_lock<std::mutex> guard(driver_mutex_);
+    driver_->Shutdown();
+    driver_ = nullptr;
+  }
+
+  if (state_ == State::kPlaying && active_playlist_ == playlist) {
+    active_playlist_ = nullptr;
+    state_ = State::kIdle;
+    OnStateChanged();
+  }
+
+  return true;
+}
+
+void XmpApp::WorkerThreadMain() {
+  while (worker_running_) {
+    if (state_ != State::kPlaying) {
+      resume_fence_.Wait();
+    }
+
+    auto playlist = active_playlist_;
+    if (!playlist) {
+      continue;
+    }
+
+    auto utf8_path = xe::path_to_utf8(playlist->songs[0].get()->file_path);
+    XELOGI("Playing file {}", utf8_path);
+
+    if (!PlayFile(utf8_path)) {
+      XELOGE("Playback failed");
+      xe::threading::Sleep(std::chrono::minutes(1));
+    }
+  }
+}
 
 X_HRESULT XmpApp::XMPGetStatus(uint32_t state_ptr) {
   if (!XThread::GetCurrentThread()->main_thread()) {
@@ -39,7 +296,7 @@ X_HRESULT XmpApp::XMPGetStatus(uint32_t state_ptr) {
     xe::threading::Sleep(std::chrono::milliseconds(1));
   }
 
-  XELOGD("XMPGetStatus({:08X})", state_ptr);
+  XELOGD("XMPGetStatus({:08X}) -> {:d}", state_ptr, (uint32_t)state_);
   xe::store_and_swap<uint32_t>(memory_->TranslateVirtual(state_ptr),
                                static_cast<uint32_t>(state_));
   return X_E_SUCCESS;
@@ -132,16 +389,10 @@ X_HRESULT XmpApp::XMPPlayTitlePlaylist(uint32_t playlist_handle,
     playlist = it->second;
   }
 
-  if (playback_client_ == PlaybackClient::kSystem) {
-    XELOGW("XMPPlayTitlePlaylist: System playback is enabled!");
-    return X_E_SUCCESS;
-  }
-
-  // Start playlist?
-  XELOGW("Playlist playback not supported");
   active_playlist_ = playlist;
   active_song_index_ = 0;
   state_ = State::kPlaying;
+  resume_fence_.Signal();
   OnStateChanged();
   kernel_state_->BroadcastNotification(kNotificationXmpPlaybackBehaviorChanged,
                                        1);
@@ -152,6 +403,11 @@ X_HRESULT XmpApp::XMPContinue() {
   XELOGD("XMPContinue()");
   if (state_ == State::kPaused) {
     state_ = State::kPlaying;
+    resume_fence_.Signal();
+    {
+      std::unique_lock<std::mutex> guard(driver_mutex_);
+      if (driver_ != nullptr) driver_->Resume();
+    }
   }
   OnStateChanged();
   return X_E_SUCCESS;
@@ -170,6 +426,10 @@ X_HRESULT XmpApp::XMPStop(uint32_t unk) {
 X_HRESULT XmpApp::XMPPause() {
   XELOGD("XMPPause()");
   if (state_ == State::kPlaying) {
+    {
+      std::unique_lock<std::mutex> guard(driver_mutex_);
+      if (driver_ != nullptr) driver_->Pause();
+    }
     state_ = State::kPaused;
   }
   OnStateChanged();
@@ -184,6 +444,7 @@ X_HRESULT XmpApp::XMPNext() {
   state_ = State::kPlaying;
   active_song_index_ =
       (active_song_index_ + 1) % active_playlist_->songs.size();
+  resume_fence_.Signal();
   OnStateChanged();
   return X_E_SUCCESS;
 }
@@ -199,6 +460,7 @@ X_HRESULT XmpApp::XMPPrevious() {
   } else {
     --active_song_index_;
   }
+  resume_fence_.Signal();
   OnStateChanged();
   return X_E_SUCCESS;
 }
@@ -309,6 +571,10 @@ X_HRESULT XmpApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
       assert_true(args->xmp_client == 0x00000002);
       XELOGD("XMPSetVolume({:g})", float(args->value));
       volume_ = args->value;
+      {
+        std::unique_lock<std::mutex> guard(driver_mutex_);
+        if (driver_ != nullptr) driver_->SetVolume(volume_);
+      }
       return X_E_SUCCESS;
     }
     case 0x0007000D: {

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_audio.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_audio.cc
@@ -96,8 +96,9 @@ dword_result_t XAudioSubmitRenderDriverFrame_entry(lpunknown_t driver_ptr,
   assert_true((driver_ptr.guest_address() & 0xFFFF0000) == 0x41550000);
 
   auto audio_system = kernel_state()->emulator()->audio_system();
-  audio_system->SubmitFrame(driver_ptr.guest_address() & 0x0000FFFF,
-                            samples_ptr);
+  auto samples =
+      kernel_state()->memory()->TranslateVirtual<float*>(samples_ptr);
+  audio_system->SubmitFrame(driver_ptr.guest_address() & 0x0000FFFF, samples);
 
   return X_ERROR_SUCCESS;
 }


### PR DESCRIPTION
Hi!

I was annoyed by not having music in Burnout Revenge so I implemented it. To do so I also had to make some changes to the audio subsystem because it was quite opinionated about what sort of data it consumed.

TODOs:
- [x] **https://github.com/xenia-canary/FFmpeg_radixsplit/pull/1 must be merged for this branch to build**
- [ ] Multi song playlists? Are there games that use more than one track per playlist?
- [ ] Lifecycle management for the worker thread? Does `XmpApp` ever get destroyed or recreated?
- [x] Config option to disable playback
- [ ] Test more games utilizing XMP

I noticed two problems with Burnout, both seem to be unrelated to my changes:
1) There's an assert that always triggers in XMA code after a race, right when the game switches to the saving screen. Also happens on the main branch. In Release mode, it manifests itself by a bunch of log messages like this:
```
!> 0100001C ffmpeg: XMA Frame sizing incorrent:
   s->buf_bit_size != (8 + padding_start + xma_frame_len + padding_end)
=> 19408 != 8 + (1 + 32767 + 1)
!> 0100001C XmaContext 18: Error sending packet for decoding
```
Happens a couple dozen times but XMA is fine after that.

2) After 1-2 XMP tracks it'll often attempt to play a bogus playlist handle and playback will stop. Honestly this almost looks like some sort of memory corruption in the game:
```
d> F8000008 XMPPlayTitlePlaylist(6C53656C, 00000000)
!> F8000008 Playlist 6C53656C not found
```
In this particular case, looks as if the handle got replaced by random ASCII data. I ran Xenia with ASan compiled in and nothing turned up, so it must be something internal to the game or how the game and emulator interact. It only seems to be a problem when there's "more" going on, like doing a race. In the EA Trax menu it's never an issue.

