### PR TITLE
[XAM] - xcontent_type fixes & more

### DIFF
--- a/src/xenia/kernel/smc.h
+++ b/src/xenia/kernel/smc.h
@@ -94,6 +94,8 @@ enum X_SMC_CMD : uint8_t {
   QUERY_RTC = 0x4,
   QUERY_TEMP_SENSOR = 0x7,
   QUERY_TRAY = 0xA,
+  QUERY_UNK_0xB =
+      0xB,  // called on start up after VdQueryVideoMode on dash v13599
   QUERY_AV_PACK = 0xF,
   I2C_READ_WRITE = 0x11,
   QUERY_SMC_VERSION = 0x12,

--- a/src/xenia/kernel/xam/ui/gamercard_ui.cc
+++ b/src/xenia/kernel/xam/ui/gamercard_ui.cc
@@ -177,6 +177,12 @@ static constexpr const char* CameraLocationOptions[] = {"Behind", "In Front",
 static constexpr const char* BrakeControlOptions[] = {"Trigger", "Button"};
 static constexpr const char* AcceleratorControlOptions[] = {"Trigger",
                                                             "Button"};
+static constexpr const char* GamerTypeOptions[] = {"None",
+                                                   nullptr,
+                                                   nullptr,
+                                                   "Xbox 360 Launch Team",
+                                                   "NXE Launch Team",
+                                                   "360 + NXE Launch Team"};
 
 constexpr std::array<UserSettingId, 19> UserSettingsToLoad = {
     UserSettingId::XPROFILE_GAMER_TYPE,
@@ -528,6 +534,10 @@ void GamercardUI::DrawGpdSettings(ImGuiIO& io) {
   DrawSettingComboBox(UserSettingId::XPROFILE_GAMER_RACE_ACCELERATOR_CONTROL,
                       "Accelerator Control", AcceleratorControlOptions,
                       static_cast<int>(std::size(AcceleratorControlOptions)),
+                      rightSideTextObjectAlignment);
+  DrawSettingComboBox(UserSettingId::XPROFILE_GAMER_TYPE, "Gamer Type",
+                      GamerTypeOptions,
+                      static_cast<int>(std::size(GamerTypeOptions)),
                       rightSideTextObjectAlignment);
 }
 

--- a/src/xenia/kernel/xam/xam_content_device.h
+++ b/src/xenia/kernel/xam/xam_content_device.h
@@ -23,6 +23,7 @@ enum class DeviceType : uint32_t {
   HDD = 1,
   MU = 2,  // support removed in 9199
   ODD = 4,
+  TransferCable = 8,
   USBMASS = 16,  // Added in 8955
 };
 

--- a/src/xenia/kernel/xam/xam_enum.cc
+++ b/src/xenia/kernel/xam/xam_enum.cc
@@ -124,7 +124,8 @@ dword_result_t XamProfileCreateEnumerator_entry(dword_t device_id,
 
   auto e = new XStaticEnumerator<X_PROFILEENUMRESULT>(kernel_state(), 1);
 
-  auto result = e->Initialize(XUserIndexAny, 0xFE, 0x23001, 0x23003, 0);
+  auto result =
+      e->Initialize(XUserIndexAny, 0xFE, 0x23001, 0x23003, 0, 0x28, nullptr);
 
   if (XFAILED(result)) {
     return result;

--- a/src/xenia/xbox.h
+++ b/src/xenia/xbox.h
@@ -414,17 +414,18 @@ enum class XOnlineCountry : uint32_t {
 };
 
 enum class XContentType : uint32_t {
+  kFolder = 0xffffffff,
   kInvalid = 0x00000000,
   kSavedGame = 0x00000001,
   kMarketplaceContent = 0x00000002,
   kPublisher = 0x00000003,
-  kXbox360Title = 0x00001000,
+  kIptvDvr = 0x00001000,
   kIptvPauseBuffer = 0x00002000,
   kXNACommunity = 0x00003000,
   kInstalledGame = 0x00004000,
   kXboxTitle = 0x00005000,
   kSocialTitle = 0x00006000,
-  kGamesOnDemand = 0x00007000,
+  kXbox360Title = 0x00007000,
   kSUStoragePack = 0x00008000,
   kAvatarItem = 0x00009000,
   kProfile = 0x00010000,
@@ -452,16 +453,18 @@ enum class XContentType : uint32_t {
 };
 
 inline const std::map<XContentType, std::string> XContentTypeMap = {
+    {XContentType::kFolder, "Folder"},
     {XContentType::kSavedGame, "Saved Game"},
     {XContentType::kMarketplaceContent, "Marketplace Content"},
     {XContentType::kPublisher, "Publisher"},
     {XContentType::kXbox360Title, "Xbox 360 Title"},
+    {XContentType::kIptvDvr, "IPTV DVR"},
     {XContentType::kIptvPauseBuffer, "IPTV Pause Buffer"},
     {XContentType::kXNACommunity, "XNA Community"},
     {XContentType::kInstalledGame, "Installed Game"},
     {XContentType::kXboxTitle, "Xbox Title"},
     {XContentType::kSocialTitle, "Social Title"},
-    {XContentType::kGamesOnDemand, "Game on Demand"},
+    {XContentType::kXbox360Title, "Xbox 360 Title"},
     {XContentType::kSUStoragePack, "SU Storage Pack"},
     {XContentType::kAvatarItem, "Avatar Item"},
     {XContentType::kProfile, "Profile"},


### PR DESCRIPTION
- added unknown smc call
- xcontent_type corrections
- add transfer cable to device type
- Select gamer type in gamercard
<img width="597" height="194" alt="Screenshot 2025-10-16 131421" src="https://github.com/user-attachments/assets/e617aa2b-2f5b-4152-b6b5-5fd77b81fd50" />
<img width="589" height="217" alt="Screenshot 2025-10-26 090436" src="https://github.com/user-attachments/assets/4d2e2ed4-974f-41fd-8be5-fed8b72e151b" />
<img width="604" height="206" alt="Screenshot 2025-10-26 090448" src="https://github.com/user-attachments/assets/e19beccc-92b2-42f5-a94d-51057e689ef4" />
