### PR TITLE
[D3D12] Simplify Intel Arc GPU checking

### DIFF
--- a/src/xenia/gpu/d3d12/d3d12_render_target_cache.cc
+++ b/src/xenia/gpu/d3d12/d3d12_render_target_cache.cc
@@ -223,6 +223,9 @@ bool D3D12RenderTargetCache::Initialize() {
     // UHD Graphics 630), the "always" stencil comparison function isn't working
     // properly, so clears in the Xbox 360's Direct3D 9 don't work. Forcing ROV
     // there.
+    // As of December 2025, Intel pre-Arc still suffers from this issue.
+    // Intel Arc (Alchemist and newer) does not have this issue so an
+    // exception is made so they default to RTV.
 #if 1
     // The ROV path is currently much slower generally.
     // TODO(Triang3l): Make ROV the default when it's optimized better (for
@@ -446,8 +449,10 @@ bool D3D12RenderTargetCache::Initialize() {
   use_stencil_reference_output_ =
       cvars::native_stencil_value_output &&
       provider.IsPSSpecifiedStencilReferenceSupported() &&
-      (cvars::native_stencil_value_output_d3d12_intel ||
-       !provider.IsIntelArcGpu());
+      (provider.IsIntelArcGpu() ||
+       cvars::native_stencil_value_output_d3d12_intel ||
+       provider.GetAdapterVendorID() !=
+           ui::GraphicsProvider::GpuVendorID::kIntel);
 
   if (path_ == Path::kHostRenderTargets) {
     // Host render targets.

--- a/src/xenia/ui/d3d12/d3d12_provider.cc
+++ b/src/xenia/ui/d3d12/d3d12_provider.cc
@@ -47,6 +47,20 @@ bool D3D12Provider::IsD3D12APIAvailable() {
   return true;
 }
 
+const std::string& D3D12Provider::GetAdapterDescription() const {
+  return adapter_description_;
+}
+
+// Check for Intel Arc cards and Intel Graphics iGPUs which use
+// the same architecture.
+bool D3D12Provider::IsIntelArcGpu() const {
+  if (adapter_vendor_id_ != GpuVendorID::kIntel) {
+    return false;
+  }
+  return adapter_description_.starts_with("Intel(R) Arc(TM)") ||
+         adapter_description_.starts_with("Intel(R) Graphics");
+}
+
 std::unique_ptr<D3D12Provider> D3D12Provider::Create() {
   std::unique_ptr<D3D12Provider> provider(new D3D12Provider);
   if (!provider->Initialize()) {
@@ -300,6 +314,7 @@ bool D3D12Provider::Initialize() {
     if (WideCharToMultiByte(CP_UTF8, 0, adapter_desc.Description, -1,
                             adapter_name_mb, adapter_name_mb_size, nullptr,
                             nullptr) != 0) {
+      adapter_description_ = adapter_name_mb;
       XELOGD3D("DXGI adapter: {} (vendor 0x{:04X}, device 0x{:04X})",
                adapter_name_mb, adapter_desc.VendorId, adapter_desc.DeviceId);
     }

--- a/src/xenia/ui/d3d12/d3d12_provider.h
+++ b/src/xenia/ui/d3d12/d3d12_provider.h
@@ -97,43 +97,8 @@ class D3D12Provider : public GraphicsProvider {
   // Adapter info.
   GpuVendorID GetAdapterVendorID() const { return adapter_vendor_id_; }
 
-  bool IsIntelArcGpu() const {
-    if (adapter_vendor_id_ != GpuVendorID::kIntel) {
-      return false;
-    }
-
-    // Desktop IDs - Alchemist
-    if (adapter_device_id_ >= 0x56A0 && adapter_device_id_ <= 0x56BD) {
-      return true;
-    }
-
-    // Mobile IDs - Alchemist
-    if (adapter_device_id_ >= 0x5690 && adapter_device_id_ <= 0x5697) {
-      return true;
-    }
-
-    // Desktop IDs - Battlemage
-    if (adapter_device_id_ >= 0xE20B && adapter_device_id_ <= 0xE20C) {
-      return true;
-    }
-
-    // Meteor Lake
-    if (adapter_device_id_ >= 0x7D40 && adapter_device_id_ <= 0x7DD5) {
-      return true;
-    }
-
-    // Lunar Lake
-    if (adapter_device_id_ >= 0x6420 && adapter_device_id_ <= 0x64B0) {
-      return true;
-    }
-
-    // Arrow Lake
-    if (adapter_device_id_ >= 0x7D41 && adapter_device_id_ <= 0x7D67) {
-      return true;
-    }
-
-    return false;
-  }
+  const std::string& GetAdapterDescription() const;
+  bool IsIntelArcGpu() const;
 
   // Device features.
   D3D12_HEAP_FLAGS GetHeapFlagCreateNotZeroed() const {
@@ -232,6 +197,7 @@ class D3D12Provider : public GraphicsProvider {
 
   GpuVendorID adapter_vendor_id_;
   uint32_t adapter_device_id_;
+  std::string adapter_description_;
 
   D3D12_HEAP_FLAGS heap_flag_create_not_zeroed_;
   D3D12_PROGRAMMABLE_SAMPLE_POSITIONS_TIER programmable_sample_positions_tier_;


### PR DESCRIPTION
Added function GetAdapterDescription() and rewrote IsIntelArcGpu to refer to the adapter description in order to be identified. This allows for future proofing when newer models of Arc GPUs release compared to the current code which relies on device ID checking. I also changed it so native_stencil_value_output_d3d12_intel is successfully ignored for Intel Arc GPUs.

Tested and works as expected (defaults to RTV and does not set native stencil to false) on an Intel Core Ultra 7 155H with Intel Arc Graphics driver 32.0.101.8331.