### PR TITLE
[UI] Set ImGUI clipboard functions to GTK implementations

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -34,7 +34,6 @@ includedirs({
 
 defines({
   "VULKAN_HPP_NO_TO_STRING",
-  "IMGUI_DISABLE_OBSOLETE_FUNCTIONS",
   "IMGUI_DISABLE_DEFAULT_FONT",
   --"IMGUI_USE_WCHAR32",
   "IMGUI_USE_STB_SPRINTF",
@@ -238,6 +237,7 @@ filter("platforms:Windows")
     "WIN32",
     "_WIN64=1",
     "_AMD64=1",
+    "IMGUI_DISABLE_OBSOLETE_FUNCTIONS",
   })
   linkoptions({
     "/ignore:4006",  -- Ignores complaints about empty obj files.

--- a/src/xenia/ui/imgui_drawer.cc
+++ b/src/xenia/ui/imgui_drawer.cc
@@ -35,6 +35,10 @@
 #include <fontconfig/fontconfig.h>
 #endif
 
+#ifdef XE_PLATFORM_LINUX
+#include <gtk/gtk.h>
+#endif
+
 DEFINE_path(
     custom_font_path, "",
     "Allows user to load custom font and use it instead of default one.", "UI");
@@ -138,6 +142,18 @@ void ImGuiDrawer::RemoveNotification(ImGuiNotification* dialog) {
   DetachIfLastWindowRemoved();
 }
 
+#ifdef XE_PLATFORM_LINUX
+static void SetClipboardText(void* user_data, const char* text) {
+  GtkClipboard* clipboard = gtk_clipboard_get(GDK_SELECTION_CLIPBOARD);
+  gtk_clipboard_set_text(clipboard, text, -1);
+}
+
+static const char* GetClipboardText(void* user_data) {
+  GtkClipboard* clipboard = gtk_clipboard_get(GDK_SELECTION_CLIPBOARD);
+  return gtk_clipboard_wait_for_text(clipboard);
+}
+#endif
+
 void ImGuiDrawer::Initialize() {
   // Setup ImGui internal state.
   // This will give us state we can swap to the ImGui globals when in use.
@@ -152,6 +168,11 @@ void ImGuiDrawer::Initialize() {
 
   InitializeFonts(font_size);
   InitializeFonts(title_font_size);
+
+#ifdef XE_PLATFORM_LINUX
+  io.SetClipboardTextFn = SetClipboardText;
+  io.GetClipboardTextFn = GetClipboardText;
+#endif
 
   auto& style = ImGui::GetStyle();
   style.ScrollbarRounding = 6.0f;


### PR DESCRIPTION
This requires removing `IMGUI_DISABLE_OBSOLETE_FUNCTIONS` but i don't know an alternative solution.