### PR TITLE
[XBDM] Implement DmQueryTitleMemoryStatistics

### DIFF
--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_memory.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_memory.cc
@@ -557,32 +557,7 @@ dword_result_t MmQueryAllocationSize_entry(lpvoid_t base_address) {
 }
 DECLARE_XBOXKRNL_EXPORT1(MmQueryAllocationSize, kMemory, kImplemented);
 
-// https://code.google.com/p/vdash/source/browse/trunk/vdash/include/kernel.h
-struct X_MM_QUERY_STATISTICS_SECTION {
-  xe::be<uint32_t> available_pages;
-  xe::be<uint32_t> total_virtual_memory_bytes;
-  xe::be<uint32_t> reserved_virtual_memory_bytes;
-  xe::be<uint32_t> physical_pages;
-  xe::be<uint32_t> pool_pages;
-  xe::be<uint32_t> stack_pages;
-  xe::be<uint32_t> image_pages;
-  xe::be<uint32_t> heap_pages;
-  xe::be<uint32_t> virtual_pages;
-  xe::be<uint32_t> page_table_pages;
-  xe::be<uint32_t> cache_pages;
-};
-
-struct X_MM_QUERY_STATISTICS_RESULT {
-  xe::be<uint32_t> size;
-  xe::be<uint32_t> total_physical_pages;
-  xe::be<uint32_t> kernel_pages;
-  X_MM_QUERY_STATISTICS_SECTION title;
-  X_MM_QUERY_STATISTICS_SECTION system;
-  xe::be<uint32_t> highest_physical_page;
-};
-static_assert_size(X_MM_QUERY_STATISTICS_RESULT, 104);
-
-dword_result_t MmQueryStatistics_entry(
+dword_result_t xeMmQueryStatistics(
     pointer_t<X_MM_QUERY_STATISTICS_RESULT> stats_ptr) {
   if (!stats_ptr) {
     return X_STATUS_INVALID_PARAMETER;
@@ -648,6 +623,11 @@ dword_result_t MmQueryStatistics_entry(
   stats_ptr->highest_physical_page = 0x0001FFFF;
 
   return X_STATUS_SUCCESS;
+}
+
+dword_result_t MmQueryStatistics_entry(
+    pointer_t<X_MM_QUERY_STATISTICS_RESULT> stats_ptr) {
+  return xeMmQueryStatistics(stats_ptr);
 }
 DECLARE_XBOXKRNL_EXPORT2(MmQueryStatistics, kMemory, kImplemented,
                          kHighFrequency);

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_memory.h
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_memory.h
@@ -17,11 +17,38 @@ namespace xe {
 namespace kernel {
 namespace xboxkrnl {
 
+// https://code.google.com/p/vdash/source/browse/trunk/vdash/include/kernel.h
+struct X_MM_QUERY_STATISTICS_SECTION {
+  xe::be<uint32_t> available_pages;
+  xe::be<uint32_t> total_virtual_memory_bytes;
+  xe::be<uint32_t> reserved_virtual_memory_bytes;
+  xe::be<uint32_t> physical_pages;
+  xe::be<uint32_t> pool_pages;
+  xe::be<uint32_t> stack_pages;
+  xe::be<uint32_t> image_pages;
+  xe::be<uint32_t> heap_pages;
+  xe::be<uint32_t> virtual_pages;
+  xe::be<uint32_t> page_table_pages;
+  xe::be<uint32_t> cache_pages;
+};
+
+struct X_MM_QUERY_STATISTICS_RESULT {
+  xe::be<uint32_t> size;
+  xe::be<uint32_t> total_physical_pages;
+  xe::be<uint32_t> kernel_pages;
+  X_MM_QUERY_STATISTICS_SECTION title;
+  X_MM_QUERY_STATISTICS_SECTION system;
+  xe::be<uint32_t> highest_physical_page;
+};
+static_assert_size(X_MM_QUERY_STATISTICS_RESULT, 104);
+
 uint32_t xeMmAllocatePhysicalMemoryEx(uint32_t flags, uint32_t region_size,
                                       uint32_t protect_bits,
                                       uint32_t min_addr_range,
                                       uint32_t max_addr_range,
                                       uint32_t alignment);
+dword_result_t xeMmQueryStatistics(
+    pointer_t<X_MM_QUERY_STATISTICS_RESULT> stats_ptr);
 uint32_t xeAllocatePoolTypeWithTag(PPCContext* context, uint32_t size,
                                    uint32_t tag, uint32_t zero);
 

--- a/src/xenia/xbox.h
+++ b/src/xenia/xbox.h
@@ -26,6 +26,7 @@ typedef uint32_t X_HANDLE;
 // https://msdn.microsoft.com/en-us/library/cc704588.aspx
 // Adding as needed.
 typedef uint32_t X_STATUS;
+#define X_FACILITY_NT_BIT 0x10000000
 #define XSUCCEEDED(s)     ((s & 0xC0000000) == 0)
 #define XFAILED(s)        (!XSUCCEEDED(s))
 #define X_STATUS_SUCCESS                                ((X_STATUS)0x00000000L)
@@ -111,6 +112,7 @@ typedef uint32_t X_RESULT;
 
 // HRESULT codes
 typedef uint32_t X_HRESULT;
+#define X_HRESULT_FROM_NT(x) (static_cast<X_HRESULT>((x) | X_FACILITY_NT_BIT))
 #define X_HRESULT_FROM_WIN32(x) ((int32_t)(x) <= 0 \
                                   ? (static_cast<X_HRESULT>(x)) \
                                   : (static_cast<X_HRESULT>(((x) & 0xFFFF) | (X_FACILITY_WIN32 << 16) | \


### PR DESCRIPTION
I didn't find a way to access the structure and function definitions from xboxkrnl_memory.cc from xbdm_misc.cc file. As a workaround I copied them into into xbdm_misc.cc. If someone know how to get rid of double definition of these structures and function declaration, please let me know how to fix this.