### PR TITLE
[Patcher] Ensure hash is checked when loading title plugins

### DIFF
--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -1526,7 +1526,8 @@ X_STATUS Emulator::CompleteLaunch(const std::filesystem::path& path,
   if (cvars::allow_plugins) {
     if (plugin_loader_->IsAnyPluginForTitleAvailable(title_id_.value(),
                                                      module->hash().value())) {
-      plugin_loader_->LoadTitlePlugins(title_id_.value());
+      plugin_loader_->LoadTitlePlugins(title_id_.value(),
+                                       module->hash().value());
     }
   }
 

--- a/src/xenia/patcher/plugin_loader.cc
+++ b/src/xenia/patcher/plugin_loader.cc
@@ -174,13 +174,18 @@ bool PluginLoader::IsAnyPluginForTitleAvailable(
   return result != plugin_configs_.cend();
 }
 
-void PluginLoader::LoadTitlePlugins(const uint32_t title_id) {
+void PluginLoader::LoadTitlePlugins(const uint32_t title_id,
+                                    const uint64_t module_hash) {
   std::vector<PluginInfoEntry> title_plugins;
 
   std::copy_if(plugin_configs_.cbegin(), plugin_configs_.cend(),
                std::back_inserter(title_plugins),
-               [title_id](const PluginInfoEntry& entry) {
-                 return entry.is_enabled && entry.title_id == title_id;
+               [title_id, module_hash](const PluginInfoEntry& entry) {
+                 const auto hash_exists =
+                     std::find(entry.hashes.cbegin(), entry.hashes.cend(),
+                               module_hash) != entry.hashes.cend();
+                 return entry.is_enabled && entry.title_id == title_id &&
+                        hash_exists;
                });
 
   if (title_plugins.empty()) {

--- a/src/xenia/patcher/plugin_loader.h
+++ b/src/xenia/patcher/plugin_loader.h
@@ -31,7 +31,7 @@ class PluginLoader {
   PluginLoader(kernel::KernelState* kernel_state,
                const std::filesystem::path plugins_root);
 
-  void LoadTitlePlugins(const uint32_t title_id);
+  void LoadTitlePlugins(const uint32_t title_id, const uint64_t module_hash);
   bool IsAnyPluginForTitleAvailable(const uint32_t title_id,
                                     const uint64_t module_hash) const;
   bool IsAnyPluginLoaded() { return is_any_plugin_loaded_; }


### PR DESCRIPTION
Fixes bug where plugin loader would load all defined plugins if at least one was valid.

Reproducing the bug, using the `plugins.toml` below Xenia will load both plugins even though they have different hashes defined.

```toml
title_name = "Call of Duty: Modern Warfare 3"
title_id = "415608CB"                         # AV-2071
#media_id = "2C8C0267" # Disc (USA, Europe): http://redump.org/disc/37074

# TU24

[[plugin]]
author = "mo"
name = "iw5-xenon"
file = "iw5-xenon.xex"
hash = "3AC94A2E70D1FECB" # default.xex
is_enabled = true

# Multiplayer
[[plugin]]
author = "mo"
name = "iw5-xenon"
file = "iw5-xenon.xex"
hash = "55003ED04B59301A" # default_mp.xex
is_enabled = true
```