### PR TITLE
[Xam/Avatar] - Allow avatar initialization

### DIFF
--- a/src/xenia/kernel/title_id_utils.h
+++ b/src/xenia/kernel/title_id_utils.h
@@ -19,6 +19,7 @@ namespace kernel {
 inline constexpr uint32_t kXN_2001 = 0x584E07D1;
 inline constexpr uint32_t kXN_2002 = 0x584E07D2;
 inline constexpr uint32_t kDashboardID = 0xFFFE07D1;
+inline constexpr uint32_t kAvatarEditorID = 0x584D07D1;
 
 inline constexpr uint16_t GetGameId(const uint32_t title_id) {
   return title_id >> 16;

--- a/src/xenia/kernel/xam/xam_avatar.cc
+++ b/src/xenia/kernel/xam/xam_avatar.cc
@@ -13,6 +13,12 @@
 #include "xenia/kernel/xam/xam_private.h"
 #include "xenia/xbox.h"
 
+DEFINE_bool(allow_avatar_initialization, false,
+            "Enable Avatar Initialization\n"
+            " Only set true when testing Avatar games. Certain games may\n"
+            " require kinect implementation.",
+            "Kernel");
+
 namespace xe {
 namespace kernel {
 namespace xam {
@@ -26,13 +32,11 @@ dword_result_t XamAvatarInitialize_entry(
     lpunknown_t unk5,          // ptr in data segment
     dword_t unk6               // flags - 0x00300000, 0x30, etc
 ) {
-  // This should only work for avatar editor to test avatar rendering
-  auto title_id = kernel_state()->title_id();
-  if (title_id == 0x584D07D1) {
+  if (kernel_state()->title_id() == kAvatarEditorID) {
     return X_STATUS_SUCCESS;
   }
-  // Negative to fail. Game should immediately call XamAvatarShutdown.
-  return ~0u;
+
+  return cvars::allow_avatar_initialization ? X_STATUS_SUCCESS : ~0u;
 }
 DECLARE_XAM_EXPORT1(XamAvatarInitialize, kAvatars, kStub);
 

--- a/src/xenia/kernel/xam/xam_nui.cc
+++ b/src/xenia/kernel/xam/xam_nui.cc
@@ -19,7 +19,7 @@
 #include "xenia/ui/windowed_app_context.h"
 #include "xenia/xbox.h"
 
-DEFINE_bool(Allow_nui_initialization, false,
+DEFINE_bool(allow_nui_initialization, false,
             "Enable NUI initialization\n"
             " Only set true when testing kinect games. Certain games may\n"
             " require avatar implementation.",
@@ -73,8 +73,8 @@ dword_result_t XamNuiGetDeviceStatus_entry(
   */
 
   status_ptr.Zero();
-  status_ptr->status = cvars::Allow_nui_initialization;
-  return cvars::Allow_nui_initialization ? X_ERROR_SUCCESS : 0xC0050006;
+  status_ptr->status = cvars::allow_nui_initialization;
+  return cvars::allow_nui_initialization ? X_ERROR_SUCCESS : 0xC0050006;
 }
 DECLARE_XAM_EXPORT1(XamNuiGetDeviceStatus, kNone, kStub);
 
@@ -197,7 +197,7 @@ dword_result_t XamNuiIsDeviceReady_entry() {
      - 0x0004
      - 0x0040
   */
-  uint16_t device_state = cvars::Allow_nui_initialization ? 1 : 0;
+  uint16_t device_state = cvars::allow_nui_initialization ? 1 : 0;
   return device_state >> 1 & 1;
 }
 DECLARE_XAM_EXPORT1(XamNuiIsDeviceReady, kNone, kImplemented);


### PR DESCRIPTION
- Let user allow avatar initialization
- fixes games that require it to access gameplay e.g.) A Kingdom for Keflings