### PR TITLE
Fix the fur rendering on #4D5307DF

### DIFF
--- a/src/xenia/gpu/d3d12/d3d12_texture_cache.cc
+++ b/src/xenia/gpu/d3d12/d3d12_texture_cache.cc
@@ -582,21 +582,41 @@ void D3D12TextureCache::WriteActiveTextureBindfulSRV(
   const TextureBinding* binding = GetValidTextureBinding(fetch_constant_index);
   if (binding && AreDimensionsCompatible(host_shader_binding.dimension,
                                          binding->key.dimension)) {
+    bool force_special_view =
+        (host_shader_binding.dimension == xenos::FetchOpDimension::k2D &&
+         binding->key.dimension == xenos::DataDimension::k3D);
+
     const D3D12TextureBinding& d3d12_binding =
         d3d12_texture_bindings_[fetch_constant_index];
     if (host_shader_binding.is_signed) {
       // Not supporting signed compressed textures - hopefully DXN and DXT5A are
       // not used as signed.
       if (texture_util::IsAnySignSigned(binding->swizzled_signs)) {
-        descriptor_index = d3d12_binding.descriptor_index_signed;
         texture = IsSignedVersionSeparateForFormat(binding->key)
                       ? binding->texture_signed
                       : binding->texture;
+
+        if (force_special_view && texture) {
+          // Request the 2D view of the 3D texture on demand
+          descriptor_index = FindOrCreateTextureDescriptor(
+              *static_cast<D3D12Texture*>(texture),
+              xenos::DataDimension::k2DOrStacked, true, binding->host_swizzle);
+        } else {
+          descriptor_index = d3d12_binding.descriptor_index_signed;
+        }
       }
     } else {
       if (texture_util::IsAnySignNotSigned(binding->swizzled_signs)) {
-        descriptor_index = d3d12_binding.descriptor_index;
         texture = binding->texture;
+
+        if (force_special_view && texture) {
+          // Request the 2D view of the 3D texture on demand
+          descriptor_index = FindOrCreateTextureDescriptor(
+              *static_cast<D3D12Texture*>(texture),
+              xenos::DataDimension::k2DOrStacked, false, binding->host_swizzle);
+        } else {
+          descriptor_index = d3d12_binding.descriptor_index;
+        }
       }
     }
   }
@@ -646,12 +666,47 @@ uint32_t D3D12TextureCache::GetActiveTextureBindlessSRVIndex(
   const TextureBinding* binding = GetValidTextureBinding(fetch_constant_index);
   if (binding && AreDimensionsCompatible(host_shader_binding.dimension,
                                          binding->key.dimension)) {
+    // 3D Texture on 2D Request
+    bool force_special_view =
+        (host_shader_binding.dimension == xenos::FetchOpDimension::k2D &&
+         binding->key.dimension == xenos::DataDimension::k3D);
+
     const D3D12TextureBinding& d3d12_binding =
         d3d12_texture_bindings_[fetch_constant_index];
-    descriptor_index = host_shader_binding.is_signed
-                           ? d3d12_binding.descriptor_index_signed
-                           : d3d12_binding.descriptor_index;
+
+    // Helper lambda to get standard index
+    uint32_t standard_index = host_shader_binding.is_signed
+                                  ? d3d12_binding.descriptor_index_signed
+                                  : d3d12_binding.descriptor_index;
+
+    if (force_special_view) {
+      // Determine which texture object to use
+      // Respect swizzled_signs from fetch constant, not just shader request
+      Texture* texture = nullptr;
+      bool use_signed = host_shader_binding.is_signed &&
+                        texture_util::IsAnySignSigned(binding->swizzled_signs);
+      if (use_signed) {
+        texture = IsSignedVersionSeparateForFormat(binding->key)
+                      ? binding->texture_signed
+                      : binding->texture;
+        if (texture) {
+          descriptor_index = FindOrCreateTextureDescriptor(
+              *static_cast<D3D12Texture*>(texture),
+              xenos::DataDimension::k2DOrStacked, true, binding->host_swizzle);
+        }
+      } else {
+        texture = binding->texture;
+        if (texture) {
+          descriptor_index = FindOrCreateTextureDescriptor(
+              *static_cast<D3D12Texture*>(texture),
+              xenos::DataDimension::k2DOrStacked, false, binding->host_swizzle);
+        }
+      }
+    } else {
+      descriptor_index = standard_index;
+    }
   }
+
   if (descriptor_index == UINT32_MAX) {
     switch (host_shader_binding.dimension) {
       case xenos::FetchOpDimension::k3DOrStacked:
@@ -1176,8 +1231,9 @@ ID3D12Resource* D3D12TextureCache::RequestSwapTexture(
 
 D3D12TextureCache::D3D12Texture::D3D12Texture(
     D3D12TextureCache& texture_cache, const TextureKey& key,
-    ID3D12Resource* resource, D3D12_RESOURCE_STATES resource_state)
-    : Texture(texture_cache, key),
+    ID3D12Resource* resource, D3D12_RESOURCE_STATES resource_state,
+    bool track_usage)
+    : Texture(texture_cache, key, track_usage),
       resource_(resource),
       resource_state_(resource_state) {
   ID3D12Device* device =
@@ -1355,7 +1411,11 @@ bool D3D12TextureCache::LoadTextureDataFromResidentMemoryImpl(Texture& texture,
   const texture_util::TextureGuestLayout& guest_layout =
       d3d12_texture.guest_layout();
   xenos::DataDimension dimension = texture_key.dimension;
+  // Whether the host texture is 3D (determines depth vs array layer layout).
   bool is_3d = dimension == xenos::DataDimension::k3D;
+  // Whether to use 3D tiling when reading from guest memory.
+  // For 3D-as-2D wrappers, the host texture is 2D but we need 3D tiling.
+  bool is_3d_tiling = is_3d || d3d12_texture.force_load_3d_tiling();
   uint32_t width = texture_key.GetWidth();
   uint32_t height = texture_key.GetHeight();
   uint32_t depth_or_array_size = texture_key.GetDepthOrArraySize();
@@ -1544,7 +1604,7 @@ bool D3D12TextureCache::LoadTextureDataFromResidentMemoryImpl(Texture& texture,
   assert_true(texture_resolution_scale_x <= 7);
   assert_true(texture_resolution_scale_y <= 7);
   load_constants.is_tiled_3d_endian_scale =
-      uint32_t(texture_key.tiled) | (uint32_t(is_3d) << 1) |
+      uint32_t(texture_key.tiled) | (uint32_t(is_3d_tiling) << 1) |
       (uint32_t(texture_key.endianness) << 2) |
       (texture_resolution_scale_x << 4) | (texture_resolution_scale_y << 7);
 
@@ -1756,36 +1816,103 @@ void D3D12TextureCache::UpdateTextureBindingsImpl(
       if (binding->texture &&
           texture_util::IsAnySignNotSigned(binding->swizzled_signs)) {
         d3d12_binding.descriptor_index = FindOrCreateTextureDescriptor(
-            *static_cast<D3D12Texture*>(binding->texture), false,
-            binding->host_swizzle);
+            *static_cast<D3D12Texture*>(binding->texture),
+            binding->key.dimension, false, binding->host_swizzle);
       }
       if (binding->texture_signed &&
           texture_util::IsAnySignSigned(binding->swizzled_signs)) {
         d3d12_binding.descriptor_index_signed = FindOrCreateTextureDescriptor(
-            *static_cast<D3D12Texture*>(binding->texture_signed), true,
-            binding->host_swizzle);
+            *static_cast<D3D12Texture*>(binding->texture_signed),
+            binding->key.dimension, true, binding->host_swizzle);
       }
     } else {
       D3D12Texture* texture = static_cast<D3D12Texture*>(binding->texture);
       if (texture) {
         if (texture_util::IsAnySignNotSigned(binding->swizzled_signs)) {
           d3d12_binding.descriptor_index = FindOrCreateTextureDescriptor(
-              *texture, false, binding->host_swizzle);
+              *texture, binding->key.dimension, false, binding->host_swizzle);
         }
         if (texture_util::IsAnySignSigned(binding->swizzled_signs)) {
           d3d12_binding.descriptor_index_signed = FindOrCreateTextureDescriptor(
-              *texture, true, binding->host_swizzle);
+              *texture, binding->key.dimension, true, binding->host_swizzle);
         }
       }
     }
   }
 }
 
+ID3D12Resource* D3D12TextureCache::D3D12Texture::GetOrCreate3DAs2DResource(
+    D3D12_RESOURCE_STATES end_state) {
+  if (!cvars::gpu_3d_to_2d_texture) {
+    return nullptr;
+  }
+
+  auto& d3d12_cache = static_cast<D3D12TextureCache&>(texture_cache());
+
+  // If cached, transition and return.
+  if (texture_3d_as_2d_) {
+    d3d12_cache.command_processor_.PushTransitionBarrier(
+        texture_3d_as_2d_->resource(),
+        texture_3d_as_2d_->SetResourceState(end_state), end_state);
+    return texture_3d_as_2d_->resource();
+  }
+
+  const ui::d3d12::D3D12Provider& provider =
+      d3d12_cache.command_processor_.GetD3D12Provider();
+  ID3D12Device* device = provider.GetDevice();
+
+  D3D12_RESOURCE_DESC source_desc = resource_->GetDesc();
+  D3D12_RESOURCE_DESC desc = source_desc;
+  desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+  desc.DepthOrArraySize = 1;
+  desc.MipLevels = 1;
+  desc.Alignment = 0;
+  desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+  desc.Flags = D3D12_RESOURCE_FLAG_NONE;
+
+  D3D12_RESOURCE_STATES initial_state = D3D12_RESOURCE_STATE_COPY_DEST;
+  Microsoft::WRL::ComPtr<ID3D12Resource> resource_2d;
+
+  if (FAILED(device->CreateCommittedResource(
+          &ui::d3d12::util::kHeapPropertiesDefault,
+          provider.GetHeapFlagCreateNotZeroed(), &desc, initial_state, nullptr,
+          IID_PPV_ARGS(&resource_2d)))) {
+    XELOGE("D3D12Texture: Failed to create 3D-as-2D resource");
+    return nullptr;
+  }
+
+  // Create a modified key for the 2D wrapper with depth=1 and mip_max_level=0.
+  // Keep dimension as k3D so guest layout uses 3D tiling math to correctly
+  // read slice 0 from the 3D-tiled guest memory.
+  TextureKey key_2d = key();
+  key_2d.depth_or_array_size_minus_1 = 0;
+  key_2d.mip_max_level = 0;
+
+  texture_3d_as_2d_.reset(new D3D12Texture(
+      d3d12_cache, key_2d, resource_2d.Get(), initial_state, false));
+
+  if (!d3d12_cache.LoadTextureData(*texture_3d_as_2d_)) {
+    XELOGE("D3D12Texture: Failed to load 3D-as-2D texture data");
+    texture_3d_as_2d_.reset();
+    return nullptr;
+  }
+
+  // Transition to requested state.
+  d3d12_cache.command_processor_.PushTransitionBarrier(
+      texture_3d_as_2d_->resource(),
+      texture_3d_as_2d_->SetResourceState(end_state), end_state);
+
+  return texture_3d_as_2d_->resource();
+}
+
 uint32_t D3D12TextureCache::FindOrCreateTextureDescriptor(
-    D3D12Texture& texture, bool is_signed, uint32_t host_swizzle) {
+    D3D12Texture& texture, xenos::DataDimension dimension, bool is_signed,
+    uint32_t host_swizzle) {
   D3D12Texture::SRVDescriptorKey descriptor_key;
+  descriptor_key.key = 0;
   descriptor_key.is_signed = uint32_t(is_signed);
   descriptor_key.host_swizzle = host_swizzle;
+  descriptor_key.dimension = uint32_t(dimension);
 
   // Try to find an existing descriptor.
   uint32_t existing_descriptor_index =
@@ -1797,7 +1924,7 @@ uint32_t D3D12TextureCache::FindOrCreateTextureDescriptor(
   TextureKey texture_key = texture.key();
 
   // Create a new bindless or cached descriptor if supported.
-  D3D12_SHADER_RESOURCE_VIEW_DESC desc;
+  D3D12_SHADER_RESOURCE_VIEW_DESC desc = {};  // Zero out struct
 
   if (IsSignedVersionSeparateForFormat(texture_key) &&
       texture_key.signed_separate != uint32_t(is_signed)) {
@@ -1819,34 +1946,44 @@ uint32_t D3D12TextureCache::FindOrCreateTextureDescriptor(
   }
 
   uint32_t mip_levels = texture_key.mip_max_level + 1;
-  switch (texture_key.dimension) {
-    case xenos::DataDimension::k1D:
-    case xenos::DataDimension::k2DOrStacked:
-      desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DARRAY;
+  ID3D12Resource* resource_for_view = texture.resource();
+
+  if (dimension == xenos::DataDimension::k3D) {
+    desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE3D;
+    desc.Texture3D.MostDetailedMip = 0;
+    desc.Texture3D.MipLevels = mip_levels;
+    desc.Texture3D.ResourceMinLODClamp = 0.0f;
+  } else if (dimension == xenos::DataDimension::kCube) {
+    desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURECUBE;
+    desc.TextureCube.MostDetailedMip = 0;
+    desc.TextureCube.MipLevels = mip_levels;
+    desc.TextureCube.ResourceMinLODClamp = 0.0f;
+  } else {
+    desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DARRAY;
+    if (texture_key.dimension == xenos::DataDimension::k3D) {
+      resource_for_view = texture.GetOrCreate3DAs2DResource(
+          D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+      if (!resource_for_view) {
+        return UINT32_MAX;
+      }
+
+      // Configure SRV for the new 2D resource
+      desc.Texture2DArray.MostDetailedMip = 0;
+      desc.Texture2DArray.MipLevels = 1;
+      desc.Texture2DArray.FirstArraySlice = 0;
+      desc.Texture2DArray.ArraySize = 1;
+      desc.Texture2DArray.PlaneSlice = 0;
+      desc.Texture2DArray.ResourceMinLODClamp = 0.0f;
+    } else {
+      // Standard behavior
       desc.Texture2DArray.MostDetailedMip = 0;
       desc.Texture2DArray.MipLevels = mip_levels;
       desc.Texture2DArray.FirstArraySlice = 0;
       desc.Texture2DArray.ArraySize = texture_key.GetDepthOrArraySize();
       desc.Texture2DArray.PlaneSlice = 0;
       desc.Texture2DArray.ResourceMinLODClamp = 0.0f;
-      break;
-    case xenos::DataDimension::k3D:
-      desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE3D;
-      desc.Texture3D.MostDetailedMip = 0;
-      desc.Texture3D.MipLevels = mip_levels;
-      desc.Texture3D.ResourceMinLODClamp = 0.0f;
-      break;
-    case xenos::DataDimension::kCube:
-      desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURECUBE;
-      desc.TextureCube.MostDetailedMip = 0;
-      desc.TextureCube.MipLevels = mip_levels;
-      desc.TextureCube.ResourceMinLODClamp = 0.0f;
-      break;
-    default:
-      assert_unhandled_case(texture_key.dimension);
-      return UINT32_MAX;
+    }
   }
-
   desc.Shader4ComponentMapping =
       host_swizzle |
       D3D12_SHADER_COMPONENT_MAPPING_ALWAYS_SET_BIT_AVOIDING_ZEROMEM_MISTAKES;
@@ -1894,7 +2031,7 @@ uint32_t D3D12TextureCache::FindOrCreateTextureDescriptor(
     }
   }
   device->CreateShaderResourceView(
-      texture.resource(), &desc,
+      resource_for_view, &desc,
       GetTextureDescriptorCPUHandle(descriptor_index));
   texture.AddSRVDescriptorIndex(descriptor_key, descriptor_index);
   return descriptor_index;

--- a/src/xenia/gpu/d3d12/d3d12_texture_cache.h
+++ b/src/xenia/gpu/d3d12/d3d12_texture_cache.h
@@ -551,6 +551,7 @@ class D3D12TextureCache final : public TextureCache {
       struct {
         uint32_t is_signed : 1;
         uint32_t host_swizzle : 12;
+        uint32_t dimension : 2;
       };
 
       SRVDescriptorKey() : key(0) { static_assert_size(*this, sizeof(key)); }
@@ -568,9 +569,13 @@ class D3D12TextureCache final : public TextureCache {
       }
     };
 
+    ID3D12Resource* GetOrCreate3DAs2DResource(D3D12_RESOURCE_STATES end_state);
+
+    // track_usage: if false, texture won't participate in LRU cache eviction.
     explicit D3D12Texture(D3D12TextureCache& texture_cache,
                           const TextureKey& key, ID3D12Resource* resource,
-                          D3D12_RESOURCE_STATES resource_state);
+                          D3D12_RESOURCE_STATES resource_state,
+                          bool track_usage = true);
     ~D3D12Texture();
 
     ID3D12Resource* resource() const { return resource_.Get(); }
@@ -594,6 +599,10 @@ class D3D12TextureCache final : public TextureCache {
    private:
     Microsoft::WRL::ComPtr<ID3D12Resource> resource_;
     D3D12_RESOURCE_STATES resource_state_;
+
+    // Cached 2D view of the first slice, managed as a standalone texture
+    // object.
+    std::unique_ptr<D3D12Texture> texture_3d_as_2d_;
 
     // For bindful - indices in the non-shader-visible descriptor cache for
     // copying to the shader-visible heap (much faster than recreating, which,
@@ -717,7 +726,8 @@ class D3D12TextureCache final : public TextureCache {
       case xenos::FetchOpDimension::k1D:
       case xenos::FetchOpDimension::k2D:
         return resource_dimension == xenos::DataDimension::k1D ||
-               resource_dimension == xenos::DataDimension::k2DOrStacked;
+               resource_dimension == xenos::DataDimension::k2DOrStacked ||
+               resource_dimension == xenos::DataDimension::k3D;
       case xenos::FetchOpDimension::k3DOrStacked:
         return resource_dimension == xenos::DataDimension::k3D;
       case xenos::FetchOpDimension::kCube:
@@ -730,8 +740,9 @@ class D3D12TextureCache final : public TextureCache {
   // Returns the index of an existing of a newly created non-shader-visible
   // cached (for bindful) or a shader-visible global (for bindless) descriptor,
   // or UINT32_MAX if failed to create.
-  uint32_t FindOrCreateTextureDescriptor(D3D12Texture& texture, bool is_signed,
-                                         uint32_t host_swizzle);
+  uint32_t FindOrCreateTextureDescriptor(D3D12Texture& texture,
+                                         xenos::DataDimension dimension,
+                                         bool is_signed, uint32_t host_swizzle);
   void ReleaseTextureDescriptor(uint32_t descriptor_index);
   D3D12_CPU_DESCRIPTOR_HANDLE GetTextureDescriptorCPUHandle(
       uint32_t descriptor_index) const;

--- a/src/xenia/gpu/gpu_flags.cc
+++ b/src/xenia/gpu/gpu_flags.cc
@@ -89,3 +89,8 @@ DEFINE_bool(no_discard_stencil_in_transfer_pipelines, false,
             "Skip stencil bit discard in render target transfer pipelines. "
             "May improve performance on some GPUs.",
             "GPU");
+
+DEFINE_bool(gpu_3d_to_2d_texture, true,
+            "Handle shaders that sample 3D textures as 2D by creating a 2D "
+            "texture from slice 0 of the guest memory.",
+            "GPU");

--- a/src/xenia/gpu/gpu_flags.h
+++ b/src/xenia/gpu/gpu_flags.h
@@ -36,6 +36,8 @@ DECLARE_bool(disassemble_pm4);
 
 DECLARE_bool(no_discard_stencil_in_transfer_pipelines);
 
+DECLARE_bool(gpu_3d_to_2d_texture);
+
 #define XE_GPU_FINE_GRAINED_DRAW_SCOPES 1
 
 #endif  // XENIA_GPU_GPU_FLAGS_H_

--- a/src/xenia/gpu/texture_cache.cc
+++ b/src/xenia/gpu/texture_cache.cc
@@ -504,7 +504,7 @@ void TextureCache::Texture::LogAction(const char* action) const {
 // performed somehow. The list is maintained by the Texture, not the
 // TextureCache itself (unlike the `textures_` container).
 TextureCache::Texture::Texture(TextureCache& texture_cache,
-                               const TextureKey& key)
+                               const TextureKey& key, bool track_usage)
     : texture_cache_(texture_cache),
       key_(key),
       guest_layout_(key.GetGuestLayout()),
@@ -512,14 +512,17 @@ TextureCache::Texture::Texture(TextureCache& texture_cache,
       mips_resolved_(key.scaled_resolve),
       last_usage_submission_index_(texture_cache.current_submission_index_),
       last_usage_time_(texture_cache.current_submission_time_),
-      used_previous_(texture_cache.texture_used_last_),
-      used_next_(nullptr) {
-  if (texture_cache.texture_used_last_) {
-    texture_cache.texture_used_last_->used_next_ = this;
-  } else {
-    texture_cache.texture_used_first_ = this;
+      used_previous_(track_usage ? texture_cache.texture_used_last_ : nullptr),
+      used_next_(nullptr),
+      in_usage_list_(track_usage) {
+  if (track_usage) {
+    if (texture_cache.texture_used_last_) {
+      texture_cache.texture_used_last_->used_next_ = this;
+    } else {
+      texture_cache.texture_used_first_ = this;
+    }
+    texture_cache.texture_used_last_ = this;
   }
-  texture_cache.texture_used_last_ = this;
 
   // Never try to upload data that doesn't exist.
   base_outdated_ = guest_layout().base.level_data_extent_bytes != 0;
@@ -534,15 +537,18 @@ TextureCache::Texture::~Texture() {
     texture_cache().shared_memory().UnwatchMemoryRange(base_watch_handle_);
   }
 
-  if (used_previous_) {
-    used_previous_->used_next_ = used_next_;
-  } else {
-    texture_cache_.texture_used_first_ = used_next_;
-  }
-  if (used_next_) {
-    used_next_->used_previous_ = used_previous_;
-  } else {
-    texture_cache_.texture_used_last_ = used_previous_;
+  // Only remove from usage list if we were added to it (track_usage=true).
+  if (in_usage_list_) {
+    if (used_previous_) {
+      used_previous_->used_next_ = used_next_;
+    } else {
+      texture_cache_.texture_used_first_ = used_next_;
+    }
+    if (used_next_) {
+      used_next_->used_previous_ = used_previous_;
+    } else {
+      texture_cache_.texture_used_last_ = used_previous_;
+    }
   }
 
   texture_cache_.UpdateTexturesTotalHostMemoryUsage(0, host_memory_usage_);
@@ -568,6 +574,10 @@ void TextureCache::Texture::MakeUpToDateAndWatch(
 }
 
 void TextureCache::Texture::MarkAsUsed() {
+  // Textures not in usage tracking (track_usage=false) should not be linked.
+  if (!in_usage_list_) {
+    return;
+  }
   assert_true(last_usage_submission_index_ <=
               texture_cache_.current_submission_index_);
   // This is called very frequently, don't relink unless needed for caching.

--- a/src/xenia/gpu/texture_cache.h
+++ b/src/xenia/gpu/texture_cache.h
@@ -251,6 +251,11 @@ class TextureCache {
       return guest_layout().mips_total_extent_bytes;
     }
 
+    // For 3D-as-2D wrappers: the host texture is 2D but we need 3D tiling
+    // when loading from guest memory.
+    bool force_load_3d_tiling() const { return force_load_3d_tiling_; }
+    void SetForceLoad3DTiling(bool force) { force_load_3d_tiling_ = force; }
+
     uint64_t GetHostMemoryUsage() const { return host_memory_usage_; }
 
     uint64_t last_usage_submission_index() const {
@@ -294,7 +299,11 @@ class TextureCache {
     void LogAction(const char* action) const;
 
    protected:
-    explicit Texture(TextureCache& texture_cache, const TextureKey& key);
+    // track_usage: if false, the texture won't be added to the LRU tracking
+    // list. Use this for wrapper textures that shouldn't participate in cache
+    // eviction (like texture_3d_as_2d_ wrappers).
+    explicit Texture(TextureCache& texture_cache, const TextureKey& key,
+                     bool track_usage = true);
 
     void SetHostMemoryUsage(uint64_t new_host_memory_usage) {
       texture_cache_.UpdateTexturesTotalHostMemoryUsage(new_host_memory_usage,
@@ -315,6 +324,13 @@ class TextureCache {
     uint64_t last_usage_time_;
     Texture* used_previous_;
     Texture* used_next_;
+    // Whether this texture is in the usage tracking list (for LRU eviction).
+    // Set to false via constructor for wrapper textures.
+    bool in_usage_list_;
+
+    // For 3D-as-2D wrappers: use 3D tiling when loading even though the host
+    // texture is 2D.
+    bool force_load_3d_tiling_ = false;
 
     // Whether the most up-to-date base / mips contain pages with data from a
     // resolve operation (rather than from the CPU or memexport), primarily for

--- a/src/xenia/gpu/vulkan/vulkan_texture_cache.cc
+++ b/src/xenia/gpu/vulkan/vulkan_texture_cache.cc
@@ -605,14 +605,37 @@ void VulkanTextureCache::RequestTextures(uint32_t used_texture_mask) {
 
 VkImageView VulkanTextureCache::GetActiveBindingOrNullImageView(
     uint32_t fetch_constant_index, xenos::FetchOpDimension dimension,
-    bool is_signed) const {
+    bool is_signed) {
   VkImageView image_view = VK_NULL_HANDLE;
   const TextureBinding* binding = GetValidTextureBinding(fetch_constant_index);
   if (binding && AreDimensionsCompatible(dimension, binding->key.dimension)) {
-    const VulkanTextureBinding& vulkan_binding =
-        vulkan_texture_bindings_[fetch_constant_index];
-    image_view = is_signed ? vulkan_binding.image_view_signed
-                           : vulkan_binding.image_view_unsigned;
+    // Check for 3D texture sampled as 2D.
+    bool force_special_view =
+        (dimension == xenos::FetchOpDimension::k2D &&
+         binding->key.dimension == xenos::DataDimension::k3D);
+
+    if (force_special_view) {
+      // Get the appropriate texture for signed/unsigned.
+      // Respect swizzled_signs from fetch constant, not just shader request.
+      Texture* texture = nullptr;
+      bool use_signed =
+          is_signed && texture_util::IsAnySignSigned(binding->swizzled_signs);
+      if (use_signed && IsSignedVersionSeparateForFormat(binding->key)) {
+        texture = binding->texture_signed;
+      } else {
+        texture = binding->texture;
+      }
+      if (texture) {
+        image_view =
+            static_cast<VulkanTexture*>(texture)->GetOrCreate3DAs2DImageView(
+                use_signed, binding->host_swizzle);
+      }
+    } else {
+      const VulkanTextureBinding& vulkan_binding =
+          vulkan_texture_bindings_[fetch_constant_index];
+      image_view = is_signed ? vulkan_binding.image_view_signed
+                             : vulkan_binding.image_view_unsigned;
+    }
   }
   if (image_view != VK_NULL_HANDLE) {
     return image_view;
@@ -1079,6 +1102,7 @@ std::unique_ptr<TextureCache::Texture> VulkanTextureCache::CreateTexture(
   image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
   image_create_info.usage =
       VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+
   // For scaled resolve textures with mips, we need transfer source to generate
   // mip levels via blit from the base level.
   if (key.scaled_resolve && key.mip_max_level > 0) {
@@ -1149,7 +1173,11 @@ bool VulkanTextureCache::LoadTextureDataFromResidentMemoryImpl(Texture& texture,
   const texture_util::TextureGuestLayout& guest_layout =
       vulkan_texture.guest_layout();
   xenos::DataDimension dimension = texture_key.dimension;
+  // Whether the host image is 3D (determines depth vs array layer layout).
   bool is_3d = dimension == xenos::DataDimension::k3D;
+  // Whether to use 3D tiling when reading from guest memory.
+  // For 3D-as-2D wrappers, the host image is 2D but we need 3D tiling.
+  bool is_3d_tiling = is_3d || vulkan_texture.force_load_3d_tiling();
   uint32_t width = texture_key.GetWidth();
   uint32_t height = texture_key.GetHeight();
   uint32_t depth_or_array_size = texture_key.GetDepthOrArraySize();
@@ -1455,7 +1483,7 @@ bool VulkanTextureCache::LoadTextureDataFromResidentMemoryImpl(Texture& texture,
   assert_true(texture_resolution_scale_x <= 7);
   assert_true(texture_resolution_scale_y <= 7);
   load_constants.is_tiled_3d_endian_scale =
-      uint32_t(texture_key.tiled) | (uint32_t(is_3d) << 1) |
+      uint32_t(texture_key.tiled) | (uint32_t(is_3d_tiling) << 1) |
       (uint32_t(texture_key.endianness) << 2) |
       (texture_resolution_scale_x << 4) | (texture_resolution_scale_y << 7);
 
@@ -1765,8 +1793,10 @@ void VulkanTextureCache::UpdateTextureBindingsImpl(
 
 VulkanTextureCache::VulkanTexture::VulkanTexture(
     VulkanTextureCache& texture_cache, const TextureKey& key, VkImage image,
-    VmaAllocation allocation)
-    : Texture(texture_cache, key), image_(image), allocation_(allocation) {
+    VmaAllocation allocation, bool track_usage)
+    : Texture(texture_cache, key, track_usage),
+      image_(image),
+      allocation_(allocation) {
   VmaAllocationInfo allocation_info;
   vmaGetAllocationInfo(texture_cache.vma_allocator_, allocation_,
                        &allocation_info);
@@ -1783,6 +1813,15 @@ VulkanTextureCache::VulkanTexture::~VulkanTexture() {
   for (const auto& view_pair : views_) {
     dfn.vkDestroyImageView(device, view_pair.second, nullptr);
   }
+  // Clean up 3D-as-2D image views. The texture_3d_as_2d_ wrapper will clean
+  // itself up via unique_ptr destructor.
+  if (image_view_3d_as_2d_unsigned_ != VK_NULL_HANDLE) {
+    dfn.vkDestroyImageView(device, image_view_3d_as_2d_unsigned_, nullptr);
+  }
+  if (image_view_3d_as_2d_signed_ != VK_NULL_HANDLE) {
+    dfn.vkDestroyImageView(device, image_view_3d_as_2d_signed_, nullptr);
+  }
+  // texture_3d_as_2d_ is a unique_ptr and will destroy its image/allocation.
   vmaDestroyImage(vulkan_texture_cache.vma_allocator_, image_, allocation_);
 }
 
@@ -1875,6 +1914,135 @@ VkImageView VulkanTextureCache::VulkanTexture::GetView(bool is_signed,
   }
   views_.emplace(view_key, view);
   return view;
+}
+
+VkImageView VulkanTextureCache::VulkanTexture::GetOrCreate3DAs2DImageView(
+    bool is_signed, uint32_t host_swizzle) {
+  if (!cvars::gpu_3d_to_2d_texture) {
+    return VK_NULL_HANDLE;
+  }
+
+  // Return cached view if available.
+  VkImageView& cached_view =
+      is_signed ? image_view_3d_as_2d_signed_ : image_view_3d_as_2d_unsigned_;
+  if (cached_view != VK_NULL_HANDLE) {
+    return cached_view;
+  }
+
+  VulkanTextureCache& vulkan_texture_cache =
+      static_cast<VulkanTextureCache&>(texture_cache());
+
+  // Create the 2D texture wrapper if it doesn't exist.
+  if (!texture_3d_as_2d_) {
+    const HostFormatPair& host_format_pair =
+        vulkan_texture_cache.GetHostFormatPair(key());
+    VkFormat format = host_format_pair.format_unsigned.format;
+    if (format == VK_FORMAT_UNDEFINED) {
+      return VK_NULL_HANDLE;
+    }
+
+    VkImageCreateInfo image_create_info = {};
+    image_create_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    image_create_info.imageType = VK_IMAGE_TYPE_2D;
+    image_create_info.format = format;
+    image_create_info.extent.width = key().GetWidth();
+    image_create_info.extent.height = key().GetHeight();
+    image_create_info.extent.depth = 1;
+    image_create_info.mipLevels = 1;
+    image_create_info.arrayLayers = 1;
+    image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
+    image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
+    image_create_info.usage =
+        VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+    image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+    VmaAllocationCreateInfo allocation_create_info = {};
+    allocation_create_info.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+
+    VkImage image_2d;
+    VmaAllocation allocation_2d;
+    if (vmaCreateImage(vulkan_texture_cache.vma_allocator_, &image_create_info,
+                       &allocation_create_info, &image_2d, &allocation_2d,
+                       nullptr) != VK_SUCCESS) {
+      XELOGE("VulkanTexture: Failed to create 3D-as-2D image");
+      return VK_NULL_HANDLE;
+    }
+
+    // Create a modified key for the 2D wrapper with depth=1 and
+    // mip_max_level=0. Keep dimension as k3D so guest layout uses 3D tiling
+    // math to correctly read slice 0 from the 3D-tiled guest memory.
+    TextureKey key_2d = key();
+    key_2d.depth_or_array_size_minus_1 = 0;
+    key_2d.mip_max_level = 0;
+
+    // Create the wrapper first so LoadTextureData can work with it.
+    texture_3d_as_2d_.reset(new VulkanTexture(vulkan_texture_cache, key_2d,
+                                              image_2d, allocation_2d, false));
+
+    if (!vulkan_texture_cache.LoadTextureData(*texture_3d_as_2d_)) {
+      XELOGE("VulkanTexture: Failed to load 3D-as-2D texture data");
+      texture_3d_as_2d_.reset();
+      return VK_NULL_HANDLE;
+    }
+
+    // LoadTextureData leaves the texture in TRANSFER_DST state.
+    // Transition to shader read state.
+    DeferredCommandBuffer& command_buffer =
+        vulkan_texture_cache.command_processor_.deferred_command_buffer();
+    VkImageMemoryBarrier barrier_to_shader = {};
+    barrier_to_shader.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barrier_to_shader.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    barrier_to_shader.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+    barrier_to_shader.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    barrier_to_shader.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    barrier_to_shader.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier_to_shader.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier_to_shader.image = texture_3d_as_2d_->image();
+    barrier_to_shader.subresourceRange =
+        ui::vulkan::util::InitializeSubresourceRange();
+    command_buffer.CmdVkPipelineBarrier(
+        VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+        0, 0, nullptr, 0, nullptr, 1, &barrier_to_shader);
+    texture_3d_as_2d_->SetUsage(Usage::kGuestShaderSampled);
+  }
+
+  // Create the image view.
+  const ui::vulkan::VulkanDevice* const vulkan_device =
+      vulkan_texture_cache.command_processor_.GetVulkanDevice();
+  const ui::vulkan::VulkanDevice::Functions& dfn = vulkan_device->functions();
+  const VkDevice device = vulkan_device->device();
+
+  const HostFormatPair& host_format_pair =
+      vulkan_texture_cache.GetHostFormatPair(key());
+  VkFormat format = (is_signed ? host_format_pair.format_signed
+                               : host_format_pair.format_unsigned)
+                        .format;
+  if (format == VK_FORMAT_UNDEFINED) {
+    return VK_NULL_HANDLE;
+  }
+
+  VkImageViewCreateInfo view_create_info = {};
+  view_create_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+  view_create_info.image = texture_3d_as_2d_->image();
+  // Use 2D_ARRAY to match shader expectations (Dim = 2D, Arrayed = 1).
+  view_create_info.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+  view_create_info.format = format;
+  view_create_info.components.r = GetComponentSwizzle(host_swizzle, 0);
+  view_create_info.components.g = GetComponentSwizzle(host_swizzle, 1);
+  view_create_info.components.b = GetComponentSwizzle(host_swizzle, 2);
+  view_create_info.components.a = GetComponentSwizzle(host_swizzle, 3);
+  view_create_info.subresourceRange =
+      ui::vulkan::util::InitializeSubresourceRange();
+  view_create_info.subresourceRange.layerCount = 1;
+
+  if (dfn.vkCreateImageView(device, &view_create_info, nullptr, &cached_view) !=
+      VK_SUCCESS) {
+    XELOGE("VulkanTexture: Failed to create 3D-as-2D image view");
+    return VK_NULL_HANDLE;
+  }
+
+  return cached_view;
 }
 
 VulkanTextureCache::VulkanTextureCache(
@@ -2801,6 +2969,9 @@ void VulkanTextureCache::GetTextureUsageMasks(VulkanTexture::Usage usage,
   layout = VK_IMAGE_LAYOUT_UNDEFINED;
   switch (usage) {
     case VulkanTexture::Usage::kUndefined:
+      // For UNDEFINED layout, use TOP_OF_PIPE as source stage (wait for
+      // nothing) with no access mask (discarding old contents).
+      stage_mask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
       break;
     case VulkanTexture::Usage::kTransferDestination:
       stage_mask = VK_PIPELINE_STAGE_TRANSFER_BIT;

--- a/src/xenia/gpu/vulkan/vulkan_texture_cache.h
+++ b/src/xenia/gpu/vulkan/vulkan_texture_cache.h
@@ -92,7 +92,7 @@ class VulkanTextureCache final : public TextureCache {
 
   VkImageView GetActiveBindingOrNullImageView(uint32_t fetch_constant_index,
                                               xenos::FetchOpDimension dimension,
-                                              bool is_signed) const;
+                                              bool is_signed);
 
   SamplerParameters GetSamplerParameters(
       const VulkanShader::SamplerBinding& binding) const;
@@ -254,9 +254,10 @@ class VulkanTextureCache final : public TextureCache {
     };
 
     // Takes ownership of the image and its memory.
+    // track_usage: if false, texture won't participate in LRU cache eviction.
     explicit VulkanTexture(VulkanTextureCache& texture_cache,
                            const TextureKey& key, VkImage image,
-                           VmaAllocation allocation);
+                           VmaAllocation allocation, bool track_usage = true);
     ~VulkanTexture();
 
     VkImage image() const { return image_; }
@@ -270,6 +271,10 @@ class VulkanTextureCache final : public TextureCache {
 
     VkImageView GetView(bool is_signed, uint32_t host_swizzle,
                         bool is_array = true);
+
+    // For 3D textures sampled as 2D - creates a 2D copy of slice 0.
+    VkImageView GetOrCreate3DAs2DImageView(bool is_signed,
+                                           uint32_t host_swizzle);
 
    private:
     union ViewKey {
@@ -331,6 +336,12 @@ class VulkanTextureCache final : public TextureCache {
     Usage usage_ = Usage::kUndefined;
 
     std::unordered_map<ViewKey, VkImageView, ViewKey::Hasher> views_;
+
+    // For 3D textures sampled as 2D - cached 2D texture loaded from slice 0.
+    // Uses a modified key (depth=1) with 3D tiling to read from guest memory.
+    std::unique_ptr<VulkanTexture> texture_3d_as_2d_;
+    VkImageView image_view_3d_as_2d_unsigned_ = VK_NULL_HANDLE;
+    VkImageView image_view_3d_as_2d_signed_ = VK_NULL_HANDLE;
   };
 
   struct VulkanTextureBinding {
@@ -359,7 +370,8 @@ class VulkanTextureCache final : public TextureCache {
       case xenos::FetchOpDimension::k1D:
       case xenos::FetchOpDimension::k2D:
         return resource_dimension == xenos::DataDimension::k1D ||
-               resource_dimension == xenos::DataDimension::k2DOrStacked;
+               resource_dimension == xenos::DataDimension::k2DOrStacked ||
+               resource_dimension == xenos::DataDimension::k3D;
       case xenos::FetchOpDimension::k3DOrStacked:
         return resource_dimension == xenos::DataDimension::k3D;
       case xenos::FetchOpDimension::kCube:


### PR DESCRIPTION
This PR fixes a rendering issue with 3D models with fur rendered with shell texturing (specifically character skins in games like #4D5307DF rendered as black (issue [#6](https://github.com/xenia-canary/game-compatibility/issues/6)).

BEFORE
<img width="1272" height="707" alt="immagine" src="https://github.com/user-attachments/assets/480cb6b6-4a3e-4ab7-a2d9-eca25cc60f23" />
<img width="1261" height="701" alt="immagine" src="https://github.com/user-attachments/assets/f9c9ea42-0585-4aa0-b928-5215286ae480" />

AFTER
<img width="1264" height="708" alt="immagine" src="https://github.com/user-attachments/assets/da5cc8c4-5d16-4a74-99a1-073341300a7e" />
<img width="1270" height="708" alt="immagine" src="https://github.com/user-attachments/assets/f336e474-d245-4712-ab88-76df6095ec7e" />

I have managed to debug this error because i have thoroughly reverse engineered the texture files this game uses, and came to the realization that for this kind of models where a fur was to be rendered, a 3D texture was loaded. This 3D texture also contained, at its first layer, the texture to be applied to the skin of such models. It is very likely then that the Xenos GPU allows shaders to sample a 3D texture using a 2D sampler (treating it as a 2D array). However, D3D12 does not allow creating a Texture2DArray SRV for a Texture3D resource.

Previously, Xenia attempted to create an invalid SRV or bind the 3D resource to a 2D slot, resulting in no resources being passed to the pixel shader, resulting in this black rendering.

I solved this problem by implementing a "Copy-on-Demand" mechanism in D3D12TextureCache:

- In FindOrCreateTextureDescriptor, we now detect if a shader requests a k2D view for a resource that is actually k3D.

- Instead of creating an invalid view, we call GetOrCreate3DAs2DResource.

- This helper creates a temporary, single-slice Texture2D and issues a CopyTextureRegion command.

- A D3D12_BOX is used with back=1 to ensure only Depth Slice 0 is copied. Copying the full volume to a single slice was previously causing upload buffer corruption.

- The 2D alias is cached in the D3D12Texture object and reused for subsequent frames.

- Added Clear3DAs2DResource to LoadTextureDataFromResidentMemoryImpl to ensure the alias is discarded if the guest game updates the parent 3D texture.


Technical Changes:

- Updated SRVDescriptorKey to include dimension in the hash to prevent collisions between 2D and 3D views of the same asset.

- Added descriptor_key.key = 0 initialization to prevent stack garbage from causing descriptor leaks.


From my testing ( GPU NVIDIA RTX 3060 Ti, game #4D5307DF) the performance impact is negligible. 