### PR TITLE
[linux_platform] Implement a bunch of missing functions necessaries to make Xenia build correctly under Linux

### DIFF
--- a/src/xenia/base/clock_posix.cc
+++ b/src/xenia/base/clock_posix.cc
@@ -53,4 +53,5 @@ uint64_t Clock::QueryHostUptimeMillis() {
   return host_tick_count_platform() * 1000 / host_tick_frequency_platform();
 }
 
+uint64_t Clock::QueryHostInterruptTime() { return host_tick_count_platform(); }
 }  // namespace xe

--- a/src/xenia/base/filesystem.cc
+++ b/src/xenia/base/filesystem.cc
@@ -24,5 +24,29 @@ bool CreateParentFolder(const std::filesystem::path& path) {
   return true;
 }
 
+std::vector<FileInfo> ListDirectories(const std::filesystem::path& path) {
+  std::vector<FileInfo> files = ListFiles(path);
+  std::vector<FileInfo> directories = {};
+
+  std::copy_if(files.cbegin(), files.cend(), std::back_inserter(directories),
+               [](const FileInfo& file) {
+                 return file.type == FileInfo::Type::kDirectory;
+               });
+
+  return std::move(directories);
+}
+
+std::vector<FileInfo> FilterByName(const std::vector<FileInfo>& files,
+                                   const std::regex pattern) {
+  std::vector<FileInfo> filtered_entries = {};
+
+  std::copy_if(
+      files.cbegin(), files.cend(), std::back_inserter(filtered_entries),
+      [pattern](const FileInfo& file) {
+        return std::regex_match(file.name.filename().string(), pattern);
+      });
+  return std::move(filtered_entries);
+}
+
 }  // namespace filesystem
 }  // namespace xe

--- a/src/xenia/base/filesystem_win.cc
+++ b/src/xenia/base/filesystem_win.cc
@@ -263,30 +263,6 @@ std::vector<FileInfo> ListFiles(const std::filesystem::path& path) {
   return result;
 }
 
-std::vector<FileInfo> ListDirectories(const std::filesystem::path& path) {
-  std::vector<FileInfo> files = ListFiles(path);
-  std::vector<FileInfo> directories = {};
-
-  std::copy_if(
-      files.cbegin(), files.cend(), std::back_inserter(directories),
-      [](FileInfo file) { return file.type == FileInfo::Type::kDirectory; });
-
-  return directories;
-}
-
-std::vector<FileInfo> FilterByName(const std::vector<FileInfo>& files,
-                                   const std::regex pattern) {
-  std::vector<FileInfo> filtered_entries = {};
-
-  std::copy_if(files.cbegin(), files.cend(),
-               std::back_inserter(filtered_entries), [pattern](FileInfo file) {
-                 return std::regex_match(file.name.filename().string(),
-                                         pattern);
-               });
-
-  return filtered_entries;
-}
-
 bool SetAttributes(const std::filesystem::path& path, uint64_t attributes) {
   return SetFileAttributes(path.c_str(), static_cast<DWORD>(attributes));
 }

--- a/src/xenia/base/main_init_posix.cc
+++ b/src/xenia/base/main_init_posix.cc
@@ -1,0 +1,46 @@
+/**
+******************************************************************************
+* Xenia : Xbox 360 Emulator Research Project                                 *
+******************************************************************************
+* Copyright 2023 Ben Vanik. All rights reserved.                             *
+* Released under the BSD license - see LICENSE in the root for more details. *
+******************************************************************************
+*/
+#include <gdk/gdk.h>
+#include <gtk/gtk.h>
+#include <xbyak/xbyak/xbyak_util.h>
+
+#include "xenia/ui/window_gtk.h"
+
+class StartupCpuFeatureCheck {
+ public:
+  StartupCpuFeatureCheck() {
+    Xbyak::util::Cpu cpu;
+    const char* error_message = nullptr;
+    if (!cpu.has(Xbyak::util::Cpu::tAVX)) {
+      error_message =
+          "Your CPU does not support AVX, which is required by Xenia. See "
+          "the "
+          "FAQ for system requirements at https://xenia.jp";
+    }
+    if (error_message == nullptr) {
+      return;
+    } else {
+      GtkDialogFlags flags = GTK_DIALOG_DESTROY_WITH_PARENT;
+      auto dialog =
+          gtk_message_dialog_new(nullptr, flags, GTK_MESSAGE_ERROR,
+                                 GTK_BUTTONS_CLOSE, "%s", error_message);
+      gtk_dialog_run(GTK_DIALOG(dialog));
+      gtk_widget_destroy(dialog);
+      exit(1);
+    }
+  }
+};
+
+// This is a hack to get an instance of StartupAvxCheck
+// constructed before any initialization code,
+// where the AVX check then happens in the constructor.
+// Ref:
+// https://reviews.llvm.org/D12689#243295
+__attribute__((
+    init_priority(101))) static StartupCpuFeatureCheck gStartupAvxCheck;

--- a/src/xenia/ui/premake5.lua
+++ b/src/xenia/ui/premake5.lua
@@ -28,3 +28,10 @@ project("xenia-ui")
       "dxgi",
       "winmm",
     })
+
+  filter("platforms:Linux")
+    links({
+      "xcb",
+      "X11",
+      "X11-xcb"
+    })


### PR DESCRIPTION
With this part fixed and a function re adapted from the original codebase to fix the different signature, we should have a compiling Linux build now.

A lot of threading_posix.cc has been cleaned up as recommended from clang-lint since I had some issues stemming from missing implementation on destructor and properly overridden destructor classes causing pthread_kill causing double exceptions and killing the process as a result.