### PR TITLE
[Build] Remove /all_resources_bound from FXC shader compilation flags

### DIFF
--- a/xenia-build.py
+++ b/xenia-build.py
@@ -1201,7 +1201,11 @@ def build_shaders(targets=None):
                     src_path,
                 ])
             else:
-                # FXC uses traditional syntax
+                # FXC uses traditional syntax.
+                # Do NOT use /all_resources_bound — it alters the generated
+                # DXBC bytecode (changes dcl_globalFlags, register allocation
+                # and instruction scheduling) which causes rendering artifacts
+                # such as blue lightning/flash glitches at scaled resolutions.
                 compiler_args.extend([
                     "/D", "SHADING_LANGUAGE_HLSL_XE=1",
                     "/I", src_dir,
@@ -1212,7 +1216,6 @@ def build_shaders(targets=None):
                     "/Qstrip_reflect",
                     "/Qstrip_debug",
                     "/Qstrip_priv",
-                    "/all_resources_bound",
                     "/Gfp",
                     "/nologo",
                     src_path,


### PR DESCRIPTION
Problem

Commit f2ac39cf ("[Build] Generate shaders on build") introduced six new FXC 
flags that were not used when the DXBC bytecodes were originally compiled and 
checked into the repository. Among these, `/all_resources_bound` alters the 
actual generated DXBC bytecode — it changes `dcl_globalFlags`, register 
allocation (e.g. temp register count), and instruction scheduling.

This causes rendering artifacts (blue lightning/flash glitches) visible at 
scaled draw resolutions (2x, 3x) across multiple titles.

<img width="2065" height="1220" alt="image-1772586875195" src="https://github.com/user-attachments/assets/6121c1fb-d041-47a5-b52e-d62bf1f0cacc" />
(Sorry again for low res but you can see the lightning/flash glitches that was one of the problem)


Analysis

Each flag was tested individually against the original bytecodes:

| Flag | Effect on bytecode | Verdict |
|---|---|---|
| `/O3` | No change | Safe ✅ |
| `/Qstrip_reflect` `/Qstrip_debug` `/Qstrip_priv` | Strips metadata only (RDEF/STAT chunks) — no change to executable code | Safe ✅ |
| `/all_resources_bound` | **Changes `dcl_globalFlags`, register count, instruction order** | ❌ Causes artifacts |
| `/Gfp` | No change | Safe ✅ |

Example: `resolve_full_32bpp_cs` goes from 8221 → 8210 lines with 
`/all_resources_bound`, with 2899 differing lines including restructured 
register allocation.

Fix

Remove only `/all_resources_bound` from the FXC compilation flags. All other 
flags (`/O3`, `/Qstrip_*`, `/Gfp`) are retained as they are confirmed safe.

Testing

Tested on Mercenaries 2: World in Flames at 3x draw resolution scale with 
ROV path (D3D12, RTX 3090). Blue lightning glitches eliminated, all other 
rendering (water, smoke, general gameplay) confirmed correct.