### PR TITLE
[x64] Add `GFNI` optimization for single-byte vector splats

### DIFF
--- a/src/xenia/cpu/backend/x64/x64_emitter.cc
+++ b/src/xenia/cpu/backend/x64/x64_emitter.cc
@@ -1313,6 +1313,12 @@ void X64Emitter::LoadConstantXmm(Xbyak::Xmm dest, const vec128_t& v) {
       }
 
       if (all_equal_bytes) {
+        if (IsFeatureEnabled(kX64EmitGFNI)) {
+          vpxor(dest, dest);
+          vgf2p8affineqb(dest, dest, dest, firstbyte);
+          return;
+        }
+
         void* bval = FindByteConstantOffset(firstbyte);
 
         if (bval) {


### PR DESCRIPTION
Use the `vgf2p8affineqb` instruction to splat byte-values across a whole register without having to touch memory.