### PR TITLE
[CPU/x64_sequences] - Fix MAX_V128

### DIFF
--- a/src/xenia/cpu/backend/x64/x64_sequences.cc
+++ b/src/xenia/cpu/backend/x64/x64_sequences.cc
@@ -570,7 +570,7 @@ struct MAX_V128 : Sequence<MAX_V128, I<OPCODE_MAX, V128Op, V128Op, V128Op>> {
     auto src2 = GetInputRegOrConstant(e, i.src2, e.xmm1);
     e.vmaxps(e.xmm2, src1, src2);
     e.vmaxps(e.xmm3, src2, src1);
-    e.vandps(i.dest, e.xmm2, e.xmm3);
+    e.vorps(i.dest, e.xmm2, e.xmm3);
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_MAX, MAX_F32, MAX_F64, MAX_V128);


### PR DESCRIPTION
- change e.vandps to e.vorps to ensure NaN instructions matches real hardware based on changes suggested in issue 405. thank [EmiGITs](https://github.com/EmiGITs)
- More testing is needed to see what else it affects
Improvements:
1.  Stops goalkeeper disappearing in FIFA 10