### PR TITLE
[Kernel] Updated XAM loader to find '$flash_xam.xex'

### DIFF
--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -589,6 +589,9 @@ X_STATUS Emulator::LaunchXexFile(const std::filesystem::path& path) {
       file_system_->RegisterSymbolicLink("font:", mount_path);
 
       auto module = kernel_state_->LoadUserModule("xam.xex");
+      if (!module) {
+        module = kernel_state_->LoadUserModule("$flash_xam.xex");
+      }
 
       if (module) {
         result = kernel_state_->FinishLoadingUserModule(module, false);


### PR DESCRIPTION
now tries to load '$flash_xam.xex' file for resource extraction if it does not detect xam.xex