### PR TITLE
[GPU] Custom resolution

### DIFF
--- a/src/xenia/gpu/graphics_system.cc
+++ b/src/xenia/gpu/graphics_system.cc
@@ -23,6 +23,7 @@
 #include "xenia/base/math.h"
 #include "xenia/base/profiling.h"
 #include "xenia/base/threading.h"
+#include "xenia/config.h"
 #include "xenia/gpu/command_processor.h"
 #include "xenia/gpu/gpu_flags.h"
 #include "xenia/kernel/kernel_state.h"
@@ -33,6 +34,8 @@
 DEFINE_uint32(internal_display_resolution, 8,
               "Allow games that support different resolutions to render "
               "in a specific resolution.\n"
+              "This is not guaranteed to work with all games or improve "
+              "performance."
               "   0=640x480\n"
               "   1=640x576\n"
               "   2=720x480\n"
@@ -49,7 +52,14 @@ DEFINE_uint32(internal_display_resolution, 8,
               "   13=1440x900\n"
               "   14=1680x1050\n"
               "   15=1920x540\n"
-              "   16=1920x1080\n",
+              "   16=1920x1080\n"
+              "   17=internal_display_resolution_x/y",
+              "Video");
+DEFINE_uint32(internal_display_resolution_x, 1280,
+              "Custom width. See internal_display_resolution. Range 1-1920.",
+              "Video");
+DEFINE_uint32(internal_display_resolution_y, 720,
+              "Custom height. See internal_display_resolution. Range 1-1080.\n",
               "Video");
 
 DEFINE_bool(
@@ -92,6 +102,21 @@ X_STATUS GraphicsSystem::Setup(cpu::Processor* processor,
 
   scaled_aspect_x_ = 16;
   scaled_aspect_y_ = 9;
+
+  auto custom_res_x = cvars::internal_display_resolution_x;
+  auto custom_res_y = cvars::internal_display_resolution_y;
+  if (!custom_res_x || custom_res_x > 1920 || !custom_res_y ||
+      custom_res_y > 1080) {
+    OVERRIDE_uint32(internal_display_resolution_x,
+                    internal_display_resolution_entries[8].first);
+    OVERRIDE_uint32(internal_display_resolution_y,
+                    internal_display_resolution_entries[8].second);
+    config::SaveConfig();
+    xe::FatalError(fmt::format(
+        "Invalid custom resolution specified: {}x{}\n"
+        "Width must be between 1-1920.\nHeight must be between 1-1080.",
+        custom_res_x, custom_res_y));
+  }
 
   if (provider_) {
     // Safe if either the UI thread call or the presenter creation fails.
@@ -408,7 +433,8 @@ bool GraphicsSystem::Restore(ByteStream* stream) {
 std::pair<uint16_t, uint16_t> GraphicsSystem::GetInternalDisplayResolution() {
   if (cvars::internal_display_resolution >=
       internal_display_resolution_entries.size()) {
-    return internal_display_resolution_entries[8];
+    return {cvars::internal_display_resolution_x,
+            cvars::internal_display_resolution_y};
   }
   return internal_display_resolution_entries
       [cvars::internal_display_resolution];


### PR DESCRIPTION
# *This is NOT resolution scaling like `resolution_scale_x/y`*

This is the same as the resolution option in the dashboard:
![](https://i.ytimg.com/vi/emAG3rLtcLk/maxresdefault.jpg)

This lets you set the resolution in the config and use a single patch instead of needing multiple patches for each resolution.

Most if not all games will need a patch to work with custom resolutions.

Minecraft:
  * 1280x800:
  ![584111F7 - 2024-10-19T03-08-55](https://github.com/user-attachments/assets/d336d7f0-2331-44bd-abf3-f2deeeee656c)
  * 1720x720 (half of 3440x1440) with 2x resolution scaling:
  ![584111F7 - 2024-10-19T03-10-31](https://github.com/user-attachments/assets/acd70175-1a7b-45fc-888f-2e5e80dadd67)
