### PR TITLE
[main ui] Properly handle XDG format specifications for Linux systems

### DIFF
--- a/src/xenia/app/xenia_main.cc
+++ b/src/xenia/app/xenia_main.cc
@@ -95,9 +95,15 @@ UPDATE_from_bool(mount_cache, 2024, 8, 31, 20, false);
 DEFINE_transient_path(target, "",
                       "Specifies the target .xex or .iso to execute.",
                       "General");
+#ifndef XE_PLATFORM_WIN32
+DEFINE_transient_bool(portable, false,
+                      "Specifies if Xenia should run in portable mode.",
+                      "General");
+#else
 DEFINE_transient_bool(portable, true,
                       "Specifies if Xenia should run in portable mode.",
                       "General");
+#endif
 
 DECLARE_bool(debug);
 
@@ -421,7 +427,7 @@ bool EmulatorApp::OnInitialize() {
     if (!cvars::portable &&
         !std::filesystem::exists(storage_root / "portable.txt")) {
       storage_root = xe::filesystem::GetUserFolder();
-#if defined(XE_PLATFORM_WIN32) || defined(XE_PLATFORM_GNU_LINUX)
+#if defined(XE_PLATFORM_WIN32) || defined(XE_PLATFORM_LINUX)
       storage_root = storage_root / "Xenia";
 #else
       // TODO(Triang3l): Point to the app's external storage "files" directory


### PR DESCRIPTION
This fixes the issue where the emulator was writing to the root directory instead of the standard XDG format folders (which is typically $HOME/.local/share/).