### PR TITLE
[Kernel] - restrict kXNotificationLiveConnectionChanged to startup

### DIFF
--- a/src/xenia/kernel/kernel_state.cc
+++ b/src/xenia/kernel/kernel_state.cc
@@ -920,7 +920,8 @@ void KernelState::RegisterNotifyListener(XNotifyListener* listener) {
     listener->EnqueueNotification(kXNotificationSystemTrayStateChanged,
                                   X_DVD_DISC_STATE::XBOX_360_GAME_DISC);
   }
-  if (listener->mask() & kXNotifyLive) {
+  if (!has_notified_live_startup_ && listener->mask() & kXNotifyLive) {
+    has_notified_live_startup_ = true;
     listener->EnqueueNotification(kXNotificationLiveConnectionChanged,
                                   0x80151802L);
     listener->EnqueueNotification(kXNotificationLiveLinkStateChanged, 0);

--- a/src/xenia/kernel/kernel_state.h
+++ b/src/xenia/kernel/kernel_state.h
@@ -358,6 +358,7 @@ class KernelState {
   std::unordered_map<uint32_t, XThread*> threads_by_id_;
   std::vector<object_ref<XNotifyListener>> notify_listeners_;
   bool has_notified_startup_ = false;
+  bool has_notified_live_startup_ = false;
 
   object_ref<UserModule> executable_module_;
   std::vector<object_ref<KernelModule>> kernel_modules_;


### PR DESCRIPTION
- allow for dashboard to show achievements and themes again.