### PR TITLE
[threading] Linux fixes on setting an incorrect priority

### DIFF
--- a/src/xenia/base/threading.h
+++ b/src/xenia/base/threading.h
@@ -402,6 +402,7 @@ class Timer : public WaitHandle {
   virtual bool Cancel() = 0;
 };
 
+#if XE_PLATFORM_WINDOWS
 struct ThreadPriority {
   static const int32_t kLowest = -2;
   static const int32_t kBelowNormal = -1;
@@ -409,6 +410,15 @@ struct ThreadPriority {
   static const int32_t kAboveNormal = 1;
   static const int32_t kHighest = 2;
 };
+#else
+struct ThreadPriority {
+  static const int32_t kLowest = 1;
+  static const int32_t kBelowNormal = 8;
+  static const int32_t kNormal = 16;
+  static const int32_t kAboveNormal = 24;
+  static const int32_t kHighest = 32;
+};
+#endif
 
 // Models a Win32-like thread object.
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms682453(v=vs.85).aspx


### PR DESCRIPTION
This call was failing since SCHED_FIFO doesn't support negative priorities, but only positive ones, see third paragraph of scheduling policies: https://man7.org/linux/man-pages/man7/sched.7.html.

Quote:
```
Processes scheduled under one of the real-time policies
(SCHED_FIFO, SCHED_RR) have a sched_priority value in the range 1
(low) to 99 (high).  (As the numbers imply, real-time threads
always have higher priority than normal threads.)  Note well:
POSIX.1 requires an implementation to support only a minimum 32
distinct priority levels for the real-time policies, and some
systems supply just this minimum.  Portable programs should use
[sched_get_priority_min(2)](https://man7.org/linux/man-pages/man2/sched_get_priority_min.2.html) and [sched_get_priority_max(2)](https://man7.org/linux/man-pages/man2/sched_get_priority_max.2.html) to find
the range of priorities supported for a particular policy.
```

Additionally Linux do provide up to 99 levels, but I've limited myself to the required UNIX standard of 32, and split the priority levels evenly from that.

I've also added a couple of rows to debug additional issues in the future like this.