### PR TITLE
Improve vibration related handling

### DIFF
--- a/src/xenia/kernel/xam/xam_input.cc
+++ b/src/xenia/kernel/xam/xam_input.cc
@@ -138,8 +138,32 @@ dword_result_t XamInputSetState_entry(
   }
 
   auto input_system = kernel_state()->emulator()->input_system();
-  auto lock = input_system->lock();
-  return input_system->SetState(user_index, vibration);
+
+  if (!input_system) {
+    XELOGW("XamInputSetState: input_system is null for user {}",
+           uint32_t(user_index));
+    return X_ERROR_DEVICE_NOT_CONNECTED;
+  }
+
+  // If vibration is disabled, just return success without locking
+  // This avoids potential mutex issues when vibration is disabled
+  if (!input_system->GetVibrationCvar()) {
+    return X_ERROR_SUCCESS;
+  }
+
+  // Try to lock with exception handling to avoid crashes
+  try {
+    auto lock = input_system->lock();
+    return input_system->SetState(user_index, vibration);
+  } catch (const std::exception& e) {
+    XELOGE("XamInputSetState: Failed to acquire lock for user {}: {}",
+           uint32_t(user_index), e.what());
+    return X_ERROR_SUCCESS;
+  } catch (...) {
+    XELOGE("XamInputSetState: Unknown error acquiring lock for user {}",
+           uint32_t(user_index));
+    return X_ERROR_SUCCESS;
+  }
 }
 DECLARE_XAM_EXPORT1(XamInputSetState, kInput, kImplemented);
 


### PR DESCRIPTION
Resolves #709

Basically adds some safety checks before attempting to acquire the lock and avoids dumping core in favor of simply logging the issue and allowing the game to keep running despite vibration related problems. Also disables the code path entirely if vibration is disabled in the config to give the user a full out if vibration implementation is problematic and cannot be disabled in the game.