### PR TITLE
Implement LaunchFileExplorer the same as LaunchWebBrowser.

### DIFF
--- a/src/xenia/base/system_gnulinux.cc
+++ b/src/xenia/base/system_gnulinux.cc
@@ -29,7 +29,11 @@ void LaunchWebBrowser(const std::string_view url) {
   system(cmd.c_str());
 }
 
-void LaunchFileExplorer(const std::filesystem::path& path) { assert_always(); }
+void LaunchFileExplorer(const std::filesystem::path& path) {
+  auto cmd = std::string("xdg-open ");
+  cmd.append(path);
+  system(cmd.c_str());
+}
 
 void ShowSimpleMessageBox(SimpleMessageBoxType type, std::string_view message) {
   void* libsdl2 = dlopen("libSDL2.so", RTLD_LAZY | RTLD_LOCAL);


### PR DESCRIPTION
This commit implements LaunchFileExplorer the same way LaunchWebBrowser is implemented so it actually works instead of crashing. I know using system() isn't the best way of doing this but surely it's better to at least having it working like LaunchWebBrowser and not crashing right? :)