### PR TITLE
Fix: Use gzip in Tar Compression of Linux Builds

### DIFF
--- a/.github/workflows/Create_release.yml
+++ b/.github/workflows/Create_release.yml
@@ -32,7 +32,7 @@ jobs:
               asset=xenia_canary_linux.tar.gz
               cd xenia_canary_linux
               chmod +x xenia_canary
-              tar -cvpf ../$asset *
+              tar -czvpf ../$asset *
               cd -
               ;;
           esac


### PR DESCRIPTION
Currently actions built linux releases are created with a `.gz` suffix without using gzip compression during tarring. 

Downloading and attempting to extract such a release with the proper flags results in the following:
```
tar -xzvf xenia_canary_linux.tar.gz                                                                                                                                                                                                             

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

Adding the `z` arg to the tar command fixes this. 