### PR TITLE
[XB] Build scripts directory and binary search logic correction

### DIFF
--- a/tools/build/helpers.py
+++ b/tools/build/helpers.py
@@ -1,0 +1,36 @@
+import os
+
+
+def is_executable(path) -> bool:
+    return os.path.isfile(path) and os.access(path, os.X_OK)
+
+
+def get_bin(binary):
+    """Checks whether the given binary is present and returns the path.
+
+    Args:
+      binary: binary name (without .exe, etc).
+
+    Returns:
+      Full path to the binary or None if not found.
+    """
+    for path in os.environ['PATH'].split(os.pathsep):
+        path = path.strip('"')
+        exe_file = os.path.join(path, binary)
+        if is_executable(exe_file):
+            return exe_file
+        if is_executable(exe_file + '.exe'):
+            return exe_file + '.exe'
+    return None
+
+
+def has_bin(binary):
+    """Checks whether the given binary is present in the PATH.
+
+    Args:
+      binary: binary name (without .exe, etc).
+
+    Returns:
+      True if the binary exists.
+    """
+    return get_bin(binary) is not None

--- a/tools/build/premake.py
+++ b/tools/build/premake.py
@@ -52,7 +52,7 @@ setup_premake_path_override()
 
 
 def main():
-    premake_bin_name = "premake5.exe" if sys.platform is "win32" else "premake 5"
+    premake_bin_name = "premake5.exe" if sys.platform is "win32" else "premake5"
     premake_build_bin = os.path.join(premake_path, "bin", "release", premake_bin_name)
     premake_local_bin = os.path.join(self_path, "bin", premake_bin_name)
     premake5_bin = None

--- a/tools/build/premake.py
+++ b/tools/build/premake.py
@@ -52,7 +52,7 @@ setup_premake_path_override()
 
 
 def main():
-    premake_bin_name = "premake5.exe" if sys.platform is "win32" else "premake5"
+    premake_bin_name = "premake5.exe" if sys.platform == "win32" else "premake5"
     premake_build_bin = os.path.join(premake_path, "bin", "release", premake_bin_name)
     premake_local_bin = os.path.join(self_path, "bin", premake_bin_name)
     premake5_bin = None

--- a/tools/build/premake.py
+++ b/tools/build/premake.py
@@ -13,10 +13,12 @@ import os
 from shutil import rmtree
 import subprocess
 import sys
+import pathlib
+from helpers import is_executable, get_bin, has_bin
 
 
 self_path = os.path.dirname(os.path.abspath(__file__))
-root_path = os.path.join(self_path, "..", "..")
+root_path = pathlib.Path(self_path).parent.parent.absolute()
 premake_submodule_path = os.path.join(root_path, "third_party", "premake-core")
 premake_path = premake_submodule_path
 
@@ -41,8 +43,8 @@ def setup_premake_path_override():
             if popen.communicate()[0] == "Android\n":
                 xb_file = os.path.join(root_path, "xenia-build.py")
                 if (os.path.isfile(xb_file) and not os.access(xb_file, os.X_OK) and
-                    "HOME" in os.environ):
-                  premake_path = os.path.join(os.environ["HOME"], ".xenia-build", "premake-core")
+                      "HOME" in os.environ):
+                    premake_path = os.path.join(os.environ["HOME"], ".xenia-build", "premake-core")
         except Exception:
             pass
 
@@ -50,29 +52,33 @@ setup_premake_path_override()
 
 
 def main():
-    # First try the freshly-built premake.
-    premake5_bin = os.path.join(premake_path, "bin", "release", "premake5")
-    if not has_bin(premake5_bin):
-        # No fresh build, so fallback to checked in copy (which we may not have).
-        premake5_bin = os.path.join(self_path, "bin", "premake5")
-    if not has_bin(premake5_bin):
-        # Still no valid binary, so build it.
+    premake_bin_name = "premake5.exe" if sys.platform is "win32" else "premake 5"
+    premake_build_bin = os.path.join(premake_path, "bin", "release", premake_bin_name)
+    premake_local_bin = os.path.join(self_path, "bin", premake_bin_name)
+    premake5_bin = None
+    # First check if premake is available at the system level
+    if has_bin('premake5'):
+        premake5_bin = get_bin("premake5")
+        print("using the installed version of premake")
+    # Next try the freshly-built premake.
+    elif is_executable(premake_build_bin):
+        premake5_bin = premake_build_bin
+        print("using local build of premake")
+    # No fresh build, so fallback to checked in copy (which we may not have).
+    elif is_executable(premake_local_bin):
+        premake5_bin = premake_local_bin
+        print("using the local prebuilt premake")
+    # Still no valid binary, so build it.
+    else:
         print("premake5 executable not found, attempting build...")
         build_premake()
-        premake5_bin = os.path.join(premake_path, "bin", "release", "premake5")
-    if not has_bin(premake5_bin):
-        # Nope, boned.
-        print("ERROR: cannot build premake5 executable.")
-        sys.exit(1)
-
-    # Ensure the submodule has been checked out.
-    if not os.path.exists(os.path.join(premake_path, "scripts", "package.lua")):
-        print("third_party/premake-core was not present; run xb setup...")
-        sys.exit(1)
-
-    if sys.platform == "win32":
-        # Append the executable extension on windows.
-        premake5_bin += ".exe"
+        if is_executable(premake_build_bin):
+            premake5_bin = premake_build_bin
+            print("using local build of premake")
+        else:
+            # Nope, boned.
+            print("ERROR: cannot build premake5 executable.")
+            sys.exit(1)
 
     return_code = shell_call([
         premake5_bin,
@@ -86,6 +92,12 @@ def main():
 def build_premake():
     """Builds premake from source.
     """
+    # Ensure the submodule has been checked out.
+    if not os.path.exists(os.path.join(premake_path, "scripts", "package.lua")):
+      print("third_party/premake-core was not present; run xb setup...")
+      sys.exit(1)
+      return
+  
     # Ensure that on Android, premake-core is in the internal storage.
     clone_premake_to_internal_storage()
     cwd = os.getcwd()
@@ -146,22 +158,6 @@ def clone_premake_to_internal_storage():
       premake_submodule_path,
       premake_path,
       ])
-
-
-def has_bin(bin):
-    """Checks whether the given binary is present.
-    """
-    for path in os.environ["PATH"].split(os.pathsep):
-        if sys.platform == "win32":
-            exe_file = os.path.join(path, f"{bin}.exe")
-            if os.path.isfile(exe_file) and os.access(exe_file, os.X_OK):
-                return True
-        else:
-            path = path.strip("\"")
-            exe_file = os.path.join(path, bin)
-            if os.path.isfile(exe_file) and os.access(exe_file, os.X_OK):
-                return True
-    return None
 
 
 def shell_call(command, throw_on_error=True, stdout_path=None, stderr_path=None, shell=False):

--- a/xenia-build.py
+++ b/xenia-build.py
@@ -17,6 +17,7 @@ from shutil import rmtree
 import subprocess
 import sys
 import stat
+from tools.build.helpers import has_bin, get_bin
 
 __author__ = "ben.vanik@gmail.com (Ben Vanik)"
 
@@ -205,42 +206,6 @@ def print_box(msg):
         "│{1: ^{2}}║\n"
         "╘{0:═^{2}}╝\n"
         .format("", msg, len(msg) + 2))
-
-
-def has_bin(binary):
-    """Checks whether the given binary is present.
-
-    Args:
-      binary: binary name (without .exe, etc).
-
-    Returns:
-      True if the binary exists.
-    """
-    bin_path = get_bin(binary)
-    if not bin_path:
-        return False
-    return True
-
-
-def get_bin(binary):
-    """Checks whether the given binary is present and returns the path.
-
-    Args:
-      binary: binary name (without .exe, etc).
-
-    Returns:
-      Full path to the binary or None if not found.
-    """
-    for path in os.environ["PATH"].split(os.pathsep):
-        path = path.strip("\"")
-        exe_file = os.path.join(path, binary)
-        if os.path.isfile(exe_file) and os.access(exe_file, os.X_OK):
-            return exe_file
-        exe_file += ".exe"
-        if os.path.isfile(exe_file) and os.access(exe_file, os.X_OK):
-            return exe_file
-    return None
-
 
 def shell_call(command, throw_on_error=True, stdout_path=None, stderr_path=None, shell=False):
     """Executes a shell command.


### PR DESCRIPTION
This PR corrects some erroneous logic in the python build scripts and consolidates some common functionality into reusable modules.

Changes include:
- Changing the premake binary search to actually check the local directories. Previously it was concatenating the PATH variable and searching for the local directory + each folder in the PATH.
- Consolidate the has_bin and get_bin functions into a reusable file so that they behave consistently across different files
- Correct the root path resolution. Previously the root path was resolving with the "../.." as a literal string in the path. After this change it will look for the parent of the parent folder like it was originally intended to.
- General refactoring to make the scripts' intent more obvious and easier to follow.