### PR TITLE
Allow user to override GDK_BACKEND

### DIFF
--- a/src/xenia/ui/windowed_app_main_posix.cc
+++ b/src/xenia/ui/windowed_app_main_posix.cc
@@ -19,7 +19,10 @@
 int main(int argc_pre_gtk, char** argv_pre_gtk) {
   // Before touching anything GTK+, make sure that when running on Wayland,
   // we'll still get an X11 (Xwayland) window
-  setenv("GDK_BACKEND", "x11", 1);
+  // also allow users to override this
+  if (!secure_getenv("GDK_BACKEND")) {
+    setenv("GDK_BACKEND", "x11", 1);
+  }
 
   // Initialize GTK+, which will handle and remove its own arguments from argv.
   // Both GTK+ and Xenia use --option=value argument format (see man


### PR DESCRIPTION
By default xenia is still going to use x11. But if user sets `GDK_BACKEND` to `wayland` it uses wayland

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8f6cba1f-77a2-47d5-ba75-ce1d155b436b" />
