### PR TITLE
[Kernel] Separate async NtReadFile from sync part and removed invalid…

### DIFF
--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_io.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_io.cc
@@ -129,7 +129,6 @@ dword_result_t NtReadFile_entry(dword_t file_handle, dword_t event_handle,
                                 lpqword_t byte_offset_ptr) {
   X_STATUS result = X_STATUS_SUCCESS;
 
-  bool signal_event = false;
   auto ev = kernel_state()->object_table()->LookupObject<XEvent>(event_handle);
   if (event_handle && !ev) {
     result = X_STATUS_INVALID_HANDLE;
@@ -140,66 +139,39 @@ dword_result_t NtReadFile_entry(dword_t file_handle, dword_t event_handle,
     result = X_STATUS_INVALID_HANDLE;
   }
 
-  if (XSUCCEEDED(result)) {
-    if (true || file->is_synchronous()) {
-      // Synchronous.
-      uint32_t bytes_read = 0;
-      result = file->Read(
-          buffer.guest_address(), buffer_length,
-          byte_offset_ptr ? static_cast<uint64_t>(*byte_offset_ptr) : -1,
-          &bytes_read, apc_context);
-      if (io_status_block) {
-        io_status_block->status = result;
-        io_status_block->information = bytes_read;
-      }
-
-      // Queue the APC callback. It must be delivered via the APC mechanism even
-      // though were are completing immediately.
-      // Low bit probably means do not queue to IO ports.
-      if ((uint32_t)apc_routine_ptr & ~1) {
-        if (apc_context && result == X_STATUS_SUCCESS) {
-          auto thread = XThread::GetCurrentThread();
-          thread->EnqueueApc(static_cast<uint32_t>(apc_routine_ptr) & ~1u,
-                             apc_context, io_status_block, 0);
-        }
-      }
-
-      if (!file->is_synchronous() && result != X_STATUS_END_OF_FILE) {
-        result = X_STATUS_PENDING;
-      }
-
-      // Mark that we should signal the event now. We do this after
-      // we have written the info out.
-      signal_event = true;
-    } else {
-      // TODO(benvanik): async.
-
-      // X_STATUS_PENDING if not returning immediately.
-      // XFile is waitable and signalled after each async req completes.
-      // reset the input event (->Reset())
-      /*xeNtReadFileState* call_state = new xeNtReadFileState();
-      XAsyncRequest* request = new XAsyncRequest(
-      state, file,
-      (XAsyncRequest::CompletionCallback)xeNtReadFileCompleted,
-      call_state);*/
-      // result = file->Read(buffer.guest_address(), buffer_length, byte_offset,
-      //                     request);
-      if (io_status_block) {
-        io_status_block->status = X_STATUS_PENDING;
-        io_status_block->information = 0;
-      }
-
-      result = X_STATUS_PENDING;
-    }
-  }
-
   if (XFAILED(result) && io_status_block) {
     io_status_block->status = result;
     io_status_block->information = 0;
+    return result;
   }
 
-  if (ev && signal_event) {
-    ev->Set(0, false);
+  uint32_t bytes_read = 0;
+  result =
+      file->Read(buffer.guest_address(), buffer_length,
+                 byte_offset_ptr ? static_cast<uint64_t>(*byte_offset_ptr) : -1,
+                 &bytes_read, apc_context);
+
+  if (io_status_block) {
+    io_status_block->status = result;
+    io_status_block->information = bytes_read;
+  }
+
+  // Queue the APC callback. It must be delivered via the APC mechanism even
+  // though were are completing immediately.
+  // Low bit probably means do not queue to IO ports.
+  if ((uint32_t)apc_routine_ptr & ~1) {
+    if (apc_context) {
+      auto thread = XThread::GetCurrentThread();
+      thread->EnqueueApc(static_cast<uint32_t>(apc_routine_ptr) & ~1u,
+                         apc_context, io_status_block, 0);
+    }
+  }
+
+  if (!file->is_synchronous()) {
+    if (ev && XSUCCEEDED(result)) {
+      ev->Set(0, false);
+    }
+    result = XSUCCEEDED(result) ? X_STATUS_PENDING : result;
   }
 
   return result;


### PR DESCRIPTION
… status handling

TODO:
- Fix JJ game. There is incorrect read offset provided for whatever reason. Confirmed that provided offset is incorrect and happens only in Xenia. Probably related to async operation.
- Fix saving in Kartz. Async read of empty file expects SUCCESS not EOF for whatever reason. Maybe STFS?