### PR TITLE
[GPU] Add configurable anisotropic filtering override.

### DIFF
--- a/src/xenia/gpu/dxbc_shader_translator.cc
+++ b/src/xenia/gpu/dxbc_shader_translator.cc
@@ -17,6 +17,7 @@
 #include "xenia/base/cvar.h"
 #include "xenia/base/math.h"
 #include "xenia/gpu/dxbc_shader.h"
+#include "xenia/gpu/gpu_flags.h"
 #include "xenia/gpu/xenos.h"
 #include "xenia/ui/graphics_provider.h"
 
@@ -1378,7 +1379,10 @@ void DxbcShaderTranslator::PostTranslation() {
       shader_binding.mag_filter = translator_binding.mag_filter;
       shader_binding.min_filter = translator_binding.min_filter;
       shader_binding.mip_filter = translator_binding.mip_filter;
-      shader_binding.aniso_filter = translator_binding.aniso_filter;
+      shader_binding.aniso_filter =
+          cvars::anisotropic_override > -1 && cvars::anisotropic_override < 6
+              ? xenos::AnisoFilter(cvars::anisotropic_override)
+              : translator_binding.aniso_filter;
     }
   }
 }

--- a/src/xenia/gpu/gpu_flags.cc
+++ b/src/xenia/gpu/gpu_flags.cc
@@ -70,3 +70,15 @@ DEFINE_int32(
     "Set to higher number than query_occlusion_sample_lower_threshold. This "
     "value is ignored if query_occlusion_sample_lower_threshold is set to -1.",
     "GPU");
+
+DEFINE_int32(anisotropic_override, -1,
+             "Level of anisotropic filtering enforced on all texture fetch "
+             "instructions.\n"
+             " -1 = No override\n"
+             "  0 = Disable anisotropic filtering\n"
+             "  1 = Force 1x anisotropic filtering\n"
+             "  2 = Force 2x anisotropic filtering\n"
+             "  3 = Force 4x anisotropic filtering\n"
+             "  4 = Force 8x anisotropic filtering\n"
+             "  5 = Force 16x anisotropic filtering",
+             "GPU");

--- a/src/xenia/gpu/gpu_flags.h
+++ b/src/xenia/gpu/gpu_flags.h
@@ -30,6 +30,8 @@ DECLARE_int32(query_occlusion_sample_lower_threshold);
 
 DECLARE_int32(query_occlusion_sample_upper_threshold);
 
+DECLARE_int32(anisotropic_override);
+
 DECLARE_bool(disassemble_pm4);
 
 #define XE_GPU_FINE_GRAINED_DRAW_SCOPES 1

--- a/src/xenia/gpu/spirv_shader_translator.cc
+++ b/src/xenia/gpu/spirv_shader_translator.cc
@@ -17,6 +17,7 @@
 #include "xenia/base/assert.h"
 #include "xenia/base/math.h"
 #include "xenia/base/string_buffer.h"
+#include "xenia/gpu/gpu_flags.h"
 #include "xenia/gpu/spirv_shader.h"
 
 namespace xe {
@@ -807,7 +808,10 @@ void SpirvShaderTranslator::PostTranslation() {
       shader_binding.mag_filter = translator_binding.mag_filter;
       shader_binding.min_filter = translator_binding.min_filter;
       shader_binding.mip_filter = translator_binding.mip_filter;
-      shader_binding.aniso_filter = translator_binding.aniso_filter;
+      shader_binding.aniso_filter =
+          cvars::anisotropic_override > -1 && cvars::anisotropic_override < 6
+              ? xenos::AnisoFilter(cvars::anisotropic_override)
+              : translator_binding.aniso_filter;
     }
   }
 }


### PR DESCRIPTION
Addresses #339 

This PR adds a user-configurable anisotropic texture filtering override option as `anisotropic_override` in the `[GPU]` config category. This allows users to forcibly enable a higher level of anisotropic filtering than what the content natively requests, effectively increasing visual fidelity in exchange for a small performance cost and the possibility of (typically very minor, if any) visual bugs.

Implementation-wise, this is done at the sampler level by overriding the `aniso_filter` value assigned to shader-bound samplers post-translation, when the configured override level is in the valid `[0-5]` range. The default value is `-1`, which simply uses the `aniso_filter` level output from the translator as normal, as do any values outside of the valid range.
The new config option is defined in `xenia/gpu/gpu_flags` to avoid duplicating it between the DX12 (dxbc) and Vulkan (SPIR-V) backends, but if this is undesirable or there's a better place to put it I can move it elsewhere.

The accepted override values are listed in the config .toml as follows:
```
anisotropic_override = 5	# Level of anisotropic filtering enforced on all texture fetch instructions.
                            #  -1 = No override
                            #   0 = Disable anisotropic filtering
                            #   1 = Force 1x anisotropic filtering
                            #   2 = Force 2x anisotropic filtering
                            #   3 = Force 4x anisotropic filtering
                            #   4 = Force 8x anisotropic filtering
                            #   5 = Force 16x anisotropic filtering
``` 

Comparison of current behaviour vs. forced 16x anisotropic filtering in (modded) Armored Core: Verdict Day (4E4D0864):
| Current (no override) | This PR (anisotropic_override = 5) |
|--------|--------|
|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f8da598e-dcf4-4898-bac1-7b9cc99270ae" />|<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/58215792-621a-487a-8126-64196820b17f" />|
Note the rather severe blocking artifacts on the asphalt, the result of its specular texture's lower-res mip levels becoming dominant at grazing angles.|With forced anisotropic filtering the blocking artifacts are basically gone, and the asphalt looks significantly more detailed regardless of its angle to the viewer.|

There is a _slight_ difference in the appearance of the ambient light and reflections when anisotropic filtering is force-enabled in the example above (I believe, in this case, due to the downsampled depth-buffer used for computing SSAO resolving slightly differently). Minor differences like this are to be expected when globally enforcing anisotropic filtering, and will vary from game to game.