### PR TITLE
[CPU/LINUX] A fix for the release build crash on Linux.

### DIFF
--- a/src/xenia/cpu/backend/x64/x64_backend.cc
+++ b/src/xenia/cpu/backend/x64/x64_backend.cc
@@ -685,9 +685,6 @@ HostToGuestThunk X64HelperEmitter::EmitHostToGuestThunk() {
 
   code_offsets.prolog = getSize();
   // rsp + 0 = return address
-  mov(qword[rsp + 8 * 3], rdx);
-  mov(qword[rsp + 8 * 2], rsi);
-  mov(qword[rsp + 8 * 1], rdi);
   sub(rsp, stack_size);
 
   code_offsets.prolog_stack_alloc = getSize();
@@ -707,9 +704,6 @@ HostToGuestThunk X64HelperEmitter::EmitHostToGuestThunk() {
   code_offsets.epilog = getSize();
 
   add(rsp, stack_size);
-  mov(rdi, qword[rsp + 8 * 1]);
-  mov(rsi, qword[rsp + 8 * 2]);
-  mov(rdx, qword[rsp + 8 * 3]);
   ret();
 #else
   assert_always("Unknown platform ABI in host to guest thunk!");


### PR DESCRIPTION
The Linux release build crashes due to improper writing to the stack, which is not an issue in the Debug build since it has extra stack space. This commit fixes the problem.