### PR TITLE
[GPU] Fix variable shadowing for SV_SampleIndex semantic name

### DIFF
--- a/src/xenia/gpu/dxbc_shader_translator.cc
+++ b/src/xenia/gpu/dxbc_shader_translator.cc
@@ -2898,7 +2898,7 @@ void DxbcShaderTranslator::WriteInputSignature() {
     // shading.
     size_t sample_index_position = SIZE_MAX;
     if (current_shader().memexport_eM_written() && IsSampleRate()) {
-      size_t sample_index_position = shader_object_.size();
+      sample_index_position = shader_object_.size();
       shader_object_.resize(shader_object_.size() + kParameterDwords);
       ++parameter_count;
       {


### PR DESCRIPTION
Due to variable never properly updating the semantic name pointer for SV_SampleIndex is never set, this means the generated DXBC shader has a SV_SampleIndex input parameter with semantic_name_ptr = 0, which points to garbage or the wrong semantic name (likely the first semantic in the blob, probably "TEXCOORD"?).

This is probably almost always okay in practice since in the driver the SV_SampleIndex is identified by system_value and not by its semantic name string, but could cause some validation problems in certain contexts.

The fix should be safe to apply.