### PR TITLE
[Build] Disable clang21 warnings in third_party

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -192,6 +192,12 @@ if os.istarget("linux") and string.contains(CLANG_BIN, "clang") then
         "nontrivial-memcall",
       })
   end
+  if tonumber(string.match(os.outputof(CLANG_BIN.." --version"), "version (%d%d)")) >= 21 then
+    filter({"language:C++", "toolset:clang"}) -- "platforms:Linux"
+      disablewarnings({
+        "character-conversion",          -- Needed for utfcpp third-party library
+      })
+  end
 end
 
 filter({"language:C", "toolset:clang or gcc"}) -- "platforms:Linux"


### PR DESCRIPTION
Doesn't affect building with other clang versions, just allows clang21 to build as well