### PR TITLE
[UI]: fix ASAN errors

### DIFF
--- a/src/xenia/app/emulator_window.cc
+++ b/src/xenia/app/emulator_window.cc
@@ -703,7 +703,8 @@ void EmulatorWindow::XMPConfigDialog::OnDraw(ImGuiIO& io) {
   ImGui::End();
 
   if (!dialog_open) {
-    emulator_window_.ToggleXMPConfigDialog();
+    Close();
+    emulator_window_.xmp_config_dialog_.release();
     return;
   }
 }

--- a/src/xenia/app/profile_dialogs.cc
+++ b/src/xenia/app/profile_dialogs.cc
@@ -29,7 +29,7 @@ void NoProfileDialog::OnDraw(ImGuiIO& io) {
                              ->profile_manager();
 
   if (profile_manager->GetAccountCount()) {
-    delete this;
+    Close();
     return;
   }
 


### PR DESCRIPTION
Fix two ASAN errors:

```
=================================================================
==15532==ERROR: AddressSanitizer: heap-use-after-free on address 0x117bdca6d1d0 at pc 0x7ff79a7c8c90 bp 0x00567e94d240 sp 0x00567e94d248
READ of size 1 at 0x117bdca6d1d0 thread T0
==15532==WARNING: Failed to use and restart external symbolizer!
==15532==*** WARNING: Failed to initialize DbgHelp!              ***
==15532==*** Most likely this means that the app is already      ***
==15532==*** using DbgHelp, possibly with incompatible flags.    ***
==15532==*** Due to technical reasons, symbolization might crash ***
==15532==*** or produce wrong results.                           ***
    #0 0x7ff79a7c8c8f in xe::ui::ImGuiDialog::Draw C:\src\xenia-canary\src\xenia\ui\imgui_dialog.cc:49
    #1 0x7ff79a7555fc in xe::ui::ImGuiDrawer::Draw C:\src\xenia-canary\src\xenia\ui\imgui_drawer.cc:617
    #2 0x7ff79a715f4c in xe::ui::Presenter::ExecuteUIDrawersFromUIThread C:\src\xenia-canary\src\xenia\ui\presenter.cc:1051
    #3 0x7ff79c5ac9d7 in xe::ui::d3d12::D3D12Presenter::PaintAndPresentImpl C:\src\xenia-canary\src\xenia\ui\d3d12\d3d12_presenter.cc:1036
    #4 0x7ff79a717b99 in xe::ui::Presenter::PaintAndPresent C:\src\xenia-canary\src\xenia\ui\presenter.cc:1278
    #5 0x7ff79a70fa54 in xe::ui::Presenter::PaintFromUIThread C:\src\xenia-canary\src\xenia\ui\presenter.cc:285
    #6 0x7ff79a734125 in xe::ui::Window::OnPaint C:\src\xenia-canary\src\xenia\ui\window.cc:540
    #7 0x7ff79a70770d in xe::ui::Win32Window::WndProc C:\src\xenia-canary\src\xenia\ui\window_win.cc:1068
    #8 0x7ff79a706867 in xe::ui::Win32Window::WndProcThunk C:\src\xenia-canary\src\xenia\ui\window_win.cc:1264
    #9 0x7ff9a3ff7845 in CallWindowProcW+0x6a5 (C:\WINDOWS\System32\USER32.dll+0x180017845)
    #10 0x7ff9a3ff70cb in SendMessageW+0xacb (C:\WINDOWS\System32\USER32.dll+0x1800170cb)
    #11 0x7ff9a4027e92 in GetWindowDpiAwarenessContext+0x1f2 (C:\WINDOWS\System32\USER32.dll+0x180047e92)
    #12 0x7ff9a5885be3 in KiUserCallbackDispatcher+0x23 (C:\WINDOWS\SYSTEM32\ntdll.dll+0x180165be3)
    #13 0x7ff9a29f18c3 in NtUserDispatchMessage+0x13 (C:\WINDOWS\System32\win32u.dll+0x1800018c3)
    #14 0x7ff9a3ff5507 in IsWindowUnicode+0x537 (C:\WINDOWS\System32\USER32.dll+0x180015507)
    #15 0x7ff79a7e11fb in xe::ui::Win32WindowedAppContext::RunMainMessageLoop C:\src\xenia-canary\src\xenia\ui\windowed_app_context_win.cc:130
    #16 0x7ff79a232499 in wWinMain C:\src\xenia-canary\src\xenia\ui\windowed_app_main_win.cc:327
    #17 0x7ff79bb50dc1 in invoke_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:118
    #18 0x7ff79bb50ce1 in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #19 0x7ff79bb50b9d in __scrt_common_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:330
    #20 0x7ff79bb50e3d in wWinMainCRTStartup D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_wwinmain.cpp:16
    #21 0x7ff9a3b8e8d6 in BaseThreadInitThunk+0x16 (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #22 0x7ff9a57ac53b in RtlUserThreadStart+0x2b (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c53b)

0x117bdca6d1d0 is located 16 bytes inside of 64-byte region [0x117bdca6d1c0,0x117bdca6d200)
freed by thread T0 here:
    #0 0x7ff79bb4f433 in operator delete D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win_delete_scalar_size_thunk.cpp:41
    #1 0x7ff79a0cadb0 in xe::app::NoProfileDialog::`scalar deleting destructor'+0x30 (C:\src\xenia-canary\build\bin\Windows\Checked\xenia_canary.exe+0x1402cadb0)
    #2 0x7ff79a1bc71b in xe::app::NoProfileDialog::OnDraw C:\src\xenia-canary\src\xenia\app\profile_dialogs.cc:32
    #3 0x7ff79a7c8c39 in xe::ui::ImGuiDialog::Draw C:\src\xenia-canary\src\xenia\ui\imgui_dialog.cc:45
    #4 0x7ff79a7555fc in xe::ui::ImGuiDrawer::Draw C:\src\xenia-canary\src\xenia\ui\imgui_drawer.cc:617
    #5 0x7ff79a715f4c in xe::ui::Presenter::ExecuteUIDrawersFromUIThread C:\src\xenia-canary\src\xenia\ui\presenter.cc:1051
    #6 0x7ff79c5ac9d7 in xe::ui::d3d12::D3D12Presenter::PaintAndPresentImpl C:\src\xenia-canary\src\xenia\ui\d3d12\d3d12_presenter.cc:1036
    #7 0x7ff79a717b99 in xe::ui::Presenter::PaintAndPresent C:\src\xenia-canary\src\xenia\ui\presenter.cc:1278
    #8 0x7ff79a70fa54 in xe::ui::Presenter::PaintFromUIThread C:\src\xenia-canary\src\xenia\ui\presenter.cc:285
    #9 0x7ff79a734125 in xe::ui::Window::OnPaint C:\src\xenia-canary\src\xenia\ui\window.cc:540
    #10 0x7ff79a70770d in xe::ui::Win32Window::WndProc C:\src\xenia-canary\src\xenia\ui\window_win.cc:1068
    #11 0x7ff79a706867 in xe::ui::Win32Window::WndProcThunk C:\src\xenia-canary\src\xenia\ui\window_win.cc:1264
    #12 0x7ff9a3ff7845 in CallWindowProcW+0x6a5 (C:\WINDOWS\System32\USER32.dll+0x180017845)
    #13 0x7ff9a3ff70cb in SendMessageW+0xacb (C:\WINDOWS\System32\USER32.dll+0x1800170cb)
    #14 0x7ff9a4027e92 in GetWindowDpiAwarenessContext+0x1f2 (C:\WINDOWS\System32\USER32.dll+0x180047e92)
    #15 0x7ff9a5885be3 in KiUserCallbackDispatcher+0x23 (C:\WINDOWS\SYSTEM32\ntdll.dll+0x180165be3)
    #16 0x7ff9a29f18c3 in NtUserDispatchMessage+0x13 (C:\WINDOWS\System32\win32u.dll+0x1800018c3)
    #17 0x7ff9a3ff5507 in IsWindowUnicode+0x537 (C:\WINDOWS\System32\USER32.dll+0x180015507)
    #18 0x7ff79a7e11fb in xe::ui::Win32WindowedAppContext::RunMainMessageLoop C:\src\xenia-canary\src\xenia\ui\windowed_app_context_win.cc:130
    #19 0x7ff79a232499 in wWinMain C:\src\xenia-canary\src\xenia\ui\windowed_app_main_win.cc:327
    #20 0x7ff79bb50dc1 in invoke_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:118
    #21 0x7ff79bb50ce1 in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #22 0x7ff79bb50b9d in __scrt_common_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:330
    #23 0x7ff79bb50e3d in wWinMainCRTStartup D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_wwinmain.cpp:16
    #24 0x7ff9a3b8e8d6 in BaseThreadInitThunk+0x16 (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #25 0x7ff9a57ac53b in RtlUserThreadStart+0x2b (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c53b)

previously allocated by thread T0 here:
    #0 0x7ff79bb4f315 in operator new D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win_new_scalar_thunk.cpp:40
    #1 0x7ff799f573a6 in xe::app::EmulatorWindow::OnEmulatorInitialized C:\src\xenia-canary\src\xenia\app\emulator_window.cc:254
    #2 0x7ff79a1dd799 in `xe::app::EmulatorApp::EmulatorThread'::`2'::<lambda_7>::operator() C:\src\xenia-canary\src\xenia\app\xenia_main.cc:693
    #3 0x7ff79a1faf0e in std::invoke<`xe::app::EmulatorApp::EmulatorThread'::`2'::<lambda_7> &> C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\type_traits:1670
    #4 0x7ff79a1df256 in std::_Func_impl_no_alloc<`xe::app::EmulatorApp::EmulatorThread'::`2'::<lambda_7>,void>::_Do_call C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\functional:880
    #5 0x7ff79a1cbbf2 in std::_Func_class<void>::operator() C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\functional:926
    #6 0x7ff79a727704 in xe::ui::WindowedAppContext::ExecutePendingFunctionsFromUIThread C:\src\xenia-canary\src\xenia\ui\windowed_app_context.cc:157
    #7 0x7ff79a2364d0 in xe::ui::WindowedAppContext::ExecutePendingFunctionsFromUIThread C:\src\xenia-canary\src\xenia\ui\windowed_app_context.h:81
    #8 0x7ff79a7e135c in xe::ui::Win32WindowedAppContext::PendingFunctionsWndProc C:\src\xenia-canary\src\xenia\ui\windowed_app_context_win.cc:159
    #9 0x7ff9a3ff7845 in CallWindowProcW+0x6a5 (C:\WINDOWS\System32\USER32.dll+0x180017845)
    #10 0x7ff9a3ff539c in IsWindowUnicode+0x3cc (C:\WINDOWS\System32\USER32.dll+0x18001539c)
    #11 0x7ff79a7e11fb in xe::ui::Win32WindowedAppContext::RunMainMessageLoop C:\src\xenia-canary\src\xenia\ui\windowed_app_context_win.cc:130
    #12 0x7ff79a232499 in wWinMain C:\src\xenia-canary\src\xenia\ui\windowed_app_main_win.cc:327
    #13 0x7ff79bb50dc1 in invoke_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:118
    #14 0x7ff79bb50ce1 in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #15 0x7ff79bb50b9d in __scrt_common_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:330
    #16 0x7ff79bb50e3d in wWinMainCRTStartup D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_wwinmain.cpp:16
    #17 0x7ff9a3b8e8d6 in BaseThreadInitThunk+0x16 (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #18 0x7ff9a57ac53b in RtlUserThreadStart+0x2b (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c53b)

SUMMARY: AddressSanitizer: heap-use-after-free C:\src\xenia-canary\src\xenia\ui\imgui_dialog.cc:49 in xe::ui::ImGuiDialog::Draw
Shadow bytes around the buggy address:
  0x117bdca6cf00: fa fa fa fa 00 00 00 00 00 00 00 fa fa fa fa fa
  0x117bdca6cf80: 00 00 00 00 00 00 00 00 fa fa fa fa fd fd fd fd
  0x117bdca6d000: fd fd fd fd fa fa fa fa fd fd fd fd fd fd fd fd
  0x117bdca6d080: fa fa fa fa fd fd fd fd fd fd fd fd fa fa fa fa
  0x117bdca6d100: fd fd fd fd fd fd fd fd fa fa fa fa fd fd fd fd
=>0x117bdca6d180: fd fd fd fd fa fa fa fa fd fd[fd]fd fd fd fd fd
  0x117bdca6d200: fa fa fa fa fd fd fd fd fd fd fd fd fa fa fa fa
  0x117bdca6d280: 00 00 00 00 00 00 00 00 fa fa fa fa fd fd fd fd
  0x117bdca6d300: fd fd fd fd fa fa fa fa fd fd fd fd fd fd fd fd
  0x117bdca6d380: fa fa fa fa fd fd fd fd fd fd fd fa fa fa fa fa
  0x117bdca6d400: fd fd fd fd fd fd fd fd fa fa fa fa fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
Address Sanitizer Error: Use of deallocated memory

==15532==ABORTING
```

```
=================================================================
==3816==ERROR: AddressSanitizer: heap-use-after-free on address 0x11f8b0be7d10 at pc 0x7ff699668c60 bp 0x00e19ab1d3a0 sp 0x00e19ab1d3a8
READ of size 1 at 0x11f8b0be7d10 thread T0
==3816==WARNING: Failed to use and restart external symbolizer!
==3816==*** WARNING: Failed to initialize DbgHelp!              ***
==3816==*** Most likely this means that the app is already      ***
==3816==*** using DbgHelp, possibly with incompatible flags.    ***
==3816==*** Due to technical reasons, symbolization might crash ***
==3816==*** or produce wrong results.                           ***
    #0 0x7ff699668c5f in xe::ui::ImGuiDialog::Draw C:\src\xenia-canary\src\xenia\ui\imgui_dialog.cc:49
    #1 0x7ff6995f55cc in xe::ui::ImGuiDrawer::Draw C:\src\xenia-canary\src\xenia\ui\imgui_drawer.cc:617
    #2 0x7ff6995b5f1c in xe::ui::Presenter::ExecuteUIDrawersFromUIThread C:\src\xenia-canary\src\xenia\ui\presenter.cc:1051
    #3 0x7ff69b44c9a7 in xe::ui::d3d12::D3D12Presenter::PaintAndPresentImpl C:\src\xenia-canary\src\xenia\ui\d3d12\d3d12_presenter.cc:1036
    #4 0x7ff6995b7b69 in xe::ui::Presenter::PaintAndPresent C:\src\xenia-canary\src\xenia\ui\presenter.cc:1278
    #5 0x7ff6995afa24 in xe::ui::Presenter::PaintFromUIThread C:\src\xenia-canary\src\xenia\ui\presenter.cc:285
    #6 0x7ff6995d40f5 in xe::ui::Window::OnPaint C:\src\xenia-canary\src\xenia\ui\window.cc:540
    #7 0x7ff6995a76dd in xe::ui::Win32Window::WndProc C:\src\xenia-canary\src\xenia\ui\window_win.cc:1068
    #8 0x7ff6995a6837 in xe::ui::Win32Window::WndProcThunk C:\src\xenia-canary\src\xenia\ui\window_win.cc:1264
    #9 0x7ff9a3ff7845 in CallWindowProcW+0x6a5 (C:\WINDOWS\System32\USER32.dll+0x180017845)
    #10 0x7ff9a3ff70cb in SendMessageW+0xacb (C:\WINDOWS\System32\USER32.dll+0x1800170cb)
    #11 0x7ff9a4027e92 in GetWindowDpiAwarenessContext+0x1f2 (C:\WINDOWS\System32\USER32.dll+0x180047e92)
    #12 0x7ff9a5885be3 in KiUserCallbackDispatcher+0x23 (C:\WINDOWS\SYSTEM32\ntdll.dll+0x180165be3)
    #13 0x7ff9a29f18c3 in NtUserDispatchMessage+0x13 (C:\WINDOWS\System32\win32u.dll+0x1800018c3)
    #14 0x7ff9a3ff5507 in IsWindowUnicode+0x537 (C:\WINDOWS\System32\USER32.dll+0x180015507)
    #15 0x7ff6996811cb in xe::ui::Win32WindowedAppContext::RunMainMessageLoop C:\src\xenia-canary\src\xenia\ui\windowed_app_context_win.cc:130
    #16 0x7ff6990d2469 in wWinMain C:\src\xenia-canary\src\xenia\ui\windowed_app_main_win.cc:327
    #17 0x7ff69a9f0d91 in invoke_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:118
    #18 0x7ff69a9f0cb1 in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #19 0x7ff69a9f0b6d in __scrt_common_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:330
    #20 0x7ff69a9f0e0d in wWinMainCRTStartup D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_wwinmain.cpp:16
    #21 0x7ff9a3b8e8d6 in BaseThreadInitThunk+0x16 (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #22 0x7ff9a57ac53b in RtlUserThreadStart+0x2b (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c53b)

0x11f8b0be7d10 is located 16 bytes inside of 72-byte region [0x11f8b0be7d00,0x11f8b0be7d48)
freed by thread T0 here:
    #0 0x7ff69a9ef403 in operator delete D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win_delete_scalar_size_thunk.cpp:41
    #1 0x7ff698f6af70 in xe::app::EmulatorWindow::XMPConfigDialog::`scalar deleting destructor'+0x30 (C:\src\xenia-canary\build\bin\Windows\Checked\xenia_canary.exe+0x1402caf70)
    #2 0x7ff698f65f3b in std::default_delete<xe::app::EmulatorWindow::XMPConfigDialog>::operator() C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\memory:3309
    #3 0x7ff69904ae29 in std::unique_ptr<xe::app::EmulatorWindow::XMPConfigDialog,std::default_delete<xe::app::EmulatorWindow::XMPConfigDialog> >::reset C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\memory:3471
    #4 0x7ff698dfc3f4 in xe::app::EmulatorWindow::ToggleXMPConfigDialog C:\src\xenia-canary\src\xenia\app\emulator_window.cc:1554
    #5 0x7ff698dffa11 in xe::app::EmulatorWindow::XMPConfigDialog::OnDraw C:\src\xenia-canary\src\xenia\app\emulator_window.cc:706
    #6 0x7ff699668c09 in xe::ui::ImGuiDialog::Draw C:\src\xenia-canary\src\xenia\ui\imgui_dialog.cc:45
    #7 0x7ff6995f55cc in xe::ui::ImGuiDrawer::Draw C:\src\xenia-canary\src\xenia\ui\imgui_drawer.cc:617
    #8 0x7ff6995b5f1c in xe::ui::Presenter::ExecuteUIDrawersFromUIThread C:\src\xenia-canary\src\xenia\ui\presenter.cc:1051
    #9 0x7ff69b44c9a7 in xe::ui::d3d12::D3D12Presenter::PaintAndPresentImpl C:\src\xenia-canary\src\xenia\ui\d3d12\d3d12_presenter.cc:1036
    #10 0x7ff6995b7b69 in xe::ui::Presenter::PaintAndPresent C:\src\xenia-canary\src\xenia\ui\presenter.cc:1278
    #11 0x7ff6995afa24 in xe::ui::Presenter::PaintFromUIThread C:\src\xenia-canary\src\xenia\ui\presenter.cc:285
    #12 0x7ff6995d40f5 in xe::ui::Window::OnPaint C:\src\xenia-canary\src\xenia\ui\window.cc:540
    #13 0x7ff6995a76dd in xe::ui::Win32Window::WndProc C:\src\xenia-canary\src\xenia\ui\window_win.cc:1068
    #14 0x7ff6995a6837 in xe::ui::Win32Window::WndProcThunk C:\src\xenia-canary\src\xenia\ui\window_win.cc:1264
    #15 0x7ff9a3ff7845 in CallWindowProcW+0x6a5 (C:\WINDOWS\System32\USER32.dll+0x180017845)
    #16 0x7ff9a3ff70cb in SendMessageW+0xacb (C:\WINDOWS\System32\USER32.dll+0x1800170cb)
    #17 0x7ff9a4027e92 in GetWindowDpiAwarenessContext+0x1f2 (C:\WINDOWS\System32\USER32.dll+0x180047e92)
    #18 0x7ff9a5885be3 in KiUserCallbackDispatcher+0x23 (C:\WINDOWS\SYSTEM32\ntdll.dll+0x180165be3)
    #19 0x7ff9a29f18c3 in NtUserDispatchMessage+0x13 (C:\WINDOWS\System32\win32u.dll+0x1800018c3)
    #20 0x7ff9a3ff5507 in IsWindowUnicode+0x537 (C:\WINDOWS\System32\USER32.dll+0x180015507)
    #21 0x7ff6996811cb in xe::ui::Win32WindowedAppContext::RunMainMessageLoop C:\src\xenia-canary\src\xenia\ui\windowed_app_context_win.cc:130
    #22 0x7ff6990d2469 in wWinMain C:\src\xenia-canary\src\xenia\ui\windowed_app_main_win.cc:327
    #23 0x7ff69a9f0d91 in invoke_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:118
    #24 0x7ff69a9f0cb1 in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #25 0x7ff69a9f0b6d in __scrt_common_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:330
    #26 0x7ff69a9f0e0d in wWinMainCRTStartup D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_wwinmain.cpp:16
    #27 0x7ff9a3b8e8d6 in BaseThreadInitThunk+0x16 (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #28 0x7ff9a57ac53b in RtlUserThreadStart+0x2b (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c53b)

previously allocated by thread T0 here:
    #0 0x7ff69a9ef2e5 in operator new D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win_new_scalar_thunk.cpp:40
    #1 0x7ff698dfc30f in xe::app::EmulatorWindow::ToggleXMPConfigDialog C:\src\xenia-canary\src\xenia\app\emulator_window.cc:1551
    #2 0x7ff698ed7bb0 in std::invoke<void (__cdecl xe::app::EmulatorWindow::*&)(void),xe::app::EmulatorWindow * &> C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\type_traits:1686
    #3 0x7ff698e415f8 in std::_Invoker_ret<std::_Unforced>::_Call<void (__cdecl xe::app::EmulatorWindow::*&)(void),xe::app::EmulatorWindow * &> C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\functional:2117
    #4 0x7ff698e416c5 in std::_Call_binder<std::_Unforced,0,void (__cdecl xe::app::EmulatorWindow::*)(void),std::tuple<xe::app::EmulatorWindow *>,std::tuple<> > C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\functional:2127
    #5 0x7ff698e360d9 in std::_Binder<std::_Unforced,void (__cdecl xe::app::EmulatorWindow::*)(void),xe::app::EmulatorWindow *>::operator()<> C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\functional:2181
    #6 0x7ff698ed7e4e in std::invoke<std::_Binder<std::_Unforced,void (__cdecl xe::app::EmulatorWindow::*)(void),xe::app::EmulatorWindow *> &> C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\type_traits:1670
    #7 0x7ff698f97c16 in std::_Func_impl_no_alloc<std::_Binder<std::_Unforced,void (__cdecl xe::app::EmulatorWindow::*)(void),xe::app::EmulatorWindow *>,void>::_Do_call C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\functional:880
    #8 0x7ff69906bbc2 in std::_Func_class<void>::operator() C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\functional:926
    #9 0x7ff699598af2 in xe::ui::MenuItem::OnSelected C:\src\xenia-canary\src\xenia\ui\menu_item.cc:67
    #10 0x7ff6995a80d8 in xe::ui::Win32Window::WndProc C:\src\xenia-canary\src\xenia\ui\window_win.cc:1210
    #11 0x7ff6995a6837 in xe::ui::Win32Window::WndProcThunk C:\src\xenia-canary\src\xenia\ui\window_win.cc:1264
    #12 0x7ff9a3ff7845 in CallWindowProcW+0x6a5 (C:\WINDOWS\System32\USER32.dll+0x180017845)
    #13 0x7ff9a3ff539c in IsWindowUnicode+0x3cc (C:\WINDOWS\System32\USER32.dll+0x18001539c)
    #14 0x7ff6996811cb in xe::ui::Win32WindowedAppContext::RunMainMessageLoop C:\src\xenia-canary\src\xenia\ui\windowed_app_context_win.cc:130
    #15 0x7ff6990d2469 in wWinMain C:\src\xenia-canary\src\xenia\ui\windowed_app_main_win.cc:327
    #16 0x7ff69a9f0d91 in invoke_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:118
    #17 0x7ff69a9f0cb1 in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #18 0x7ff69a9f0b6d in __scrt_common_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:330
    #19 0x7ff69a9f0e0d in wWinMainCRTStartup D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_wwinmain.cpp:16
    #20 0x7ff9a3b8e8d6 in BaseThreadInitThunk+0x16 (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #21 0x7ff9a57ac53b in RtlUserThreadStart+0x2b (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c53b)

SUMMARY: AddressSanitizer: heap-use-after-free C:\src\xenia-canary\src\xenia\ui\imgui_dialog.cc:49 in xe::ui::ImGuiDialog::Draw
Shadow bytes around the buggy address:
  0x11f8b0be7a80: 00 00 00 00 00 fa fa fa fa fa fd fd fd fd fd fd
  0x11f8b0be7b00: fd fd fd fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x11f8b0be7b80: fd fd fa fa fa fa 00 00 00 00 00 00 00 00 06 fa
  0x11f8b0be7c00: fa fa fa fa 00 00 00 00 00 00 00 00 00 fa fa fa
  0x11f8b0be7c80: fa fa fd fd fd fd fd fd fd fd fd fa fa fa fa fa
=>0x11f8b0be7d00: fd fd[fd]fd fd fd fd fd fd fa fa fa fa fa fd fd
  0x11f8b0be7d80: fd fd fd fd fd fd fd fd fa fa fa fa fd fd fd fd
  0x11f8b0be7e00: fd fd fd fd fd fd fa fa fa fa fd fd fd fd fd fd
  0x11f8b0be7e80: fd fd fd fd fa fa fa fa fd fd fd fd fd fd fd fd
  0x11f8b0be7f00: fd fd fa fa fa fa fd fd fd fd fd fd fd fd fd fa
  0x11f8b0be7f80: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
Address Sanitizer Error: Use of deallocated memory
==3816==ABORTING
```