### PR TITLE
[xb] Allow `premake5 --cc` arguments to be optional

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -159,8 +159,8 @@ filter({"platforms:Linux", "language:C++", "toolset:clang"})
     "deprecated-enum-enum-conversion",
     "attributes",
   })
-if os.istarget("linux") and string.contains(_OPTIONS["cc"], "clang") then
-  CLANG_BIN = os.getenv("CC") or _OPTIONS["cc"]
+CLANG_BIN = os.getenv("CC") or _OPTIONS["cc"] or "clang"
+if os.istarget("linux") and string.contains(CLANG_BIN, "clang") then
   if tonumber(string.match(os.outputof(CLANG_BIN.." --version"), "version (%d%d)")) >= 20 then
     filter({"platforms:Linux", "language:C++", "toolset:clang"})
       disablewarnings({


### PR DESCRIPTION
Since commit 0aeac841b8354806f1c455402edb0815dfe9729e, without specifying a `--cc` argument or having a `CC` environment variable set, the `premake5` command will fail.
```shell
$ premake5 --file=premake5.lua cmake
Error: [string "src/base/string.lua"]:5: bad argument #1 to 'find' (string expected, got nil)
```