### PR TITLE
[MISC] Bump DXGI to 1.6

### DIFF
--- a/src/xenia/ui/d3d12/d3d12_api.h
+++ b/src/xenia/ui/d3d12/d3d12_api.h
@@ -17,7 +17,7 @@
 #include <d3d12.h>
 #include <d3d12sdklayers.h>
 #include <d3dcompiler.h>
-#include <dxgi1_5.h>
+#include <dxgi1_6.h>
 #include <dxgidebug.h>
 // For Microsoft::WRL::ComPtr.
 #include <wrl/client.h>


### PR DESCRIPTION
I have bumped the **DXGI** version from **2017 (1.5)** to **2018 (1.6 latest)**.