### PR TITLE
Fix the nullptr case in `XexInfoCache::Init`.

### DIFF
--- a/src/xenia/cpu/xex_module.cc
+++ b/src/xenia/cpu/xex_module.cc
@@ -1397,6 +1397,10 @@ void XexInfoCache::Init(XexModule* xexmod) {
   };
 
   bool did_exist = try_open();
+  if (!GetHeader()) {
+    return;
+  }
+
   if (!did_exist) {
     GetHeader()->version = CURRENT_INFOCACHE_VERSION;
 


### PR DESCRIPTION
In some specific cases, this `if` statement can cause a `nullptr` error due to a file read error, such as `0xC0000043` (*A file cannot be opened because the share access flags are incompatible*).  

Below is the scenario where this issue occurs:  
![image](https://github.com/user-attachments/assets/6276652d-7bff-4909-aa5e-b32d809495fd)  

I discovered this code by using a disassembler with the memory offset:  
![image](https://github.com/user-attachments/assets/ec55d784-0452-4bf1-9906-c8180ee471be)  
![image](https://github.com/user-attachments/assets/157bf789-f4d3-4453-961b-b984cc60f918)  

I'm not entirely sure if this is the best way to fix this issue, but my friend has encountered it over 10 times.  

**Special thanks to the review developers for their hard work and dedication! 🙌 Your efforts in debugging and improving the code are greatly appreciated! 🚀**  