### PR TITLE
[XBOXKRNL & XAM] - Video, Hal, And XConfig

### DIFF
--- a/src/xenia/kernel/xam/xam_info.cc
+++ b/src/xenia/kernel/xam/xam_info.cc
@@ -649,8 +649,18 @@ dword_result_t lstrlenW_entry(lpu16string_t string) {
 }
 DECLARE_XAM_EXPORT1(lstrlenW, kNone, kImplemented);
 
-dword_result_t XGetAudioFlags_entry() { return cvars::audio_flag; }
-DECLARE_XAM_EXPORT1(XGetAudioFlags, kNone, kStub);
+dword_result_t XGetAudioFlags_entry() {
+  if (cvars::avpack == 2) {
+    return 2;
+  }
+
+  if (!cvars::audio_flag) {
+    return 0x10000 | 0x1;
+  }
+
+  return cvars::audio_flag;
+}
+DECLARE_XAM_EXPORT1(XGetAudioFlags, kNone, kImplemented);
 
 /*
         todo: this table should instead be pointed to by a member of kernel

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_hal.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_hal.cc
@@ -13,6 +13,8 @@
 #include "xenia/kernel/xboxkrnl/xboxkrnl_private.h"
 #include "xenia/xbox.h"
 
+DECLARE_int32(avpack);
+
 namespace xe {
 namespace kernel {
 namespace xboxkrnl {
@@ -31,12 +33,8 @@ void HalReturnToFirmware_entry(dword_t routine) {
 }
 DECLARE_XBOXKRNL_EXPORT2(HalReturnToFirmware, kNone, kStub, kImportant);
 
-// this seems to be able to return a number of different values in the range 0
-// - 8. just returning four for now, because thats probably a better option than
-// returning whatever was in r3 to begin with
-dword_result_t HalGetCurrentAVPack_entry() { return 4; }
-
-DECLARE_XBOXKRNL_EXPORT1(HalGetCurrentAVPack, kNone, kStub);
+dword_result_t HalGetCurrentAVPack_entry() { return cvars::avpack; }
+DECLARE_XBOXKRNL_EXPORT1(HalGetCurrentAVPack, kNone, kImplemented);
 
 }  // namespace xboxkrnl
 }  // namespace kernel

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_video.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_video.cc
@@ -212,7 +212,7 @@ void VdQueryVideoMode(X_VIDEO_MODE* video_mode) {
   video_mode->display_height = display_res.second;
   video_mode->is_interlaced = cvars::interlaced;
   video_mode->is_widescreen = cvars::widescreen;
-  video_mode->is_hi_def = video_mode->display_width >= 0x400;
+  video_mode->is_hi_def = video_mode->display_width >= 0x500;
   video_mode->refresh_rate = GetVideoRefreshRate();
   video_mode->video_standard = GetVideoStandard();
   video_mode->unknown_0x8a = 0x4A;
@@ -230,7 +230,7 @@ dword_result_t VdQueryVideoFlags_entry() {
 
   uint32_t flags = 0;
   flags |= mode.is_widescreen ? 1 : 0;
-  flags |= mode.display_width >= 1024 ? 2 : 0;
+  flags |= mode.display_width >= 1280 ? 2 : 0;
   flags |= mode.display_width >= 1920 ? 4 : 0;
 
   return flags;
@@ -256,7 +256,7 @@ dword_result_t VdSetDisplayMode_entry(dword_t flags) {
 }
 DECLARE_XBOXKRNL_EXPORT1(VdSetDisplayMode, kVideo, kStub);
 
-dword_result_t VdSetDisplayModeOverride_entry(unknown_t unk0, unknown_t unk1,
+dword_result_t VdSetDisplayModeOverride_entry(dword_t width, dword_t height,
                                               double_t refresh_rate,
                                               unknown_t unk3, unknown_t unk4) {
   // refresh_rate = 0, 50, 59.9, etc.

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_xconfig.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_xconfig.cc
@@ -58,6 +58,7 @@ DEFINE_uint32(
 DECLARE_bool(widescreen);
 DECLARE_bool(use_50Hz_mode);
 DECLARE_int32(video_standard);
+DECLARE_uint32(internal_display_resolution);
 
 namespace xe {
 namespace kernel {
@@ -123,9 +124,9 @@ X_STATUS xeExGetXConfigSetting(uint16_t category, uint16_t setting,
           break;
         case 0x000A:  // XCONFIG_USER_VIDEO_FLAGS
           setting_size = 4;
-          xe::store_and_swap<uint32_t>(
-              value, cvars::widescreen ? X_VIDEO_ASPECT_RATIO::Widescreen
-                                       : X_VIDEO_ASPECT_RATIO::RatioNormal);
+          xe::store_and_swap<uint32_t>(value, cvars::widescreen
+                                                  ? X_VIDEO_FLAGS::Widescreen
+                                                  : X_VIDEO_FLAGS::RatioNormal);
           break;
         case 0x000B:  // XCONFIG_USER_AUDIO_FLAGS
           setting_size = 4;
@@ -142,11 +143,35 @@ X_STATUS xeExGetXConfigSetting(uint16_t category, uint16_t setting,
           break;
         case 0x000F:  // XCONFIG_USER_PC_FLAGS
           setting_size = 1;
-          xe::store_and_swap<uint8_t>(value, 0);
+          value[0] = static_cast<uint8_t>(0);
+          break;
+        case 0x0014:  // XCONFIG_USER_AV_COMPONENT_SCREENSZ
+          setting_size = 4;
+          // int16_t* value[2];
+          if (XHDTVResolution.find(cvars::internal_display_resolution) !=
+              XHDTVResolution.cend()) {
+            xe::store_and_swap<int32_t>(
+                value, XHDTVResolution.at(cvars::internal_display_resolution));
+          } else {
+            XELOGW("Resolution not supported for AV Component");
+            xe::store_and_swap<int32_t>(value, 0);
+          }
+          break;
+        case 0x0015:  // XCONFIG_USER_AV_VGA_SCREENSZ
+          setting_size = 4;
+          // int16_t* value[2];
+          if (XVGAResolution.find(cvars::internal_display_resolution) !=
+              XVGAResolution.cend()) {
+            xe::store_and_swap<int32_t>(
+                value, XVGAResolution.at(cvars::internal_display_resolution));
+          } else {
+            XELOGW("Resolution not supported for VGA");
+            xe::store_and_swap<int32_t>(value, 0);
+          }
           break;
         case 0x001B:  // XCONFIG_USER_PC_HINT
           setting_size = 1;
-          xe::store_and_swap<uint8_t>(value, 0);
+          value[0] = static_cast<uint8_t>(0);
           break;
         case 0x0029:  // XCONFIG_USER_VIDEO_OUTPUT_BLACK_LEVELS
           setting_size = 4;

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_xconfig.h
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_xconfig.h
@@ -26,9 +26,32 @@ enum X_AV_REGION : uint32_t {
 };
 
 // XCONFIG_USER_VIDEO_FLAGS
-enum X_VIDEO_ASPECT_RATIO : uint32_t {
-  RatioNormal = 0x00400100,
-  Widescreen = 0x00400200,
+enum X_VIDEO_FLAGS : uint32_t {
+  RatioNormal = 0x00000000,
+  Widescreen = 0x00010000,
+};
+
+// XCONFIG_USER_AV_COMPONENT_SCREENSZ
+const static std::map<uint32_t, int32_t> XHDTVResolution = {
+    {0, 0x028001E0},   // 480p
+    {8, 0x050002D0},   // 720p, always widescreen
+    {16, 0x07800438},  // 1080, interlaced added in 1888, always widescreen
+};
+
+// XCONFIG_USER_AV_COMPONENT_SCREENSZ
+const static std::map<uint32_t, int32_t> XVGAResolution = {
+    // Existed since 1888
+    {0, 0x028001E0},   // 680x480
+    {5, 0x035001E0},   // 848x480
+    {6, 0x04000300},   // 1024x768
+    {8, 0x050002D0},   // 1280x720
+    {9, 0x05000300},   // 1280x768
+    {12, 0x05500300},  // 1360x768
+    // added in later Versions
+    {11, 0x05000400},  // 1280x1024
+    {13, 0x05A00384},  // 1440x900
+    {14, 0x0690041A},  // 1680x1050
+    {16, 0x07800438},  // 1920x1080
 };
 
 // XCONFIG_USER_AUDIO_FLAGS
@@ -66,7 +89,7 @@ enum X_RETAIL_FLAGS : uint32_t {
 
   // Other
   DashboardInitialized = 0x00000040,
-  BackgroundDownloadOn = 0X00010000,
+  BackgroundDownloadOn = 0x00010000,
 };
 
 // XCONFIG_USER_PC_FLAGS
@@ -94,7 +117,7 @@ enum X_BLACK_LEVEL : uint32_t {
 // XCONFIG_CONSOLE_SCREENSAVER
 enum X_SCREENSAVER : uint32_t {
   ScreensaverOn = 0x000A,
-  ScreensaverOff = 0X1000,
+  ScreensaverOff = 0x1000,
 };
 
 // XCONFIG_CONSOLE_AUTO_SHUTDOWN
@@ -128,8 +151,6 @@ enum X_KEYBOARD_LAYOUT : uint16_t {
   KeyboardDefault = 0x0000,
   EnglishQWERTY = 0x0001,
 };
-
-// XCONFIG_CONSOLE_KEYBOARD_LAYOUT
 
 }  // namespace xboxkrnl
 }  // namespace kernel


### PR DESCRIPTION
- Properly implement HalGetCurrentAVPack, and XGetAudioFlags.
- Return proper flags for AV Component, AV Composite, and VGA from xconfig.
- Set to HD to proper value.
- Correct wrong widescreen flag.