### PR TITLE
[xb] Fix `--target` flags not being passed on for Linux builds

### DIFF
--- a/xenia-build
+++ b/xenia-build
@@ -880,7 +880,7 @@ class BaseBuildCommand(Command):
                     *targets
                 ] + pass_args, shell=False, env=dict(os.environ))
             if result != 0:
-                print('ERROR: ninja failed with one or more errors.')
+                print('ERROR: ninja (via "cmake --build") failed with one or more errors.')
                 return result
         return 0
 

--- a/xenia-build
+++ b/xenia-build
@@ -872,10 +872,12 @@ class BaseBuildCommand(Command):
             if result != 0:
                 print('ERROR: cmake failed with one or more errors.')
                 return result
+            targets = ['--target', 'all'] if not len(args['target']) else [item for sublist in [['--target', target] for target in args['target']] for item in sublist]
             result = subprocess.call([
-                    'ninja',
-                    '-C./build/build_%s' % (args['config']),
-                    '-j' if threads == 0 else '-j%d' % threads,
+                    'cmake',
+                    '--build', 'build/build_%s' % (args['config']),
+                    '--parallel', '1' if threads <= 1 else '%d' % threads,
+                    *targets
                 ] + pass_args, shell=False, env=dict(os.environ))
             if result != 0:
                 print('ERROR: ninja failed with one or more errors.')


### PR DESCRIPTION
`xenia-build` was not respecting the `--target` flags for non-`win32`/`darwin` platforms.

Some `xenia-build` subcommands, such as ` test` will also fail because of this issue as it is unable to target `xenia-base-tests` & `xenia-cpu-ppc-tests`

https://github.com/xenia-canary/xenia-canary/blob/fb3c12d362cec07294375c1a302c39e5f652ab1b/xenia-build#L1188-L1192