### PR TITLE
[Build] Hack to support VS 2026 preview in the build

### DIFF
--- a/xenia-build.py
+++ b/xenia-build.py
@@ -547,6 +547,10 @@ def run_platform_premake(target_os_override=None, cc=None, devenv=None):
             devenv = "xcode4"
         elif target_os == "windows":
             vs_version = os.getenv("VSVERSION", VSVERSION_MINIMUM)
+            # VS 2026 preview reports as vs18, map to vs2022 for premake
+            # as it doesn't yet have a vs2026 target
+            if vs_version == "18":
+                vs_version = "2022"
             devenv = f"vs{vs_version}"
         elif target_os == "android":
             devenv = "androidndk"


### PR DESCRIPTION
Simply force version detection to id it as 2022 for now until there is an official target for vs2026