### PR TITLE
[XAM/XNOTIFY] - Fixes and more flags

### DIFF
--- a/src/xenia/kernel/xam/xam_notify.cc
+++ b/src/xenia/kernel/xam/xam_notify.cc
@@ -10,7 +10,9 @@
 #include "xenia/kernel/kernel_state.h"
 #include "xenia/kernel/util/shim_utils.h"
 #include "xenia/kernel/xam/xam_private.h"
+#include "xenia/kernel/xboxkrnl/xboxkrnl_threading.h"
 #include "xenia/kernel/xnotifylistener.h"
+#include "xenia/kernel/xthread.h"
 #include "xenia/xbox.h"
 
 namespace xe {
@@ -27,7 +29,7 @@ uint32_t xeXamNotifyCreateListener(uint64_t mask, uint32_t is_system,
 
   auto listener =
       object_ref<XNotifyListener>(new XNotifyListener(kernel_state()));
-  listener->Initialize(mask, max_version);
+  listener->Initialize(mask, is_system, max_version);
 
   // Handle ref is incremented, so return that.
   uint32_t handle = listener->handle();
@@ -37,7 +39,10 @@ uint32_t xeXamNotifyCreateListener(uint64_t mask, uint32_t is_system,
 
 dword_result_t XamNotifyCreateListener_entry(qword_t mask,
                                              dword_t max_version) {
-  return xeXamNotifyCreateListener(mask, 0, max_version);
+  auto thread = kernel::XThread::GetCurrentThread();
+  auto ctx = thread->thread_state()->context();
+  auto type = xboxkrnl::xeKeGetCurrentProcessType(ctx);
+  return xeXamNotifyCreateListener(mask, type == 2, max_version);
 }
 DECLARE_XAM_EXPORT1(XamNotifyCreateListener, kNone, kImplemented);
 

--- a/src/xenia/kernel/xnotifylistener.cc
+++ b/src/xenia/kernel/xnotifylistener.cc
@@ -22,12 +22,14 @@ XNotifyListener::XNotifyListener(KernelState* kernel_state)
 
 XNotifyListener::~XNotifyListener() {}
 
-void XNotifyListener::Initialize(uint64_t mask, uint32_t max_version) {
+void XNotifyListener::Initialize(uint64_t mask, uint32_t is_system,
+                                 uint32_t max_version) {
   assert_false(wait_handle_);
 
   wait_handle_ = xe::threading::Event::CreateManualResetEvent(false);
   assert_not_null(wait_handle_);
   mask_ = mask;
+  is_system_ = is_system;
   max_version_ = max_version;
 
   kernel_state_->RegisterNotifyListener(this);
@@ -109,8 +111,9 @@ object_ref<XNotifyListener> XNotifyListener::Restore(KernelState* kernel_state,
   notify->RestoreObject(stream);
 
   auto mask = stream->Read<uint64_t>();
+  auto is_system = stream->Read<uint32_t>();
   auto max_version = stream->Read<uint32_t>();
-  notify->Initialize(mask, max_version);
+  notify->Initialize(mask, is_system, max_version);
 
   auto notification_count_ = stream->Read<size_t>();
   for (size_t i = 0; i < notification_count_; i++) {

--- a/src/xenia/kernel/xnotifylistener.h
+++ b/src/xenia/kernel/xnotifylistener.h
@@ -48,9 +48,10 @@ class XNotifyListener : public XObject {
   ~XNotifyListener() override;
 
   uint64_t mask() const { return mask_; }
+  uint32_t is_system() const { return is_system_; }
   uint32_t max_version() const { return max_version_; }
 
-  void Initialize(uint64_t mask, uint32_t max_version);
+  void Initialize(uint64_t mask, uint32_t is_system, uint32_t max_version);
 
   void EnqueueNotification(XNotificationID id, uint32_t data);
   bool DequeueNotification(XNotificationID* out_id, uint32_t* out_data);
@@ -70,6 +71,7 @@ class XNotifyListener : public XObject {
   xe::global_critical_region global_critical_region_;
   std::vector<std::pair<XNotificationID, uint32_t>> notifications_;
   uint64_t mask_ = 0;
+  uint32_t is_system_ = 0;
   uint32_t max_version_ = 0;
 };
 

--- a/src/xenia/xbox.h
+++ b/src/xenia/xbox.h
@@ -161,10 +161,10 @@ constexpr uint8_t XUserIndexAny = 0xFF;
 typedef uint32_t XNotificationID;
 
 struct X_NOTIFICATION_ID {
-  uint32_t reserved : 1;  // Always one
-  uint32_t area : 6;
-  uint32_t version : 9;
-  uint32_t message_id : 16;
+  uint32_t message_id : 16;  // 0b0 sz:16
+  uint32_t version : 9;      // 0b16 sz:9
+  uint32_t area : 6;         // 0b25 sz:6
+  uint32_t Internal : 1;     // 0b31 sz:1
 };
 static_assert_size(X_NOTIFICATION_ID, 4);
 
@@ -179,6 +179,11 @@ enum : XNotificationID {
   kXNotifyParty = 0x00000080,
   kXNotifyAll = 0x000000EF,
 
+  // Special Flags
+  kXNotificationInternal = 0x80000000,
+  kXNotificationAreaMask = 0x7e000000,
+  kXNotificationVersionMask = 0x01FF0000,
+
   // XNotification System
   /* System Notes:
      - for some functions if XamIsNuiUIActive returns false then
@@ -186,14 +191,6 @@ enum : XNotificationID {
      - XNotifyBroadcast(kXNotificationSystemNUIHardwareStatusChanged,
      device_state)
   */
-  kXNotificationSystemTitleLoad = 0x80000001,
-  kXNotificationSystemTimeZone = 0x80000002,
-  kXNotificationSystemLanguage = 0x80000003,
-  kXNotificationSystemVideoFlags = 0x80000004,
-  kXNotificationSystemAudioFlags = 0x80000005,
-  kXNotificationSystemParentalControlGames = 0x80000006,
-  kXNotificationSystemParentalControlPassword = 0x80000007,
-  kXNotificationSystemParentalControlMovies = 0x80000008,
   kXNotificationSystemUI = 0x00000009,
   kXNotificationSystemSignInChanged = 0x0000000A,
   kXNotificationSystemStorageDevicesChanged = 0x0000000B,
@@ -210,7 +207,6 @@ enum : XNotificationID {
      some funcs the third param is used with
      XNotifyBroadcast(kXNotificationSystemUnknown, unk)
   */
-  kXNotificationSystemUnknown = 0x80010014,
   kXNotificationSystemPlayerTimerNotice = 0x00030015,
   kXNotificationSystemAvatarChanged = 0x00040017,
   kXNotificationSystemNUIHardwareStatusChanged = 0x00060019,
@@ -221,23 +217,35 @@ enum : XNotificationID {
   kXNotificationSystemAudioLatencyChanged = 0x0008001E,
   kXNotificationSystemNUIChatBindingChanged = 0x0008001F,
   kXNotificationSystemInputActivityChanged = 0x00090020,
+  kXNotificationSystemProfileSettingChanged = 0x0000000E,
+  // XNotification System Internal
+  kXNotificationSystemTitleLoad = 0x80000001,
+  kXNotificationSystemTimeZone = 0x80000002,
+  kXNotificationSystemLanguage = 0x80000003,
+  kXNotificationSystemVideoFlags = 0x80000004,
+  kXNotificationSystemAudioFlags = 0x80000005,
+  kXNotificationSystemParentalControlGames = 0x80000006,
+  kXNotificationSystemParentalControlPassword = 0x80000007,
+  kXNotificationSystemParentalControlMovies = 0x80000008,
   kXNotificationSystemDashContextChanged = 0x8000000C,
   kXNotificationSystemTrayStateChanged = 0x8000000D,
-  kXNotificationSystemProfileSettingChanged = 0x0000000E,
   kXNotificationSystemThemeChanged = 0x8000000F,
   kXNotificationSystemSystemUpdateChanged = 0x80000010,
+  kXNotificationSystemUnknown = 0x80010014,
+  kXNotificationSystemDashboard = 0x80040016,
 
   // XNotification Live
   kXNotificationLiveConnectionChanged = 0x02000001,
   kXNotificationLiveInviteAccepted = 0x02000002,
   kXNotificationLiveLinkStateChanged = 0x02000003,
-  kXNotificationLiveInvitedRecieved = 0x82000004,
-  kXNotificationLiveInvitedAnswerRecieved = 0x82000005,
-  kXNotificationLiveMessageListChanged = 0x82000006,
   kXNotificationLiveContentInstalled = 0x02000007,
   kXNotificationLiveMembershipPurchased = 0x02000008,
   kXNotificationLiveVoicechatAway = 0x02000009,
   kXNotificationLivePresenceChanged = 0x0200000A,
+  // XNotification Live Internal
+  kXNotificationLiveInvitedRecieved = 0x82000004,
+  kXNotificationLiveInvitedAnswerRecieved = 0x82000005,
+  kXNotificationLiveMessageListChanged = 0x82000006,
   kXNotificationLivePointsBalanceChanged = 0x8200000B,
   kXNotificationLivePlayerListChanged = 0x8200000C,
   kXNotificationLiveItemPurchased = 0x8200000D,
@@ -246,6 +254,7 @@ enum : XNotificationID {
   kXNotificationFriendsPresenceChanged = 0x04000001,
   kXNotificationFriendsFriendAdded = 0x04000002,
   kXNotificationFriendsFriendRemoved = 0x04000003,
+  // XNotification Friends Internal
   kXNotificationFriendsFriendRequestReceived = 0x84000004,
   kXNotificationFriendsFriendAnswerReceived = 0x84000005,
   kXNotificationFriendsFriendRequestResult = 0x84000006,
@@ -258,6 +267,7 @@ enum : XNotificationID {
   kXNotificationXmpStateChanged = 0x0A000001,
   kXNotificationXmpPlaybackBehaviorChanged = 0x0A000002,
   kXNotificationXmpPlaybackControllerChanged = 0x0A000003,
+  // XNotification XMP Internal
   kXNotificationXmpMediaSourceConnectionChanged = 0x8A000004,
   kXNotificationXmpTitlePlayListContentChanged = 0x8A000005,
   kXNotificationXmpLocalMediaContentChanged = 0x8A000006,


### PR DESCRIPTION
- Properly set is_system in XamNotifyCreateListener
- Save is_system for later use
- Correct X_NOTIFICATION_ID
- Add missing XNotificationID flags