### PR TITLE
[VFS/Posix] Fix Rename to properly handle guest paths

### DIFF
--- a/src/xenia/vfs/devices/host_path_entry.h
+++ b/src/xenia/vfs/devices/host_path_entry.h
@@ -51,7 +51,8 @@ class HostPathEntry : public Entry {
   std::unique_ptr<Entry> CreateEntryInternal(const std::string_view name,
                                              uint32_t attributes) override;
   bool DeleteEntryInternal(Entry* entry) override;
-  void RenameEntryInternal(const std::filesystem::path file_path) override;
+  void RenameEntryInternal(
+      const std::vector<std::string_view>& path_parts) override;
 
   std::filesystem::path host_path_;
 };

--- a/src/xenia/vfs/entry.cc
+++ b/src/xenia/vfs/entry.cc
@@ -135,19 +135,19 @@ void Entry::Touch() {
 }
 
 void Entry::Rename(const std::filesystem::path file_path) {
-  std::vector<std::string_view> splitted_path =
-      xe::utf8::split_path(xe::path_to_utf8(file_path));
+  // Store the string to ensure string_views from split_path remain valid
+  const std::string path_str = xe::path_to_utf8(file_path);
+  std::vector<std::string_view> path_parts = xe::utf8::split_path(path_str);
 
-  splitted_path.erase(splitted_path.begin());
+  // Remove the root (e.g., "cache:")
+  path_parts.erase(path_parts.begin());
 
-  const std::string guest_path_without_root =
-      xe::utf8::join_guest_paths(splitted_path);
+  RenameEntryInternal(path_parts);
 
-  RenameEntryInternal(guest_path_without_root);
-
-  absolute_path_ = xe::utf8::join_guest_paths(device_->mount_path(),
-                                              guest_path_without_root);
-  path_ = guest_path_without_root;
+  const std::string guest_path = xe::utf8::join_guest_paths(path_parts);
+  absolute_path_ =
+      xe::utf8::join_guest_paths(device_->mount_path(), guest_path);
+  path_ = guest_path;
   name_ = xe::path_to_utf8(file_path.filename());
 }
 

--- a/src/xenia/vfs/entry.h
+++ b/src/xenia/vfs/entry.h
@@ -141,7 +141,8 @@ class Entry {
     return nullptr;
   }
   virtual bool DeleteEntryInternal(Entry* entry) = 0;
-  virtual void RenameEntryInternal(const std::filesystem::path file_path) {}
+  virtual void RenameEntryInternal(
+      const std::vector<std::string_view>& path_parts) {}
 
   xe::global_critical_region global_critical_region_;
   Device* device_;


### PR DESCRIPTION
And ensure string_views aren't pointing at freed memory by saving a reference to the result of path_to_utf8.

Issue reproducible when booting JP version of Blue Dragon disc 2 (path being renamed contains random garbage from freed mem)