### PR TITLE
[XboxKrnl/xconfig.cc] - Fixes and logging changes

### DIFF
--- a/src/xenia/gpu/graphics_system.cc
+++ b/src/xenia/gpu/graphics_system.cc
@@ -35,7 +35,7 @@ DEFINE_uint32(internal_display_resolution, 8,
               "Allow games that support different resolutions to render "
               "in a specific resolution.\n"
               "This is not guaranteed to work with all games or improve "
-              "performance."
+              "performance.\n"
               "   0=640x480\n"
               "   1=640x576\n"
               "   2=720x480\n"

--- a/src/xenia/kernel/xam/user_profile.cc
+++ b/src/xenia/kernel/xam/user_profile.cc
@@ -170,7 +170,8 @@ void UserProfile::LoadSetting(UserSetting* setting) {
   } else {
     // Unsupported for now.  Other settings aren't per-game and need to be
     // stored some other way.
-    XELOGW("Attempting to load unsupported profile setting from disk");
+    XELOGW("Attempting to load unsupported profile setting 0x{:08X} from disk",
+           setting->GetSettingId());
   }
 }
 
@@ -204,7 +205,8 @@ void UserProfile::SaveSetting(UserSetting* setting) {
   } else {
     // Unsupported for now.  Other settings aren't per-game and need to be
     // stored some other way.
-    XELOGW("Attempting to save unsupported profile setting to disk");
+    XELOGW("Attempting to save unsupported profile setting 0x{:08X} from disk",
+           setting->GetSettingId());
   }
 }
 

--- a/src/xenia/kernel/xam/xam_ui.cc
+++ b/src/xenia/kernel/xam/xam_ui.cc
@@ -1255,6 +1255,8 @@ DECLARE_XAM_EXPORT1(XamShowCommunitySessionsUI, kNone, kStub);
 dword_result_t XamSetDashContext_entry(dword_t value,
                                        const ppc_context_t& ctx) {
   ctx->kernel_state->dash_context_ = value;
+  kernel_state()->BroadcastNotification(
+      kXNotificationDvdDriveUnknownDashContext, 0);
   return 0;
 }
 

--- a/src/xenia/xbox.h
+++ b/src/xenia/xbox.h
@@ -272,13 +272,6 @@ constexpr uint8_t XUserIndexAny = 0xFF;
 // https://github.com/ThirteenAG/Ultimate-ASI-Loader/blob/master/source/xlive/xliveless.h
 typedef uint32_t XNotificationID;
 enum : XNotificationID {
-  /* Notes:
-      - kXNotificationSystemUnknown, kXNotificationLiveUnknown,
-     kXNotificationCustomGamercard, kXNotificationDvdDriveUnknown,
-     kXNotificationXmpUnknown, kXNotificationFriendsUnknown, and
-     kXNotificationMsgrUnknown are all called together by XNotifyBroadcast
-  */
-
   // Notification Areas
   kXNotifySystem = 0x00000001,
   kXNotifyLive = 0x00000002,
@@ -333,6 +326,7 @@ enum : XNotificationID {
 
   // XNotification Dvd ?
   kXNotificationDvdDriveUnknown = 0x80000003,
+  kXNotificationDvdDriveUnknownDashContext = 0x8000000C,
   kXNotificationDvdDriveTrayStateChanged = 0x8000000D,
 
   // XNotification XMP (13 total)


### PR DESCRIPTION
- Adding more information in logs for easier debugging
- XamSetDashContext correction
- XCONFIG_USER_VIDEO_FLAGS reports widescreen when set in config by user
- XCONFIG_SECURED_AV_REGION reports proper values when set in config by user
- Added missing \n