### PR TITLE
Revert ac6fd65 fetch and implement context-sensitive AF override.

### DIFF
--- a/src/xenia/gpu/dxbc_shader_translator.cc
+++ b/src/xenia/gpu/dxbc_shader_translator.cc
@@ -17,7 +17,6 @@
 #include "xenia/base/cvar.h"
 #include "xenia/base/math.h"
 #include "xenia/gpu/dxbc_shader.h"
-#include "xenia/gpu/gpu_flags.h"
 #include "xenia/gpu/xenos.h"
 #include "xenia/ui/graphics_provider.h"
 
@@ -1379,10 +1378,7 @@ void DxbcShaderTranslator::PostTranslation() {
       shader_binding.mag_filter = translator_binding.mag_filter;
       shader_binding.min_filter = translator_binding.min_filter;
       shader_binding.mip_filter = translator_binding.mip_filter;
-      shader_binding.aniso_filter =
-          cvars::anisotropic_override > -1 && cvars::anisotropic_override < 6
-              ? xenos::AnisoFilter(cvars::anisotropic_override)
-              : translator_binding.aniso_filter;
+      shader_binding.aniso_filter = translator_binding.aniso_filter;
     }
   }
 }

--- a/src/xenia/gpu/gpu_flags.cc
+++ b/src/xenia/gpu/gpu_flags.cc
@@ -72,8 +72,10 @@ DEFINE_int32(
     "GPU");
 
 DEFINE_int32(anisotropic_override, -1,
-             "Level of anisotropic filtering enforced on all texture fetch "
-             "instructions.\n"
+             "Forces anisotropic filtering (AF) for eligible textures.\n"
+             "Higher values keep textures sharper at oblique angles at the "
+             "cost of GPU bandwidth, though most GPUs handle up to 16x fine.\n"
+             "In rare cases, forcing AF can introduce visual artifacts.\n"
              " -1 = No override\n"
              "  0 = Disable anisotropic filtering\n"
              "  1 = Force 1x anisotropic filtering\n"

--- a/src/xenia/gpu/spirv_shader_translator.cc
+++ b/src/xenia/gpu/spirv_shader_translator.cc
@@ -17,7 +17,6 @@
 #include "xenia/base/assert.h"
 #include "xenia/base/math.h"
 #include "xenia/base/string_buffer.h"
-#include "xenia/gpu/gpu_flags.h"
 #include "xenia/gpu/spirv_shader.h"
 
 namespace xe {
@@ -808,10 +807,7 @@ void SpirvShaderTranslator::PostTranslation() {
       shader_binding.mag_filter = translator_binding.mag_filter;
       shader_binding.min_filter = translator_binding.min_filter;
       shader_binding.mip_filter = translator_binding.mip_filter;
-      shader_binding.aniso_filter =
-          cvars::anisotropic_override > -1 && cvars::anisotropic_override < 6
-              ? xenos::AnisoFilter(cvars::anisotropic_override)
-              : translator_binding.aniso_filter;
+      shader_binding.aniso_filter = translator_binding.aniso_filter;
     }
   }
 }


### PR DESCRIPTION
Numerous Discord users have reported that the [new anisotropy override](https://github.com/xenia-canary/xenia-canary/pull/848) can introduce significant regressions & Vulkan support is limited.

Instead of touching fetch, this override is applied at host sampler creation, with separate D3D12/Vulkan implementations, which should be the safest and most predictable approach. It only affects textures that are already using bilinear/trilinear filtering and have more than one mip level, aligning with the AF override guardrails used by DXVK and NVCP. Point filtered resources (UI textures, LUTs, fonts, etc) are left untouched.

I asked four Xenia Discord members to test the override on both backends; they reported behavior comparable to the NVIDIA driver override, except this actually works on Blackwell.