### PR TITLE
[XMP] Ensure volume always set when driver created.

### DIFF
--- a/src/xenia/apu/audio_media_player.cc
+++ b/src/xenia/apu/audio_media_player.cc
@@ -245,8 +245,10 @@ void AudioMediaPlayer::Play() {
 
   if (volume_ == 0.0f) {
     volume_ = cvars::xmp_default_volume / 100.0f;
-    SetVolume(volume_);
   }
+
+  // Always apply the stored volume to the newly created driver
+  driver_->SetVolume(volume_);
 
   auto result =
       ProcessAudioLoop(this, driver_.get(), formatContext, codecContext, 0);


### PR DESCRIPTION
Fixes the issue of the volume starting at default and abruptly adjusting to the game setting as it changes.

Can be see in TDU when turning on the radio (d-pad left, then up). You start with 0 volume (radio off) and are meant to ramp it up but the volume goes immediately to 70 and then drops to low value again as you try to turn the volume knob.