### PR TITLE
[APP] Fixed potential conflicting ImGUI ID in profile menu

### DIFF
--- a/src/xenia/app/profile_dialogs.cc
+++ b/src/xenia/app/profile_dialogs.cc
@@ -189,7 +189,7 @@ void ProfileConfigDialog::OnDraw(ImGuiIO& io) {
              ImGui::GetWindowPos().y);
 
   for (auto& [xuid, account] : *profiles) {
-    ImGui::PushID(static_cast<int>(xuid));
+    ImGui::PushID(fmt::format("{:016X}", xuid).c_str());
 
     const uint8_t user_index =
         profile_manager->GetUserIndexAssignedToProfile(xuid);


### PR DESCRIPTION
Installing multiple profiles created from the same console would cause ImGUI ID conflicts in the profile menu due to truncating the offline XUID.