### PR TITLE
[Build] Fix `discord-rpc` multi-arch builds

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -77,7 +77,11 @@ add_library(discord-rpc STATIC
   discord-rpc/src/serialization.cpp
   discord-rpc/src/serialization.h
 )
-target_compile_definitions(discord-rpc PRIVATE RAPIDJSON_SSE42)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+  target_compile_definitions(discord-rpc PRIVATE RAPIDJSON_SSE42)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+  target_compile_definitions(discord-rpc PRIVATE RAPIDJSON_NEON)
+endif()
 target_include_directories(discord-rpc PUBLIC discord-rpc/include PRIVATE rapidjson/include)
 if(WIN32)
   target_sources(discord-rpc PRIVATE


### PR DESCRIPTION
RapidJson needs to be configured to use NEON rather than SSE4.2 on arm64