### PR TITLE
[GPU] Fast readback resolve

### DIFF
--- a/src/xenia/app/emulator_window.cc
+++ b/src/xenia/app/emulator_window.cc
@@ -50,7 +50,7 @@ DECLARE_bool(guide_button);
 
 DECLARE_bool(clear_memory_page_state);
 
-DECLARE_bool(readback_resolve);
+DECLARE_string(readback_resolve);
 
 DECLARE_bool(readback_memexport);
 
@@ -1822,10 +1822,10 @@ EmulatorWindow::ControllerHotKey EmulatorWindow::ProcessControllerHotkey(
       xe::threading::Sleep(delay);
       break;
     case ButtonFunctions::ReadbackResolve:
-      ToggleGPUSetting(GPUSetting::ReadbackResolve);
+      CycleReadbackResolve();
 
-      notificationTitle = "Toggle Readback Resolve";
-      notificationDesc = cvars::readback_resolve ? "Enabled" : "Disabled";
+      notificationTitle = "Readback Resolve Mode";
+      notificationDesc = cvars::readback_resolve;
 
       // Extra Sleep
       xe::threading::Sleep(delay);
@@ -2009,12 +2009,20 @@ void EmulatorWindow::ToggleGPUSetting(gpu::GPUSetting setting) {
       SaveGPUSetting(GPUSetting::ClearMemoryPageState,
                      !cvars::clear_memory_page_state);
       break;
-    case GPUSetting::ReadbackResolve:
-      SaveGPUSetting(GPUSetting::ReadbackResolve, !cvars::readback_resolve);
-      break;
     case GPUSetting::ReadbackMemexport:
       SaveGPUSetting(GPUSetting::ReadbackMemexport, !cvars::readback_memexport);
       break;
+  }
+}
+
+void EmulatorWindow::CycleReadbackResolve() {
+  const std::string& current = cvars::readback_resolve;
+  if (current == "fast") {
+    gpu::SetReadbackResolveMode("full");
+  } else if (current == "full") {
+    gpu::SetReadbackResolveMode("none");
+  } else {
+    gpu::SetReadbackResolveMode("fast");
   }
 }
 
@@ -2056,8 +2064,7 @@ void EmulatorWindow::DisplayHotKeysConfig() {
   msg.insert(0, msg_passthru);
   msg += "\n";
 
-  msg += "Readback Resolve: " +
-         xe::string_util::BoolToString(cvars::readback_resolve);
+  msg += "Readback Resolve: " + cvars::readback_resolve;
   msg += "\n";
 
   msg += "Clear Memory Page State: " +

--- a/src/xenia/app/emulator_window.h
+++ b/src/xenia/app/emulator_window.h
@@ -280,6 +280,7 @@ class EmulatorWindow {
                          bool vibrate = true);
   void GamepadHotKeys();
   void ToggleGPUSetting(gpu::GPUSetting setting);
+  void CycleReadbackResolve();
   void DisplayHotKeysConfig();
 
   static std::string CanonicalizeFileExtension(

--- a/src/xenia/base/cvar.cc
+++ b/src/xenia/base/cvar.cc
@@ -30,6 +30,7 @@ cxxopts::Options options("xenia", "Xbox 360 Emulator");
 std::map<std::string, ICommandVar*>* CmdVars;
 std::map<std::string, IConfigVar*>* ConfigVars;
 std::multimap<uint32_t, const IConfigVarUpdate*>* IConfigVarUpdate::updates_;
+std::vector<std::string>* config_type_mismatch_warnings = nullptr;
 
 void PrintHelpAndExit() {
   std::cout << options.help({""}) << std::endl;


### PR DESCRIPTION
Adds type mismatch handling to allow old readback_resolve to be processed without crashing.

Also includes fix to force commit memory to prevent crashes in games like ng2 that try to readback to uncommitted buffers.