### PR TITLE
[XAM/XLIVE] - stubbed message Ids

### DIFF
--- a/src/xenia/kernel/kernel_state.cc
+++ b/src/xenia/kernel/kernel_state.cc
@@ -23,6 +23,7 @@
 #include "xenia/kernel/xboxkrnl/xboxkrnl_threading.h"
 #include "xenia/kernel/xevent.h"
 #include "xenia/kernel/xmodule.h"
+#include "xenia/kernel/xnet.h"
 #include "xenia/kernel/xnotifylistener.h"
 #include "xenia/kernel/xobject.h"
 #include "xenia/kernel/xthread.h"
@@ -1052,7 +1053,7 @@ void KernelState::RegisterNotifyListener(XNotifyListener* listener) {
     has_notified_live_startup_ = true;
     // X_ONLINE_S_LOGON_DISCONNECTED
     listener->EnqueueNotification(kXNotificationLiveConnectionChanged,
-                                  0x001510F1L);
+                                  X_ONLINE_S_LOGON_DISCONNECTED);
     listener->EnqueueNotification(kXNotificationLiveLinkStateChanged, 0);
   }
 

--- a/src/xenia/kernel/kernel_state.cc
+++ b/src/xenia/kernel/kernel_state.cc
@@ -23,6 +23,7 @@
 #include "xenia/kernel/xboxkrnl/xboxkrnl_threading.h"
 #include "xenia/kernel/xevent.h"
 #include "xenia/kernel/xmodule.h"
+#include "xenia/kernel/xnet.h"
 #include "xenia/kernel/xnotifylistener.h"
 #include "xenia/kernel/xobject.h"
 #include "xenia/kernel/xthread.h"
@@ -1031,7 +1032,7 @@ void KernelState::RegisterNotifyListener(XNotifyListener* listener) {
     has_notified_live_startup_ = true;
     // X_ONLINE_S_LOGON_DISCONNECTED
     listener->EnqueueNotification(kXNotificationLiveConnectionChanged,
-                                  0x001510F1L);
+                                  X_ONLINE_S_LOGON_DISCONNECTED);
     listener->EnqueueNotification(kXNotificationLiveLinkStateChanged, 0);
   }
 }

--- a/src/xenia/kernel/xam/apps/xgi_app.cc
+++ b/src/xenia/kernel/xam/apps/xgi_app.cc
@@ -8,6 +8,7 @@
  */
 
 #include "xenia/kernel/xam/apps/xgi_app.h"
+#include "xenia/kernel/xnet.h"
 #include "xenia/kernel/xsession.h"
 
 #include "xenia/base/logging.h"
@@ -271,7 +272,7 @@ X_HRESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
         xe::be<uint32_t> results_guest_address;
       }* data = reinterpret_cast<XUserReadStats*>(buffer);
 
-      return 0x80151802;  // X_ONLINE_E_LOGON_NOT_LOGGED_ON
+      return X_ONLINE_E_LOGON_NOT_LOGGED_ON;
     }
     case 0x000B0036: {
       // Called after opening xbox live arcade and clicking on xbox live v5759

--- a/src/xenia/kernel/xam/apps/xlivebase_app.cc
+++ b/src/xenia/kernel/xam/apps/xlivebase_app.cc
@@ -8,6 +8,8 @@
  */
 
 #include "xenia/kernel/xam/apps/xlivebase_app.h"
+#include "xenia/kernel/xenumerator.h"
+#include "xenia/kernel/xnet.h"
 
 #include "xenia/base/logging.h"
 
@@ -45,7 +47,7 @@ X_HRESULT XLiveBaseApp::DispatchMessageSync(uint32_t message,
          - Return is Saved elsewhere and used here
       */
       XELOGD("XLiveBaseLogonGetHR, implemented in netplay");
-      return 0x001510F1;  // X_ONLINE_S_LOGON_DISCONNECTED
+      return X_ONLINE_S_LOGON_DISCONNECTED;
     }
     case 0x00058004: {
       /* Notes:
@@ -61,7 +63,7 @@ X_HRESULT XLiveBaseApp::DispatchMessageSync(uint32_t message,
       // Buffer only set when online
       assert_true(!buffer_length || buffer_length == 4);
       XELOGD("XLiveBaseGetNatType({:08X})", buffer_ptr);
-      return 0x80151802;  // X_ONLINE_E_LOGON_NOT_LOGGED_ON
+      return X_ONLINE_E_LOGON_NOT_LOGGED_ON;
     }
     case 0x00058007: {
       // Occurs if title calls XOnlineGetServiceInfo, expects dwServiceId
@@ -69,34 +71,51 @@ X_HRESULT XLiveBaseApp::DispatchMessageSync(uint32_t message,
       // XONLINE_SERVICE_INFO structure.
       XELOGD("XLiveBaseOnlineGetServiceInfo({:08X}, {:08X})", buffer_ptr,
              buffer_length);
-      return 0x80151802;  // X_ONLINE_E_LOGON_NOT_LOGGED_ON
+      return X_ONLINE_E_LOGON_NOT_LOGGED_ON;
+    }
+    case 0x0005800E: {
+      // 4D530A26
+      XELOGD("XLiveBaseUserMuteListQuery({:08X}, {:08X})", buffer_ptr,
+             buffer_length);
+      return XUserMuteListQuery(buffer_ptr, buffer_length);
+    }
+    case 0x00058019: {
+      // 54510846, 41560929
+      XELOGD("XLiveBasePresenceCreateEnumerator({:08X}, {:08X} stubbed)",
+             buffer_ptr, buffer_length);
+      return XLiveBasePresenceCreateEnumerator(buffer_ptr, buffer_length);
+    }
+    case 0x0005801E: {
+      // 54510846, 41560929, 55530874, 584112B0
+      XELOGD(
+          "XLiveBasePresenceSubscribe({:08X}, {:08X}, implemented in netplay)",
+          buffer_ptr, buffer_length);
+      return X_ONLINE_E_NOTIFICATION_NOT_INITIALIZED;
     }
     case 0x00058020: {
-      // 0x00058004 is called right before this.
-      // We should create a XamEnumerate-able empty list here, but I'm not
-      // sure of the format.
-      // buffer_length seems to be the same ptr sent to 0x00058004.
-      XELOGD("CXLiveFriends::Enumerate({:08X}, {:08X}) unimplemented",
+      XELOGD("XLiveBaseFriendsCreateEnumerator({:08X}, {:08X}) stubbed",
              buffer_ptr, buffer_length);
-      return X_E_FAIL;
+      return XLiveBaseFriendsCreateEnumerator(buffer_ptr, buffer_length);
     }
     case 0x00058023: {
+      // Offline: 584107D7
       XELOGD(
-          "CXLiveMessaging::XMessageGameInviteGetAcceptedInfo({:08X}, {:08X}) "
-          "unimplemented",
+          "XLiveBaseInviteGetAcceptedInfo({:08X}, {:08X}), implemented in "
+          "netplay",
           buffer_ptr, buffer_length);
-      return X_E_FAIL;
+      return X_ONLINE_E_MESSAGE_PROPERTY_NOT_FOUND;
     }
     case 0x00058037: {
-      XELOGD("XPresenceInitialize({:08X}, {:08X})", buffer_ptr, buffer_length);
+      XELOGD("XLiveBasePresenceInitializeLegacy({:08X}, {:08X})", buffer_ptr,
+             buffer_length);
       return X_E_SUCCESS;
     }
     case 0x00058046: {
+      // Used in newer games such as Forza 4, MW3, FH2
+      // Offline: 454109B6, 454109F4
       // Required to be successful for 4D530910 to detect signed-in profile
-      // Doesn't seem to set anything in the given buffer, probably only takes
-      // input
-      XELOGD("XLiveBaseUnk58046({:08X}, {:08X}) unimplemented", buffer_ptr,
-             buffer_length);
+      XELOGD("XLiveBasePresenceInitialize({:08X}, {:08X}) unimplemented",
+             buffer_ptr, buffer_length);
       return X_E_SUCCESS;
     }
   }
@@ -105,6 +124,202 @@ X_HRESULT XLiveBaseApp::DispatchMessageSync(uint32_t message,
       "arg2={:08X}",
       app_id(), message, buffer_ptr, buffer_length);
   return X_E_FAIL;
+}
+
+X_HRESULT XLiveBaseApp::XUserMuteListQuery(uint32_t buffer_ptr,
+                                           uint32_t buffer_length) {
+  if (!buffer_ptr || !buffer_length) {
+    return X_E_INVALIDARG;
+  }
+
+  X_MUTE_SET_STATE* remote_player_ptr =
+      memory_->TranslateVirtual<X_MUTE_SET_STATE*>(buffer_ptr);
+
+  if (remote_player_ptr->user_index >= XUserMaxUserCount) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!IsOnlineXUID(remote_player_ptr->remote_xuid)) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!kernel_state_->xam_state()->IsUserSignedIn(
+          remote_player_ptr->user_index)) {
+    return X_ONLINE_E_LOGON_NOT_LOGGED_ON;
+  }
+
+  auto user_profile =
+      kernel_state_->xam_state()->GetUserProfile(remote_player_ptr->user_index);
+
+  xe::be<uint32_t>* mute_list_ptr =
+      memory_->TranslateVirtual<xe::be<uint32_t>*>(buffer_length);
+
+  *mute_list_ptr = user_profile->IsPlayerMuted(remote_player_ptr->remote_xuid);
+
+  return X_E_SUCCESS;
+}
+
+// Return presence information for a user's friends and subscribed peers.
+X_HRESULT XLiveBaseApp::XLiveBasePresenceCreateEnumerator(
+    uint32_t buffer_ptr, uint32_t buffer_length) {
+  if (!buffer_ptr || !buffer_length) {
+    return X_E_INVALIDARG;
+  }
+
+  Memory* memory = kernel_state_->memory();
+
+  const X_PRESENCE_CREATE_ENUMERATOR* create_args =
+      reinterpret_cast<X_PRESENCE_CREATE_ENUMERATOR*>(
+          memory->TranslateVirtual(buffer_length));
+
+  const uint32_t buffer_address =
+      static_cast<uint32_t>(create_args->buffer_length_ptr.argument_value_ptr);
+  const uint32_t handle_address = static_cast<uint32_t>(
+      create_args->enumerator_handle_ptr.argument_value_ptr);
+  uint32_t* handle_ptr = memory->TranslateVirtual<uint32_t*>(handle_address);
+  uint32_t* buffer_size_ptr =
+      memory->TranslateVirtual<uint32_t*>(buffer_address);
+
+  if (create_args->argument_count < 7) {
+    return X_E_INVALIDARG;
+  }
+  if (!handle_ptr || !buffer_size_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  uint32_t max_peers = xe::load_and_swap<uint32_t>(memory->TranslateVirtual(
+      static_cast<uint32_t>(create_args->max_peers.argument_value_ptr)));
+  const uint32_t user_index =
+      xe::load_and_swap<uint32_t>(memory->TranslateVirtual(
+          static_cast<uint32_t>(create_args->user_index.argument_value_ptr)));
+
+  auto e = make_object<XStaticEnumerator<X_ONLINE_PRESENCE>>(kernel_state_,
+                                                             max_peers);
+  auto result =
+      e->Initialize(user_index, app_id(), 0x5801A, 0x5801B, 0, 0x330, nullptr);
+
+  if (XFAILED(result)) {
+    return result;
+  }
+  const uint32_t starting_index = xe::load_and_swap<uint32_t>(
+      memory->TranslateVirtual(static_cast<uint32_t>(
+          create_args->starting_index.argument_value_ptr)));
+  const uint32_t xuid_address =
+      static_cast<uint32_t>(create_args->peer_xuids_ptr.argument_value_ptr);
+  const uint32_t num_peers =
+      xe::load_and_swap<uint32_t>(memory->TranslateVirtual(
+          static_cast<uint32_t>(create_args->num_peers.argument_value_ptr)));
+
+  auto object = memory->TranslateVirtual(e->guest_object());
+
+  X_ENUMERATOR_ALLOC_PRESENCE_ENUM* args =
+      reinterpret_cast<X_ENUMERATOR_ALLOC_PRESENCE_ENUM*>(object);
+  args->enum_user_index = xe::byte_swap<uint32_t>(user_index);
+  args->num_peers = xe::byte_swap<uint32_t>(num_peers);
+  args->peer_xuids_ptr = xe::byte_swap<uint32_t>(xuid_address);
+  args->starting_index = xe::byte_swap<uint32_t>(starting_index);
+  args->max_peers = xe::byte_swap<uint32_t>(max_peers);
+
+  if (starting_index > X_ONLINE_MAX_FRIENDS) {
+    return X_E_INVALIDARG;
+  }
+  if (max_peers > X_ONLINE_MAX_FRIENDS) {
+    return X_E_INVALIDARG;
+  }
+
+  const uint32_t presence_buffer_size =
+      static_cast<uint32_t>(e->items_per_enumerate() * e->item_size());
+
+  *buffer_size_ptr = xe::byte_swap<uint32_t>(presence_buffer_size);
+
+  *handle_ptr = xe::byte_swap<uint32_t>(e->handle());
+
+  return X_E_SUCCESS;
+}
+
+X_HRESULT XLiveBaseApp::XLiveBaseFriendsCreateEnumerator(
+    uint32_t buffer_ptr, uint32_t buffer_length) {
+  if (!buffer_ptr || !buffer_length) {
+    return X_E_INVALIDARG;
+  }
+
+  Memory* memory = kernel_state_->memory();
+  X_CREATE_FRIENDS_ENUMERATOR* friends_enumerator =
+      memory->TranslateVirtual<X_CREATE_FRIENDS_ENUMERATOR*>(buffer_length);
+
+  const uint32_t buffer_address =
+      static_cast<uint32_t>(friends_enumerator->buffer_ptr.argument_value_ptr);
+  uint32_t* buffer_size_ptr =
+      memory->TranslateVirtual<uint32_t*>(buffer_address);
+  const uint32_t handle_address =
+      static_cast<uint32_t>(friends_enumerator->handle_ptr.argument_value_ptr);
+  uint32_t* handle_ptr = memory->TranslateVirtual<uint32_t*>(handle_address);
+
+  // 41560834 and 45410923 expect invalid handle of 0 (not -1) for failure,
+  // therefore set as soon as possible.
+  *handle_ptr = 0;
+
+  if (friends_enumerator->argument_count < 5) {
+    return X_E_INVALIDARG;
+  }
+  if (!handle_address || !buffer_size_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  uint32_t friends_amount = xe::load_and_swap<uint32_t>(
+      memory->TranslateVirtual(static_cast<uint32_t>(
+          friends_enumerator->friends_amount.argument_value_ptr)));
+
+  auto e = make_object<XStaticEnumerator<X_ONLINE_FRIEND>>(kernel_state_,
+                                                           friends_amount);
+  auto result = e->Initialize(-1, app_id(), 0x58021, 0x58022, 0, 0x10, nullptr);
+
+  if (XFAILED(result)) {
+    return result;
+  }
+
+  const uint32_t user_index = xe::load_and_swap<uint32_t>(
+      memory->TranslateVirtual(static_cast<uint32_t>(
+          friends_enumerator->user_index.argument_value_ptr)));
+
+  if (user_index >= XUserMaxUserCount) {
+    return X_E_INVALIDARG;
+  }
+
+  uint32_t friends_starting_index = xe::load_and_swap<uint32_t>(
+      memory->TranslateVirtual(static_cast<uint32_t>(
+          friends_enumerator->friends_starting_index.argument_value_ptr)));
+
+  if (friends_starting_index >= X_ONLINE_MAX_FRIENDS) {
+    return X_E_INVALIDARG;
+  }
+
+  if (friends_amount > X_ONLINE_MAX_FRIENDS) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!kernel_state_->xam_state()->IsUserSignedIn(user_index)) {
+    return X_E_NO_SUCH_USER;
+  }
+
+  auto const profile = kernel_state_->xam_state()->GetUserProfile(user_index);
+
+  auto object = memory->TranslateVirtual(e->guest_object());
+
+  X_ENUMERATOR_ALLOC_FRIENDS_ENUM* args =
+      reinterpret_cast<X_ENUMERATOR_ALLOC_FRIENDS_ENUM*>(object);
+  args->xuid = xe::byte_swap<uint64_t>(profile->xuid());  // online
+  args->friends_amount = xe::byte_swap<uint32_t>(friends_amount);
+  args->friends_starting_index =
+      xe::byte_swap<uint32_t>(friends_starting_index);
+
+  const uint32_t friends_buffer_size =
+      static_cast<uint32_t>(e->items_per_enumerate() * e->item_size());
+
+  *buffer_size_ptr = xe::byte_swap<uint32_t>(friends_buffer_size);
+
+  *handle_ptr = xe::byte_swap<uint32_t>(e->handle());
+  return X_E_SUCCESS;
 }
 
 }  // namespace apps

--- a/src/xenia/kernel/xam/apps/xlivebase_app.h
+++ b/src/xenia/kernel/xam/apps/xlivebase_app.h
@@ -24,6 +24,13 @@ class XLiveBaseApp : public App {
 
   X_HRESULT DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
                                 uint32_t buffer_length) override;
+
+ private:
+  X_HRESULT XUserMuteListQuery(uint32_t buffer_ptr, uint32_t buffer_length);
+  X_HRESULT XLiveBasePresenceCreateEnumerator(uint32_t buffer_ptr,
+                                              uint32_t buffer_length);
+  X_HRESULT XLiveBaseFriendsCreateEnumerator(uint32_t buffer_ptr,
+                                             uint32_t buffer_length);
 };
 
 }  // namespace apps

--- a/src/xenia/kernel/xam/user_profile.cc
+++ b/src/xenia/kernel/xam/user_profile.cc
@@ -198,6 +198,14 @@ bool UserProfile::RemoveGpd(const uint32_t title_id) {
   return true;
 }
 
+bool UserProfile::IsPlayerMuted(uint64_t xuid) const {
+  const auto it = std::find_if(
+      muted_players_.cbegin(), muted_players_.cend(),
+      [xuid](const uint64_t muted_xuid) { return muted_xuid == xuid; });
+
+  return it != muted_players_.end();
+}
+
 }  // namespace xam
 }  // namespace kernel
 }  // namespace xe

--- a/src/xenia/kernel/xam/user_profile.cc
+++ b/src/xenia/kernel/xam/user_profile.cc
@@ -211,6 +211,14 @@ bool UserProfile::RemoveGpd(const uint32_t title_id) {
   return true;
 }
 
+bool UserProfile::IsPlayerMuted(uint64_t xuid) const {
+  const auto it = std::find_if(
+      muted_players_.cbegin(), muted_players_.cend(),
+      [xuid](const uint64_t muted_xuid) { return muted_xuid == xuid; });
+
+  return it != muted_players_.end();
+}
+
 }  // namespace xam
 }  // namespace kernel
 }  // namespace xe

--- a/src/xenia/kernel/xam/user_profile.h
+++ b/src/xenia/kernel/xam/user_profile.h
@@ -152,6 +152,8 @@ class UserProfile {
                 sizeof(account_info_.passcode));
   };
 
+  bool IsPlayerMuted(uint64_t xuid) const;
+
   friend class UserTracker;
   friend class GpdAchievementBackend;
 
@@ -162,6 +164,7 @@ class UserProfile {
   GpdInfoProfile dashboard_gpd_;
   std::map<uint32_t, GpdInfoTitle> games_gpd_;
   std::vector<Property> properties_;  // Includes contexts!
+  std::vector<uint64_t> muted_players_;
 
   std::map<XTileType, std::vector<uint8_t>> profile_images_;
 

--- a/src/xenia/kernel/xam/xam_party.cc
+++ b/src/xenia/kernel/xam/xam_party.cc
@@ -10,6 +10,7 @@
 #include "xenia/kernel/kernel_state.h"
 #include "xenia/kernel/util/shim_utils.h"
 #include "xenia/kernel/xam/xam_private.h"
+#include "xenia/kernel/xnet.h"
 #include "xenia/xbox.h"
 
 namespace xe {
@@ -20,7 +21,7 @@ dword_result_t XamPartyGetUserList_entry(dword_t player_count,
                                          lpdword_t party_list) {
   // 5345085D wants specifically this code to skip loading party data.
   // This code is not documented in NT_STATUS code list
-  return 0x807D0003;
+  return X_PARTY_E_NOT_IN_PARTY;
 }
 DECLARE_XAM_EXPORT1(XamPartyGetUserList, kNone, kStub);
 

--- a/src/xenia/kernel/xenumerator.h
+++ b/src/xenia/kernel/xenumerator.h
@@ -51,6 +51,34 @@ struct X_ENUMERATE_PARAM {
 };
 static_assert_size(X_ENUMERATE_PARAM, 0x1C);
 
+struct X_ENUMERATOR_FRIENDS_STRUCT {
+  xe::be<uint64_t> xuid;                    // 0x00 sz:0x8
+  xe::be<uint32_t> friends_amount;          // 0x08 sz:0x4
+  xe::be<uint32_t> friends_starting_index;  // 0x0C sz:0x4
+};
+static_assert_size(X_ENUMERATOR_FRIENDS_STRUCT, 0x10);
+
+struct X_ENUMERATOR_ALLOC_FRIENDS_ENUM : X_KENUMERATOR,
+                                         X_ENUMERATOR_FRIENDS_STRUCT {};
+static_assert_size(X_ENUMERATOR_ALLOC_FRIENDS_ENUM,
+                   sizeof(X_ENUMERATOR_FRIENDS_STRUCT) + sizeof(X_KENUMERATOR));
+
+struct X_ENUMERATOR_PRESENCE_STRUCT {
+  xe::be<uint32_t> enum_user_index;  // 0x00 sz:0x4
+  xe::be<uint32_t> num_peers;        // 0x04 sz:0x4
+  xe::be<uint32_t> peer_xuids_ptr;   // 0x08 sz:0x4
+  uint8_t unk[0x31C];
+  xe::be<uint32_t> starting_index;  // 0x328 sz:0x4
+  xe::be<uint32_t> max_peers;       // 0x32c sz:0x4
+};
+static_assert_size(X_ENUMERATOR_PRESENCE_STRUCT, 0x330);
+
+struct X_ENUMERATOR_ALLOC_PRESENCE_ENUM : X_KENUMERATOR,
+                                          X_ENUMERATOR_PRESENCE_STRUCT {};
+static_assert_size(X_ENUMERATOR_ALLOC_PRESENCE_ENUM,
+                   sizeof(X_ENUMERATOR_PRESENCE_STRUCT) +
+                       sizeof(X_KENUMERATOR));
+
 struct X_KENUMERATOR_CONTENT_AGGREGATE {
   be<uint32_t> magic;
   be<uint32_t> handle;

--- a/src/xenia/kernel/xnet.h
+++ b/src/xenia/kernel/xnet.h
@@ -1,0 +1,117 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2026 Xenia Emulator. All rights reserved.                        *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_KERNEL_XNET_H_
+#define XENIA_KERNEL_XNET_H_
+
+#include "xenia/base/byte_order.h"
+#include "xenia/base/literals.h"
+#include "xenia/kernel/util/xfiletime.h"
+
+namespace xe {
+using namespace xe::literals;
+
+// clang-format off
+
+// https://github.com/davispuh/XLiveServices/blob/master/lib/xlive_services/hresult.rb
+
+#define X_ONLINE_E_BASE                                     static_cast<X_HRESULT>(0x80150000L)
+
+#define X_ONLINE_S_LOGON_DISCONNECTED                       static_cast<X_HRESULT>(0x001510F1L)
+#define X_ONLINE_E_LOGON_NOT_LOGGED_ON                      static_cast<X_HRESULT>(0x80151802L) // ERROR_CONNECTION_INVALID
+#define X_ONLINE_E_MESSAGE_PROPERTY_NOT_FOUND               static_cast<X_HRESULT>(0x80155a03L)
+#define X_ONLINE_E_NOTIFICATION_NOT_INITIALIZED             static_cast<X_HRESULT>(0x8015200DL)
+
+#define X_PARTY_E_NOT_IN_PARTY                              static_cast<X_HRESULT>(0x807D0003L)
+
+#define X_ONLINE_MAX_FRIENDS                                100
+#define X_MAX_RICHPRESENCE_SIZE                             64
+
+// clang-format on
+
+namespace kernel {
+
+struct XNKID {
+  uint8_t ab[8];
+  uint64_t as_uint64() { return *reinterpret_cast<uint64_t*>(&ab); }
+  uint64_t as_uintBE64() { return xe::byte_swap(as_uint64()); }
+};
+static_assert_size(XNKID, 0x8);
+
+#pragma region XLiveBase
+
+struct X_ARGUMENT_ENTRY {
+  xe::be<uint32_t> native_size;  // 4
+  xe::be<uint64_t> argument_value_ptr;
+};
+static_assert_size(X_ARGUMENT_ENTRY, 0x10);
+
+#pragma pack(push, 4)
+
+struct X_MUTE_SET_STATE {
+  xe::be<uint32_t> user_index;
+  xe::be<uint64_t> remote_xuid;
+  xe::be<uint32_t> set_muted;
+};
+
+struct X_PRESENCE_CREATE_ENUMERATOR {
+  X_ARGUMENT_ENTRY user_index;
+  X_ARGUMENT_ENTRY num_peers;
+  X_ARGUMENT_ENTRY peer_xuids_ptr;
+  X_ARGUMENT_ENTRY starting_index;
+  X_ARGUMENT_ENTRY max_peers;
+  X_ARGUMENT_ENTRY buffer_length_ptr;      // output
+  X_ARGUMENT_ENTRY enumerator_handle_ptr;  // output
+  X_ARGUMENT_ENTRY reserved[25];
+  xe::be<uint32_t> argument_count;
+};
+static_assert_size(X_PRESENCE_CREATE_ENUMERATOR, 0x204);
+
+struct X_ONLINE_PRESENCE {
+  xe::be<uint64_t> xuid;
+  xe::be<uint32_t> state;
+  XNKID session_id;
+  xe::be<uint32_t> title_id;
+  X_FILETIME state_change_time;
+  xe::be<uint32_t> cchRichPresence;
+  xe::be<char16_t> wszRichPresence[X_MAX_RICHPRESENCE_SIZE];
+};
+static_assert_size(X_ONLINE_PRESENCE, 0xA4);
+
+struct X_CREATE_FRIENDS_ENUMERATOR {
+  X_ARGUMENT_ENTRY user_index;
+  X_ARGUMENT_ENTRY friends_starting_index;
+  X_ARGUMENT_ENTRY friends_amount;
+  X_ARGUMENT_ENTRY buffer_ptr;
+  X_ARGUMENT_ENTRY handle_ptr;
+  X_ARGUMENT_ENTRY reserved[27];
+  xe::be<uint32_t> argument_count;
+};
+static_assert_size(X_CREATE_FRIENDS_ENUMERATOR, 0x204);
+
+struct X_ONLINE_FRIEND {
+  xe::be<uint64_t> xuid;
+  char Gamertag[16];
+  xe::be<uint32_t> state;
+  XNKID session_id;
+  xe::be<uint32_t> title_id;
+  X_FILETIME ftUserTime;
+  XNKID xnkidInvite;
+  X_FILETIME gameinviteTime;
+  xe::be<uint32_t> cchRichPresence;
+  xe::be<char16_t> wszRichPresence[X_MAX_RICHPRESENCE_SIZE];
+};
+static_assert_size(X_ONLINE_FRIEND, 0xC4);
+
+#pragma pack(pop)
+
+}  // namespace kernel
+}  // namespace xe
+
+#endif  // XENIA_KERNEL_XNET_H_


### PR DESCRIPTION
- Merge only after netplay rebase to make adrian's life easier
- Bring over message ids from netplay that are used during offline play
- Stub XLiveBaseUserMuteListQuery, used in 4D530A26
- Stub XLiveBasePresenceCreateEnumerator, used in 41560929
- Return error in XLiveBasePresenceSubscribe, used in 41560929
- Stub XLiveBaseFriendsCreateEnumerator, used in various games
- XLiveBaseInviteGetAcceptedInfo return error code, used in 584107D7
- Replace magic number error codes