### PR TITLE
Revert "[XAM] Fixed possible crash caused by printing invalid charact…

### DIFF
--- a/src/xenia/kernel/xam/achievement_manager.cc
+++ b/src/xenia/kernel/xam/achievement_manager.cc
@@ -32,7 +32,6 @@ namespace xam {
 
 AchievementManager::AchievementManager() {
   default_achievements_backend_ = std::make_unique<GpdAchievementBackend>();
-
   // Add any optional backend here.
 };
 void AchievementManager::EarnAchievement(const uint32_t user_index,


### PR DESCRIPTION
…ers in XamUserGetGamerTag and XamUserGetName"

This reverts commit fe85be88176373742e21d94325d44aadb07fc8a0.