### PR TITLE
[CPU/A64] Bring the arm64 backend up on macOS

### DIFF
--- a/src/xenia/base/exception_handler_mac.cc
+++ b/src/xenia/base/exception_handler_mac.cc
@@ -1,0 +1,284 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2026 Ben Vanik. All rights reserved.
+ * Released under the BSD license - see LICENSE in the root for more details.
+ ******************************************************************************
+ */
+
+#define _XOPEN_SOURCE 600
+
+#include "xenia/base/exception_handler.h"
+
+#include <signal.h>
+#include <ucontext.h>
+#include <cstdint>
+#include <cstring>
+
+#include "xenia/base/assert.h"
+#include "xenia/base/host_thread_context.h"
+#include "xenia/base/logging.h"
+#include "xenia/base/math.h"
+#include "xenia/base/platform.h"
+
+namespace xe {
+
+bool signal_handlers_installed_ = false;
+struct sigaction original_sigill_handler_;
+struct sigaction original_sigtrap_handler_;
+struct sigaction original_sigbus_handler_;
+struct sigaction original_sigsegv_handler_;
+
+// This can be as large as needed, but isn't often needed.
+// As we will be sometimes firing many exceptions we want to avoid having to
+// scan the table too much or invoke many custom handlers.
+constexpr size_t kMaxHandlerCount = 8;
+
+// All custom handlers, left-aligned and null terminated.
+// Executed in order.
+std::pair<ExceptionHandler::Handler, void*> handlers_[kMaxHandlerCount];
+
+static void ExceptionHandlerCallback(int signal_number, siginfo_t* signal_info,
+                                     void* signal_context) {
+#if XE_ARCH_ARM64
+  // On ARM64, ucontext_t requires 16-byte alignment but the kernel may provide
+  // an unaligned pointer in the signal handler. Copy to an aligned local to
+  // avoid undefined behavior from misaligned access.
+  alignas(16) ucontext_t ucontext_storage;
+  std::memcpy(&ucontext_storage, signal_context, sizeof(ucontext_t));
+  ucontext_t* ucontext = &ucontext_storage;
+#else
+  ucontext_t* ucontext = reinterpret_cast<ucontext_t*>(signal_context);
+#endif
+  mcontext_t& mcontext = ucontext->uc_mcontext;
+
+  HostThreadContext thread_context;
+
+#if XE_ARCH_ARM64
+  // Extract the general-purpose registers from mcontext
+  thread_context.pc = mcontext->__ss.__pc;
+  thread_context.sp = mcontext->__ss.__sp;
+  thread_context.pstate = mcontext->__ss.__cpsr;
+
+  // x0 - x28
+  for (int i = 0; i < 29; ++i) {
+    thread_context.x[i] = mcontext->__ss.__x[i];
+  }
+  // x29 is the frame pointer
+  thread_context.x[29] = mcontext->__ss.__fp;
+  // x30 is the link register
+  thread_context.x[30] = mcontext->__ss.__lr;
+
+  // Copy the vector registers
+  for (int i = 0; i < 32; ++i) {
+    thread_context.v[i].low =
+        static_cast<uint64_t>(mcontext->__ns.__v[i] & 0xFFFFFFFFFFFFFFFF);
+    thread_context.v[i].high = static_cast<uint64_t>(
+        (mcontext->__ns.__v[i] >> 64) & 0xFFFFFFFFFFFFFFFF);
+  }
+
+  thread_context.fpsr = mcontext->__ns.__fpsr;
+  thread_context.fpcr = mcontext->__ns.__fpcr;
+#elif XE_ARCH_AMD64
+  thread_context.rip = mcontext->__ss.__rip;
+  thread_context.eflags = static_cast<uint32_t>(mcontext->__ss.__rflags);
+  thread_context.rax = mcontext->__ss.__rax;
+  thread_context.rcx = mcontext->__ss.__rcx;
+  thread_context.rdx = mcontext->__ss.__rdx;
+  thread_context.rbx = mcontext->__ss.__rbx;
+  thread_context.rsp = mcontext->__ss.__rsp;
+  thread_context.rbp = mcontext->__ss.__rbp;
+  thread_context.rsi = mcontext->__ss.__rsi;
+  thread_context.rdi = mcontext->__ss.__rdi;
+  thread_context.r8 = mcontext->__ss.__r8;
+  thread_context.r9 = mcontext->__ss.__r9;
+  thread_context.r10 = mcontext->__ss.__r10;
+  thread_context.r11 = mcontext->__ss.__r11;
+  thread_context.r12 = mcontext->__ss.__r12;
+  thread_context.r13 = mcontext->__ss.__r13;
+  thread_context.r14 = mcontext->__ss.__r14;
+  thread_context.r15 = mcontext->__ss.__r15;
+#endif  // XE_ARCH
+
+  Exception ex;
+  switch (signal_number) {
+    case SIGILL:
+    case SIGTRAP:
+      ex.InitializeIllegalInstruction(&thread_context);
+      break;
+    case SIGBUS:
+    case SIGSEGV: {
+      Exception::AccessViolationOperation access_violation_operation =
+          Exception::AccessViolationOperation::kUnknown;
+#if XE_ARCH_ARM64
+      // For a Data Abort (EC - ESR_EL1 bits 31:26 - 0b100100 from a lower
+      // Exception Level, 0b100101 without a change in the Exception Level),
+      // bit 6 is 0 for reading from a memory location, 1 for writing to a
+      // memory location.
+      const uint64_t esr = mcontext->__es.__esr;
+      if (((esr >> 26) & 0b111110) == 0b100100) {
+        access_violation_operation =
+            (esr & (UINT64_C(1) << 6))
+                ? Exception::AccessViolationOperation::kWrite
+                : Exception::AccessViolationOperation::kRead;
+      }
+#elif XE_ARCH_AMD64
+      // x86 page fault error code: bit 1 set indicates write.
+      constexpr uint64_t kX86PageFaultErrorCodeWrite = UINT64_C(1) << 1;
+      access_violation_operation =
+          (uint64_t(mcontext->__es.__err) & kX86PageFaultErrorCodeWrite)
+              ? Exception::AccessViolationOperation::kWrite
+              : Exception::AccessViolationOperation::kRead;
+#endif  // XE_ARCH
+
+      ex.InitializeAccessViolation(
+          &thread_context, reinterpret_cast<uint64_t>(signal_info->si_addr),
+          access_violation_operation);
+    } break;
+    default:
+      assert_unhandled_case(signal_number);
+  }
+
+  for (size_t i = 0; i < xe::countof(handlers_) && handlers_[i].first; ++i) {
+    if (handlers_[i].first(&ex, handlers_[i].second)) {
+      // Exception handled.
+#if XE_ARCH_ARM64
+      // Write back the modified registers to mcontext
+      mcontext->__ss.__pc = thread_context.pc;
+      mcontext->__ss.__sp = thread_context.sp;
+      mcontext->__ss.__cpsr = (__uint32_t)thread_context.pstate;
+
+      uint32_t modified_register_index;
+      uint32_t modified_x_registers_remaining = ex.modified_x_registers();
+      while (xe::bit_scan_forward(modified_x_registers_remaining,
+                                  &modified_register_index)) {
+        modified_x_registers_remaining &=
+            ~(UINT32_C(1) << modified_register_index);
+        if (modified_register_index < 29) {
+          mcontext->__ss.__x[modified_register_index] =
+              thread_context.x[modified_register_index];
+        } else if (modified_register_index == 29) {
+          mcontext->__ss.__fp = thread_context.x[29];
+        } else if (modified_register_index == 30) {
+          mcontext->__ss.__lr = thread_context.x[30];
+        }
+      }
+
+      if (ex.modified_v_registers()) {
+        uint32_t modified_v_register_index;
+        uint32_t modified_v_registers_remaining = ex.modified_v_registers();
+        while (xe::bit_scan_forward(modified_v_registers_remaining,
+                                    &modified_v_register_index)) {
+          modified_v_registers_remaining &=
+              ~(UINT32_C(1) << modified_v_register_index);
+          mcontext->__ns.__v[modified_v_register_index] =
+              (static_cast<__uint128_t>(
+                   thread_context.v[modified_v_register_index].high)
+               << 64) |
+              static_cast<__uint128_t>(
+                  thread_context.v[modified_v_register_index].low);
+        }
+        mcontext->__ns.__fpsr = thread_context.fpsr;
+        mcontext->__ns.__fpcr = thread_context.fpcr;
+      }
+      // Copy modified context back to the original signal context
+      std::memcpy(signal_context, ucontext, sizeof(ucontext_t));
+#elif XE_ARCH_AMD64
+      mcontext->__ss.__rip = thread_context.rip;
+      mcontext->__ss.__rflags = thread_context.eflags;
+      uint32_t modified_register_index;
+      uint16_t modified_int_registers_remaining = ex.modified_int_registers();
+      uint64_t* kIntRegisterMap[] = {
+          &mcontext->__ss.__rax, &mcontext->__ss.__rcx, &mcontext->__ss.__rdx,
+          &mcontext->__ss.__rbx, &mcontext->__ss.__rsp, &mcontext->__ss.__rbp,
+          &mcontext->__ss.__rsi, &mcontext->__ss.__rdi, &mcontext->__ss.__r8,
+          &mcontext->__ss.__r9,  &mcontext->__ss.__r10, &mcontext->__ss.__r11,
+          &mcontext->__ss.__r12, &mcontext->__ss.__r13, &mcontext->__ss.__r14,
+          &mcontext->__ss.__r15,
+      };
+      while (xe::bit_scan_forward(modified_int_registers_remaining,
+                                  &modified_register_index)) {
+        modified_int_registers_remaining &=
+            ~(UINT16_C(1) << modified_register_index);
+        *kIntRegisterMap[modified_register_index] =
+            thread_context.int_registers[modified_register_index];
+      }
+#endif  // XE_ARCH
+      return;
+    }
+  }
+}
+
+void ExceptionHandler::Install(Handler fn, void* data) {
+  if (!signal_handlers_installed_) {
+    struct sigaction signal_handler;
+
+    std::memset(&signal_handler, 0, sizeof(signal_handler));
+    signal_handler.sa_sigaction = ExceptionHandlerCallback;
+    signal_handler.sa_flags = SA_SIGINFO;
+
+    if (sigaction(SIGILL, &signal_handler, &original_sigill_handler_) != 0) {
+      assert_always("Failed to install new SIGILL handler");
+    }
+    if (sigaction(SIGTRAP, &signal_handler, &original_sigtrap_handler_) != 0) {
+      assert_always("Failed to install new SIGTRAP handler");
+    }
+    if (sigaction(SIGBUS, &signal_handler, &original_sigbus_handler_) != 0) {
+      assert_always("Failed to install new SIGBUS handler");
+    }
+    if (sigaction(SIGSEGV, &signal_handler, &original_sigsegv_handler_) != 0) {
+      assert_always("Failed to install new SIGSEGV handler");
+    }
+    signal_handlers_installed_ = true;
+  }
+
+  for (size_t i = 0; i < xe::countof(handlers_); ++i) {
+    if (!handlers_[i].first) {
+      handlers_[i].first = fn;
+      handlers_[i].second = data;
+      return;
+    }
+  }
+  assert_always("Too many exception handlers installed");
+}
+
+void ExceptionHandler::Uninstall(Handler fn, void* data) {
+  for (size_t i = 0; i < xe::countof(handlers_); ++i) {
+    if (handlers_[i].first == fn && handlers_[i].second == data) {
+      for (; i < xe::countof(handlers_) - 1; ++i) {
+        handlers_[i] = handlers_[i + 1];
+      }
+      handlers_[i].first = nullptr;
+      handlers_[i].second = nullptr;
+      break;
+    }
+  }
+
+  bool has_any = false;
+  for (size_t i = 0; i < xe::countof(handlers_); ++i) {
+    if (handlers_[i].first) {
+      has_any = true;
+      break;
+    }
+  }
+  if (!has_any) {
+    if (signal_handlers_installed_) {
+      if (sigaction(SIGILL, &original_sigill_handler_, NULL) != 0) {
+        assert_always("Failed to restore original SIGILL handler");
+      }
+      if (sigaction(SIGTRAP, &original_sigtrap_handler_, NULL) != 0) {
+        assert_always("Failed to restore original SIGTRAP handler");
+      }
+      if (sigaction(SIGBUS, &original_sigbus_handler_, NULL) != 0) {
+        assert_always("Failed to restore original SIGBUS handler");
+      }
+      if (sigaction(SIGSEGV, &original_sigsegv_handler_, NULL) != 0) {
+        assert_always("Failed to restore original SIGSEGV handler");
+      }
+      signal_handlers_installed_ = false;
+    }
+  }
+}
+
+}  // namespace xe

--- a/src/xenia/cpu/backend/a64/a64_assembler.cc
+++ b/src/xenia/cpu/backend/a64/a64_assembler.cc
@@ -93,10 +93,15 @@ bool A64Assembler::Assemble(GuestFunction* function, HIRBuilder* builder,
 
   // Install into indirection table.
   uint64_t host_address = reinterpret_cast<uint64_t>(machine_code);
+#if XE_A64_INDIRECTION_64BIT
+  reinterpret_cast<A64CodeCache*>(backend_->code_cache())
+      ->AddIndirection64(function->address(), host_address);
+#else
   assert_true((host_address >> 32) == 0);
   reinterpret_cast<A64CodeCache*>(backend_->code_cache())
       ->AddIndirection(function->address(),
                        static_cast<uint32_t>(host_address));
+#endif
 
   return true;
 }

--- a/src/xenia/cpu/backend/a64/a64_backend.cc
+++ b/src/xenia/cpu/backend/a64/a64_backend.cc
@@ -608,8 +608,13 @@ bool A64Backend::Initialize(Processor* processor) {
   }
 
   // Set the indirection table default to point at the resolve thunk.
+#if XE_A64_INDIRECTION_64BIT
+  code_cache_->set_indirection_default_64(
+      reinterpret_cast<uint64_t>(resolve_function_thunk_));
+#else
   code_cache_->set_indirection_default(
       uint32_t(reinterpret_cast<uint64_t>(resolve_function_thunk_)));
+#endif
 
   // Commit the indirection table range used by guest trampolines so that
   // CreateGuestTrampoline can call AddIndirection without faulting.
@@ -749,9 +754,14 @@ uint32_t A64Backend::CreateGuestTrampoline(GuestTrampolineProc proc,
       GUEST_TRAMPOLINE_BASE +
       (static_cast<uint32_t>(new_index) * GUEST_TRAMPOLINE_MIN_LEN);
 
+#if XE_A64_INDIRECTION_64BIT
+  code_cache()->AddIndirection64(indirection_guest_addr,
+                                 reinterpret_cast<uint64_t>(write_pos));
+#else
   code_cache()->AddIndirection(
       indirection_guest_addr,
       static_cast<uint32_t>(reinterpret_cast<uintptr_t>(write_pos)));
+#endif
 
   return indirection_guest_addr;
 }

--- a/src/xenia/cpu/backend/a64/a64_backend.cc
+++ b/src/xenia/cpu/backend/a64/a64_backend.cc
@@ -9,14 +9,25 @@
 
 #include "xenia/cpu/backend/a64/a64_backend.h"
 
+#include <array>
+#include <atomic>
 #include <cstddef>
 #include <cstring>
+
+#if XE_PLATFORM_MAC
+#include <pthread.h>
+#endif
+
+#if XE_PLATFORM_MAC || XE_PLATFORM_LINUX || XE_PLATFORM_IOS
+#include <dlfcn.h>
+#endif
 
 #include "xenia/base/clock.h"
 #include "xenia/base/exception_handler.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/memory.h"
 #include "xenia/base/platform.h"
+#include "xenia/base/string_buffer.h"
 #if XE_PLATFORM_WIN32
 #include "xenia/base/platform_win.h"
 #endif
@@ -30,11 +41,14 @@
 #include "xenia/cpu/backend/a64/a64_sequences.h"
 #include "xenia/cpu/backend/a64/a64_stack_layout.h"
 #include "xenia/cpu/breakpoint.h"
+#include "xenia/cpu/ppc/ppc_opcode_info.h"
 #include "xenia/cpu/ppc/ppc_context.h"
 #include "xenia/cpu/processor.h"
 #include "xenia/cpu/stack_walker.h"
 #include "xenia/cpu/thread_state.h"
 #include "xenia/cpu/xex_module.h"
+
+DECLARE_bool(record_mmio_access_exceptions);
 
 DEFINE_int64(a64_max_stackpoints, 65536,
              "Max number of host->guest stack mappings we can record.", "a64");
@@ -44,15 +58,45 @@ DEFINE_bool(a64_enable_host_guest_stack_synchronization, true,
             "and checks for reentry at return sites. Has slight performance "
             "impact, but fixes crashes in games that use setjmp/longjmp.",
             "a64");
+DEFINE_bool(a64_resolve_function_log, false,
+            "Log A64 ResolveFunction failures with module ranges.", "a64");
+DEFINE_int32(a64_resolve_function_log_limit, 8,
+             "Maximum ResolveFunction failure logs.", "a64");
+DEFINE_bool(a64_stack_sync_log, false, "Log A64 stack sync events.", "a64");
+DEFINE_int32(a64_stack_sync_log_limit, 16, "Maximum A64 stack sync logs.",
+             "a64");
 
 namespace xe {
 namespace cpu {
 namespace backend {
 namespace a64 {
 
+namespace {
+
+bool ShouldLogResolveFailure() {
+  if (!cvars::a64_resolve_function_log) {
+    return false;
+  }
+  const int32_t limit = cvars::a64_resolve_function_log_limit;
+  if (limit <= 0) {
+    return false;
+  }
+  static std::atomic<int32_t> log_count{0};
+  const int32_t count = log_count.fetch_add(1, std::memory_order_relaxed);
+  return count < limit;
+}
+
+}  // namespace
+
 // Resolve a guest function at runtime. Called by the resolve thunk when
 // a guest address has not yet been compiled.
-uint64_t ResolveFunction(void* raw_context, uint64_t target_address);
+uint64_t ResolveFunction(void* raw_context, uint64_t target_address,
+                         uint64_t host_return_address);
+
+void ForwardMMIOAccessForRecording(void* context, void* hostaddr) {
+  reinterpret_cast<A64Backend*>(context)
+      ->RecordMMIOExceptionForGuestInstruction(hostaddr);
+}
 
 // ==========================================================================
 // A64HelperEmitter — generates thunks using xbyak_aarch64.
@@ -61,10 +105,11 @@ class A64HelperEmitter : public A64Emitter {
  public:
   A64HelperEmitter(A64Backend* backend, XbyakA64Allocator* allocator);
 
-  HostToGuestThunk EmitHostToGuestThunk();
-  GuestToHostThunk EmitGuestToHostThunk();
-  ResolveFunctionThunk EmitResolveFunctionThunk();
-  void* EmitGuestAndHostSynchronizeStackHelper();
+  HostToGuestThunk EmitHostToGuestThunk(size_t* code_size_out = nullptr);
+  GuestToHostThunk EmitGuestToHostThunk(size_t* code_size_out = nullptr);
+  ResolveFunctionThunk EmitResolveFunctionThunk(size_t* code_size_out = nullptr);
+  void* EmitGuestAndHostSynchronizeStackHelper(
+      size_t* code_size_out = nullptr);
 };
 
 A64HelperEmitter::A64HelperEmitter(A64Backend* backend,
@@ -85,7 +130,7 @@ A64HelperEmitter::A64HelperEmitter(A64Backend* backend,
 //
 // We save all callee-saved regs, set up context (x20) and membase (x21),
 // then call the target. On return, restore and return to host.
-HostToGuestThunk A64HelperEmitter::EmitHostToGuestThunk() {
+HostToGuestThunk A64HelperEmitter::EmitHostToGuestThunk(size_t* code_size_out) {
   struct {
     size_t prolog;
     size_t prolog_stack_alloc;
@@ -175,6 +220,9 @@ HostToGuestThunk A64HelperEmitter::EmitHostToGuestThunk() {
       code_offsets.prolog_stack_alloc - code_offsets.prolog;
   func_info.stack_size = thunk_stack;
 
+  if (code_size_out) {
+    *code_size_out = func_info.code_size.total;
+  }
   void* fn = Emplace(func_info);
   return reinterpret_cast<HostToGuestThunk>(fn);
 }
@@ -189,7 +237,7 @@ HostToGuestThunk A64HelperEmitter::EmitHostToGuestThunk() {
 //
 // We save volatile guest registers that we need to preserve across the
 // host call, then call the host function with context as the first arg.
-GuestToHostThunk A64HelperEmitter::EmitGuestToHostThunk() {
+GuestToHostThunk A64HelperEmitter::EmitGuestToHostThunk(size_t* code_size_out) {
   struct {
     size_t prolog;
     size_t prolog_stack_alloc;
@@ -217,8 +265,9 @@ GuestToHostThunk A64HelperEmitter::EmitGuestToHostThunk() {
   //   q28, q29     sp + 0x100
   //   q30, q31     sp + 0x120
   //   x29, x30     sp + 0x140
-  //   Total: 0x150 = 336 bytes (16-byte aligned)
-  const size_t g2h_stack = 336;
+  //   x20, x21     sp + 0x150
+  //   Total: 0x160 = 352 bytes (16-byte aligned)
+  const size_t g2h_stack = 352;
   sub(sp, sp, static_cast<uint32_t>(g2h_stack));
   code_offsets.prolog_stack_alloc = getSize();
 
@@ -235,6 +284,8 @@ GuestToHostThunk A64HelperEmitter::EmitGuestToHostThunk() {
   stp(Xbyak_aarch64::QReg(30), Xbyak_aarch64::QReg(31), ptr(sp, 0x120));
   // Save x29/x30 (FP/LR).
   stp(x29, x30, ptr(sp, 0x140));
+  // Some host callbacks don't preserve our reserved guest-state registers.
+  stp(x20, x21, ptr(sp, 0x150));
 
   code_offsets.body = getSize();
 
@@ -245,6 +296,12 @@ GuestToHostThunk A64HelperEmitter::EmitGuestToHostThunk() {
   // x1, x2, x3 already hold args from the caller.
   blr(x9);
 
+  // Restore the reserved guest-state registers explicitly rather than relying
+  // on every host callback to honor AAPCS64 callee-save rules.
+  ldp(x20, x21, ptr(sp, 0x150));
+  // Reload membase in case the host callback clobbered x21.
+  ldr(x21, ptr(x20, static_cast<int32_t>(
+                        offsetof(ppc::PPCContext, virtual_membase))));
   // Host callbacks may change FPCR. Restore the guest scalar FPCR before
   // resuming the JIT so later guest ops observe the cached PPC mode.
   sub(x10, x20, static_cast<uint32_t>(sizeof(A64BackendContext)));
@@ -282,6 +339,9 @@ GuestToHostThunk A64HelperEmitter::EmitGuestToHostThunk() {
       code_offsets.prolog_stack_alloc - code_offsets.prolog;
   func_info.stack_size = g2h_stack;
 
+  if (code_size_out) {
+    *code_size_out = func_info.code_size.total;
+  }
   void* fn = Emplace(func_info);
   return reinterpret_cast<GuestToHostThunk>(fn);
 }
@@ -294,10 +354,11 @@ GuestToHostThunk A64HelperEmitter::EmitGuestToHostThunk() {
 // We call ResolveFunction to compile/lookup the target, then jump to it.
 //
 // On entry from the indirection table:
-//   w16 = guest PPC address (loaded by the call sequence)
+//   w17 = guest PPC address (preserved by the call sequence)
 //   x20 = context
 //   x30 = return address (from the BLR that got us here)
-ResolveFunctionThunk A64HelperEmitter::EmitResolveFunctionThunk() {
+ResolveFunctionThunk A64HelperEmitter::EmitResolveFunctionThunk(
+    size_t* code_size_out) {
   struct {
     size_t prolog;
     size_t prolog_stack_alloc;
@@ -319,14 +380,20 @@ ResolveFunctionThunk A64HelperEmitter::EmitResolveFunctionThunk() {
 
   code_offsets.body = getSize();
 
-  // Call ResolveFunction(context, target_address).
+  // Call ResolveFunction(context, target_address, host_return_address).
+  stp(x20, x21, ptr(sp, 0x10));
   mov(x0, x20);  // x0 = PPCContext*
-  mov(x1, x16);  // x1 = guest address (32-bit in w16)
+  mov(w1, w17);  // x1 = guest address (32-bit in w17)
+  mov(x2, x30);  // x2 = host return address after the call site
   // Load address of ResolveFunction.
   mov(x9, reinterpret_cast<uint64_t>(&ResolveFunction));
   blr(x9);
   // x0 now holds the resolved host machine code address.
   mov(x9, x0);
+  ldp(x20, x21, ptr(sp, 0x10));
+  // Reload membase in case ResolveFunction clobbered x21.
+  ldr(x21, ptr(x20, static_cast<int32_t>(
+                        offsetof(ppc::PPCContext, virtual_membase))));
 
   code_offsets.epilog = getSize();
 
@@ -351,6 +418,9 @@ ResolveFunctionThunk A64HelperEmitter::EmitResolveFunctionThunk() {
       code_offsets.prolog_stack_alloc - code_offsets.prolog;
   func_info.stack_size = thunk_stack;
 
+  if (code_size_out) {
+    *code_size_out = func_info.code_size.total;
+  }
   void* fn = Emplace(func_info);
   return reinterpret_cast<ResolveFunctionThunk>(fn);
 }
@@ -367,7 +437,8 @@ ResolveFunctionThunk A64HelperEmitter::EmitResolveFunctionThunk() {
 //   x9  = caller's stack size (to subtract from restored SP)
 //   x20 = PPCContext*
 //   The backend context is at (x20 - sizeof(A64BackendContext)).
-void* A64HelperEmitter::EmitGuestAndHostSynchronizeStackHelper() {
+void* A64HelperEmitter::EmitGuestAndHostSynchronizeStackHelper(
+    size_t* code_size_out) {
   using namespace Xbyak_aarch64;
   struct {
     size_t prolog;
@@ -461,27 +532,369 @@ void* A64HelperEmitter::EmitGuestAndHostSynchronizeStackHelper() {
       code_offsets.prolog_stack_alloc - code_offsets.prolog;
   func_info.stack_size = 0;
 
+  if (code_size_out) {
+    *code_size_out = func_info.code_size.total;
+  }
   return Emplace(func_info);
 }
 
 // ==========================================================================
 // ResolveFunction — runtime function resolution.
 // ==========================================================================
-uint64_t ResolveFunction(void* raw_context, uint64_t target_address) {
+uint64_t ResolveFunction(void* raw_context, uint64_t target_address,
+                         uint64_t host_return_address) {
   auto guest_context = reinterpret_cast<ppc::PPCContext*>(raw_context);
+  assert_not_null(guest_context);
   auto thread_state = guest_context->thread_state;
+  assert_not_null(thread_state);
   assert_not_zero(target_address);
 
-  auto fn = thread_state->processor()->ResolveFunction(
-      static_cast<uint32_t>(target_address));
-  if (!fn) {
-    // Unresolvable — return 0 which will fault.
+  uint32_t guest_address = 0;
+  if (target_address > 0xFFFFFFFFu) {
+    const auto ctx_ptr = reinterpret_cast<uint64_t>(guest_context);
+    if (target_address >= ctx_ptr &&
+        target_address < ctx_ptr + sizeof(ppc::PPCContext)) {
+      XELOGE(
+          "ResolveFunction: target_address 0x{:016X} is within PPCContext "
+          "[0x{:016X}, 0x{:016X})",
+          target_address, ctx_ptr, ctx_ptr + sizeof(ppc::PPCContext));
+      XELOGE(
+          "ResolveFunction: The target register contains a context pointer "
+          "instead of a function address");
+      return 0;
+    }
+
+    auto* code_cache = static_cast<A64CodeCache*>(
+        thread_state->processor()->backend()->code_cache());
+    auto* guest_function = code_cache->LookupFunction(target_address);
+    if (guest_function) {
+      guest_address =
+          guest_function->MapMachineCodeToGuestAddress(target_address);
+    } else {
+      guest_address = static_cast<uint32_t>(target_address);
+    }
+  } else {
+    guest_address = static_cast<uint32_t>(target_address);
+  }
+
+  if (!guest_address) {
+    XELOGE("ResolveFunction: guest_address is 0");
     return 0;
   }
 
-  auto guest_fn = static_cast<GuestFunction*>(fn);
+  if (cvars::a64_enable_host_guest_stack_synchronization &&
+      target_address <= 0xFFFFFFFFu) {
+    auto* processor = thread_state->processor();
+    auto* module_for_address =
+        processor->LookupModule(static_cast<uint32_t>(target_address));
+    if (module_for_address) {
+      auto* xexmod = dynamic_cast<XexModule*>(module_for_address);
+      if (xexmod) {
+        auto* flags = xexmod->GetInstructionAddressFlags(
+            static_cast<uint32_t>(target_address));
+        if (flags && flags->is_return_site) {
+          auto ones_with_address = processor->FindFunctionsWithAddress(
+              static_cast<uint32_t>(target_address));
+          if (!ones_with_address.empty()) {
+            A64Function* candidate = nullptr;
+            uintptr_t host_address = 0;
+            for (auto* entry : ones_with_address) {
+              auto* afunc = static_cast<A64Function*>(entry);
+              host_address = afunc->MapGuestAddressToMachineCode(
+                  static_cast<uint32_t>(target_address));
+              if (host_address &&
+                  afunc->machine_code() !=
+                      reinterpret_cast<const uint8_t*>(host_address)) {
+                candidate = afunc;
+                break;
+              }
+            }
+
+            if (candidate && host_address) {
+              auto* backend = static_cast<A64Backend*>(processor->backend());
+              auto* backend_context =
+                  backend->BackendContextForGuestContext(guest_context);
+              if (backend_context->stackpoints &&
+                  backend_context->current_stackpoint_depth > 0) {
+                uint32_t current_stackpoint_index =
+                    backend_context->current_stackpoint_depth - 1;
+                const uint32_t current_guest_stackpointer =
+                    static_cast<uint32_t>(guest_context->r[1]);
+                uint32_t num_frames_bigger = 0;
+
+                while (current_stackpoint_index != 0xFFFFFFFFu) {
+                  if (current_guest_stackpointer >
+                      backend_context->stackpoints[current_stackpoint_index]
+                          .guest_stack_) {
+                    --current_stackpoint_index;
+                    ++num_frames_bigger;
+                  } else {
+                    break;
+                  }
+                }
+
+                if (num_frames_bigger > 1 &&
+                    current_stackpoint_index != 0xFFFFFFFFu) {
+                  const uint32_t guest_lr =
+                      static_cast<uint32_t>(guest_context->lr);
+                  uint32_t scan_index = current_stackpoint_index;
+                  while (scan_index != 0xFFFFFFFFu) {
+                    const auto& sp_entry =
+                        backend_context->stackpoints[scan_index];
+                    if (sp_entry.guest_stack_ != current_guest_stackpointer) {
+                      break;
+                    }
+                    if (sp_entry.guest_return_address_ == guest_lr) {
+                      current_stackpoint_index = scan_index;
+                      break;
+                    }
+                    if (!scan_index) {
+                      break;
+                    }
+                    --scan_index;
+                  }
+
+                  if (cvars::a64_stack_sync_log) {
+                    static std::atomic<int32_t> sync_log_count{0};
+                    const int32_t limit = cvars::a64_stack_sync_log_limit;
+                    const int32_t count = sync_log_count.fetch_add(
+                        1, std::memory_order_relaxed);
+                    if (limit <= 0 || count < limit) {
+                      XELOGI(
+                          "A64 stack sync: guest=0x{:08X} host=0x{:016X} "
+                          "guest_sp=0x{:08X} depth={} index={}",
+                          static_cast<uint32_t>(target_address), host_address,
+                          current_guest_stackpointer,
+                          backend_context->current_stackpoint_depth,
+                          current_stackpoint_index);
+                    }
+                  }
+                  return host_address;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  auto fn = thread_state->processor()->ResolveFunction(guest_address);
+  if (!fn) {
+    XELOGE("ResolveFunction: Failed to resolve guest address 0x{:08X} "
+           "(target=0x{:016X}, lr=0x{:016X}, ctr=0x{:016X}, "
+           "host_return=0x{:016X}, thread={})",
+           guest_address, target_address, guest_context->lr,
+           guest_context->ctr, host_return_address, guest_context->thread_id);
+    if (ShouldLogResolveFailure()) {
+      auto* processor = thread_state->processor();
+      auto* code_cache = static_cast<A64CodeCache*>(processor->backend()->code_cache());
+      auto log_modules_for_address = [&](uint32_t address, const char* label) {
+        bool found = false;
+        for (auto* module : processor->GetModules()) {
+          if (!module) {
+            continue;
+          }
+          if (module->ContainsAddress(address)) {
+            XELOGI("ResolveFunction: {} module '{}' contains 0x{:08X}", label,
+                   module->name(), address);
+            found = true;
+          }
+        }
+        if (!found) {
+          XELOGI("ResolveFunction: {} no module contains 0x{:08X}", label,
+                 address);
+        }
+      };
+      log_modules_for_address(static_cast<uint32_t>(guest_context->lr), "lr");
+      log_modules_for_address(guest_address, "guest");
+
+      auto lr_functions = processor->FindFunctionsWithAddress(
+          static_cast<uint32_t>(guest_context->lr));
+      if (lr_functions.empty()) {
+        XELOGI("ResolveFunction: no resolved function covers LR 0x{:08X}",
+               static_cast<uint32_t>(guest_context->lr));
+      } else {
+        const auto* lr_fn = lr_functions.front();
+        XELOGI("ResolveFunction: LR function {} [0x{:08X},0x{:08X}) name='{}'",
+               lr_functions.size(), lr_fn->address(), lr_fn->end_address(),
+               lr_fn->name());
+      }
+
+      if (host_return_address) {
+        auto* host_fn = code_cache->LookupFunction(host_return_address);
+        if (!host_fn || !host_fn->machine_code()) {
+          XELOGI("ResolveFunction: no compiled guest function covers "
+                 "host_return=0x{:016X}",
+                 host_return_address);
+        } else {
+          const uint32_t host_resume_guest =
+              host_fn->MapMachineCodeToGuestAddress(host_return_address);
+          const uint32_t host_call_guest =
+              host_resume_guest >= 4 ? host_resume_guest - 4 : host_resume_guest;
+          XELOGI(
+              "ResolveFunction: host_return=0x{:016X} maps to function "
+              "[0x{:08X},0x{:08X}) '{}' resume=0x{:08X} callsite=0x{:08X}",
+              host_return_address, host_fn->address(), host_fn->end_address(),
+              host_fn->name(), host_resume_guest, host_call_guest);
+        }
+      }
+
+      auto* memory = thread_state->memory();
+      if (!memory) {
+        XELOGI("ResolveFunction: no Memory available for guest dump");
+      } else if (!memory->LookupHeap(guest_address)) {
+        XELOGI("ResolveFunction: guest_address 0x{:08X} not in any heap",
+               guest_address);
+      } else {
+        const uint8_t* data =
+            memory->TranslateVirtual<const uint8_t*>(guest_address);
+        std::array<uint8_t, 16> bytes = {};
+        std::memcpy(bytes.data(), data, bytes.size());
+        XELOGI(
+            "ResolveFunction: guest[0x{:08X}] = {:02X} {:02X} {:02X} {:02X} "
+            "{:02X} {:02X} {:02X} {:02X} {:02X} {:02X} {:02X} {:02X} "
+            "{:02X} {:02X} {:02X} {:02X}",
+            guest_address, bytes[0], bytes[1], bytes[2], bytes[3], bytes[4],
+            bytes[5], bytes[6], bytes[7], bytes[8], bytes[9], bytes[10],
+            bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]);
+
+        const uint32_t lr = static_cast<uint32_t>(guest_context->lr);
+        if (memory->LookupHeap(lr)) {
+          XELOGI(
+              "ResolveFunction: GPRs "
+              "r0=0x{:08X} r1=0x{:08X} r2=0x{:08X} r3=0x{:08X} "
+              "r4=0x{:08X} r5=0x{:08X} r6=0x{:08X} r7=0x{:08X}",
+              static_cast<uint32_t>(guest_context->r[0]),
+              static_cast<uint32_t>(guest_context->r[1]),
+              static_cast<uint32_t>(guest_context->r[2]),
+              static_cast<uint32_t>(guest_context->r[3]),
+              static_cast<uint32_t>(guest_context->r[4]),
+              static_cast<uint32_t>(guest_context->r[5]),
+              static_cast<uint32_t>(guest_context->r[6]),
+              static_cast<uint32_t>(guest_context->r[7]));
+          XELOGI(
+              "ResolveFunction: GPRs "
+              "r8=0x{:08X} r9=0x{:08X} r10=0x{:08X} r11=0x{:08X} "
+              "r12=0x{:08X} r13=0x{:08X} r31=0x{:08X}",
+              static_cast<uint32_t>(guest_context->r[8]),
+              static_cast<uint32_t>(guest_context->r[9]),
+              static_cast<uint32_t>(guest_context->r[10]),
+              static_cast<uint32_t>(guest_context->r[11]),
+              static_cast<uint32_t>(guest_context->r[12]),
+              static_cast<uint32_t>(guest_context->r[13]),
+              static_cast<uint32_t>(guest_context->r[31]));
+
+          for (int offset = -4; offset <= 4; ++offset) {
+            const uint32_t pc = lr + offset * 4;
+            if (!memory->LookupHeap(pc)) {
+              continue;
+            }
+            const uint32_t* instruction_ptr =
+                memory->TranslateVirtual<const uint32_t*>(pc);
+            if (!instruction_ptr) {
+              continue;
+            }
+            const uint32_t instruction = xe::load_and_swap<uint32_t>(
+                const_cast<uint32_t*>(instruction_ptr));
+            xe::StringBuffer disasm;
+            if (cpu::ppc::DisasmPPC(pc, instruction, &disasm)) {
+              XELOGI("ResolveFunction: lr_window{} 0x{:08X} {}",
+                     offset == 0 ? "*" : " ", instruction,
+                     disasm.to_string());
+            } else {
+              XELOGI("ResolveFunction: lr_window{} 0x{:08X}",
+                     offset == 0 ? "*" : " ", instruction);
+            }
+          }
+
+          if (host_return_address) {
+            auto* host_fn = code_cache->LookupFunction(host_return_address);
+            if (host_fn && host_fn->machine_code()) {
+              const uint32_t host_resume_guest =
+                  host_fn->MapMachineCodeToGuestAddress(host_return_address);
+              const uint32_t host_call_guest =
+                  host_resume_guest >= 4 ? host_resume_guest - 4
+                                         : host_resume_guest;
+              for (int offset = -4; offset <= 8; ++offset) {
+                const uint32_t pc = host_call_guest + offset * 4;
+                if (!memory->LookupHeap(pc)) {
+                  continue;
+                }
+                const uint32_t* instruction_ptr =
+                    memory->TranslateVirtual<const uint32_t*>(pc);
+                if (!instruction_ptr) {
+                  continue;
+                }
+                const uint32_t instruction = xe::load_and_swap<uint32_t>(
+                    const_cast<uint32_t*>(instruction_ptr));
+                xe::StringBuffer disasm;
+                if (cpu::ppc::DisasmPPC(pc, instruction, &disasm)) {
+                  XELOGI("ResolveFunction: callsite_window{} 0x{:08X} {}",
+                         offset == 0 ? "*" : " ", instruction,
+                         disasm.to_string());
+                } else {
+                  XELOGI("ResolveFunction: callsite_window{} 0x{:08X}",
+                         offset == 0 ? "*" : " ", instruction);
+                }
+              }
+            }
+          }
+
+          const uint32_t r31 = static_cast<uint32_t>(guest_context->r[31]);
+          if (memory->LookupHeap(r31)) {
+            XELOGI(
+                "ResolveFunction: stack32 "
+                "[r31+0x120]=0x{:08X} [r31+0x124]=0x{:08X} "
+                "[r31+0x128]=0x{:08X} [r31+0x12C]=0x{:08X}",
+                xe::load_and_swap<uint32_t>(
+                    memory->TranslateVirtual<uint32_t*>(r31 + 0x120)),
+                xe::load_and_swap<uint32_t>(
+                    memory->TranslateVirtual<uint32_t*>(r31 + 0x124)),
+                xe::load_and_swap<uint32_t>(
+                    memory->TranslateVirtual<uint32_t*>(r31 + 0x128)),
+                xe::load_and_swap<uint32_t>(
+                    memory->TranslateVirtual<uint32_t*>(r31 + 0x12C)));
+            XELOGI(
+                "ResolveFunction: stack32 "
+                "[r31+0x130]=0x{:08X} [r31+0x134]=0x{:08X} "
+                "[r31+0x138]=0x{:08X} [r31+0x13C]=0x{:08X}",
+                xe::load_and_swap<uint32_t>(
+                    memory->TranslateVirtual<uint32_t*>(r31 + 0x130)),
+                xe::load_and_swap<uint32_t>(
+                    memory->TranslateVirtual<uint32_t*>(r31 + 0x134)),
+                xe::load_and_swap<uint32_t>(
+                    memory->TranslateVirtual<uint32_t*>(r31 + 0x138)),
+                xe::load_and_swap<uint32_t>(
+                    memory->TranslateVirtual<uint32_t*>(r31 + 0x13C)));
+            XELOGI(
+                "ResolveFunction: stack32 "
+                "[r31+0x140]=0x{:08X} [r31+0x144]=0x{:08X} "
+                "[r31+0x148]=0x{:08X} [r31+0x14C]=0x{:08X}",
+                xe::load_and_swap<uint32_t>(
+                    memory->TranslateVirtual<uint32_t*>(r31 + 0x140)),
+                xe::load_and_swap<uint32_t>(
+                    memory->TranslateVirtual<uint32_t*>(r31 + 0x144)),
+                xe::load_and_swap<uint32_t>(
+                    memory->TranslateVirtual<uint32_t*>(r31 + 0x148)),
+                xe::load_and_swap<uint32_t>(
+                    memory->TranslateVirtual<uint32_t*>(r31 + 0x14C)));
+          }
+        } else {
+          XELOGI("ResolveFunction: LR 0x{:08X} not in any heap", lr);
+        }
+      }
+    }
+    return 0;
+  }
+
+  auto* guest_fn = static_cast<A64Function*>(fn);
   auto code = guest_fn->machine_code();
   if (!code) {
+    XELOGE(
+        "ResolveFunction: Function at guest address 0x{:08X} has no machine "
+        "code",
+        guest_address);
     return 0;
   }
   return reinterpret_cast<uint64_t>(code);
@@ -595,9 +1008,17 @@ bool A64Backend::Initialize(Processor* processor) {
   XbyakA64Allocator allocator;
   A64HelperEmitter thunk_emitter(this, &allocator);
 
-  host_to_guest_thunk_ = thunk_emitter.EmitHostToGuestThunk();
-  guest_to_host_thunk_ = thunk_emitter.EmitGuestToHostThunk();
-  resolve_function_thunk_ = thunk_emitter.EmitResolveFunctionThunk();
+  size_t host_to_guest_thunk_size = 0;
+  size_t guest_to_host_thunk_size = 0;
+  size_t resolve_function_thunk_size = 0;
+  size_t synchronize_guest_and_host_stack_helper_size = 0;
+
+  host_to_guest_thunk_ =
+      thunk_emitter.EmitHostToGuestThunk(&host_to_guest_thunk_size);
+  guest_to_host_thunk_ =
+      thunk_emitter.EmitGuestToHostThunk(&guest_to_host_thunk_size);
+  resolve_function_thunk_ =
+      thunk_emitter.EmitResolveFunctionThunk(&resolve_function_thunk_size);
 
   if (!host_to_guest_thunk_ || !guest_to_host_thunk_ ||
       !resolve_function_thunk_) {
@@ -607,8 +1028,15 @@ bool A64Backend::Initialize(Processor* processor) {
 
   if (cvars::a64_enable_host_guest_stack_synchronization) {
     synchronize_guest_and_host_stack_helper_ =
-        thunk_emitter.EmitGuestAndHostSynchronizeStackHelper();
+        thunk_emitter.EmitGuestAndHostSynchronizeStackHelper(
+            &synchronize_guest_and_host_stack_helper_size);
   }
+  host_to_guest_thunk_size_ = static_cast<uint32_t>(host_to_guest_thunk_size);
+  guest_to_host_thunk_size_ = static_cast<uint32_t>(guest_to_host_thunk_size);
+  resolve_function_thunk_size_ =
+      static_cast<uint32_t>(resolve_function_thunk_size);
+  synchronize_guest_and_host_stack_helper_size_ =
+      static_cast<uint32_t>(synchronize_guest_and_host_stack_helper_size);
 
   // Set the indirection table default to point at the resolve thunk.
 #if XE_A64_INDIRECTION_64BIT
@@ -629,6 +1057,10 @@ bool A64Backend::Initialize(Processor* processor) {
 
   // Register exception handler for MMIO access from JIT code.
   ExceptionHandler::Install(ExceptionCallbackThunk, this);
+  if (cvars::record_mmio_access_exceptions) {
+    processor->memory()->SetMMIOExceptionRecordingCallback(
+        ForwardMMIOAccessForRecording, this);
+  }
 
   return true;
 }
@@ -655,6 +1087,8 @@ uint64_t A64Backend::CalculateNextHostInstruction(ThreadDebugInfo* thread_info,
 
 // ARM64 BRK #0 encoding (4 bytes, fixed-width instruction).
 static constexpr uint32_t kArm64Brk0 = 0xD4200000;
+static constexpr uint32_t kArm64BrkMask = 0xFFE0001F;
+static constexpr uint32_t kArm64BrkFixed = 0xD4200000;
 
 void A64Backend::InstallBreakpoint(Breakpoint* breakpoint) {
   breakpoint->ForEachHostAddress([breakpoint](uint64_t host_address) {
@@ -744,9 +1178,18 @@ uint32_t A64Backend::CreateGuestTrampoline(GuestTrampolineProc proc,
   uint8_t* write_pos =
       &guest_trampoline_memory_[kGuestTrampolineSize * new_index];
 
+#if XE_PLATFORM_MAC
+  // MAP_JIT pages are only writable while thread-local JIT write protection is
+  // disabled. Guest trampolines are emitted lazily on running guest threads, so
+  // we must flip the thread into write mode for this small patch-up window.
+  pthread_jit_write_protect_np(0);
+#endif
   BuildGuestTrampoline(write_pos, reinterpret_cast<void*>(proc), userdata1,
                        userdata2,
                        reinterpret_cast<void*>(guest_to_host_thunk_));
+#if XE_PLATFORM_MAC
+  pthread_jit_write_protect_np(1);
+#endif
 
   // Flush instruction cache for the new trampoline code.
 #if XE_PLATFORM_WIN32
@@ -856,11 +1299,48 @@ void A64Backend::RecordMMIOExceptionForGuestInstruction(void* host_address) {
         cpu::InfoCacheFlags* icf =
             xex_guest_module->GetInstructionAddressFlags(guestaddr);
         if (icf) {
+          const bool was_mmio = icf->accessed_mmio;
           icf->accessed_mmio = true;
+          if (!was_mmio) {
+            xex_guest_module->FlushInfoCache();
+          }
         }
       }
     }
   }
+}
+
+const char* A64Backend::LookupHelperThunk(uint64_t host_pc,
+                                          uint32_t* offset_out) const {
+  struct HelperRange {
+    uint64_t start;
+    uint32_t size;
+    const char* name;
+  };
+  const HelperRange ranges[] = {
+      {reinterpret_cast<uint64_t>(host_to_guest_thunk_), host_to_guest_thunk_size_,
+       "host_to_guest"},
+      {reinterpret_cast<uint64_t>(guest_to_host_thunk_), guest_to_host_thunk_size_,
+       "guest_to_host"},
+      {reinterpret_cast<uint64_t>(resolve_function_thunk_),
+       resolve_function_thunk_size_, "resolve_function"},
+      {reinterpret_cast<uint64_t>(synchronize_guest_and_host_stack_helper_),
+       synchronize_guest_and_host_stack_helper_size_, "stack_sync_helper"},
+  };
+
+  for (const auto& range : ranges) {
+    if (!range.start || !range.size) {
+      continue;
+    }
+    const uint64_t end = range.start + range.size;
+    if (host_pc >= range.start && host_pc < end) {
+      if (offset_out) {
+        *offset_out = static_cast<uint32_t>(host_pc - range.start);
+      }
+      return range.name;
+    }
+  }
+  return nullptr;
 }
 
 bool A64Backend::ExceptionCallbackThunk(Exception* ex, void* data) {
@@ -869,14 +1349,145 @@ bool A64Backend::ExceptionCallbackThunk(Exception* ex, void* data) {
 }
 
 bool A64Backend::ExceptionCallback(Exception* ex) {
+  if (ex->code() == Exception::Code::kAccessViolation) {
+    const uint64_t host_pc = ex->pc();
+    const uint64_t fault_address = ex->fault_address();
+    uint64_t guest_pc = 0;
+    uint32_t host_offset = 0;
+    uint32_t helper_offset = 0;
+    bool in_trampoline_stub = false;
+    const char* helper_name = LookupHelperThunk(host_pc, &helper_offset);
+    if (guest_trampoline_memory_) {
+      const uint64_t tramp_base =
+          reinterpret_cast<uint64_t>(guest_trampoline_memory_);
+      const uint64_t tramp_end =
+          tramp_base +
+          static_cast<uint64_t>(kGuestTrampolineSize) *
+              static_cast<uint64_t>(MAX_GUEST_TRAMPOLINES);
+      if (host_pc >= tramp_base && host_pc < tramp_end) {
+        const size_t stub_index = static_cast<size_t>((host_pc - tramp_base) /
+                                                      kGuestTrampolineSize);
+        guest_pc = GUEST_TRAMPOLINE_BASE +
+                   static_cast<uint32_t>(stub_index) * GUEST_TRAMPOLINE_MIN_LEN;
+        in_trampoline_stub = true;
+      }
+    }
+    auto function = code_cache_->LookupFunction(host_pc);
+    if (function && function->machine_code()) {
+      const uint64_t function_pc =
+          reinterpret_cast<uint64_t>(function->machine_code());
+      host_offset = static_cast<uint32_t>(host_pc - function_pc);
+      if (const auto* entry = function->LookupMachineCodeOffset(host_offset)) {
+        guest_pc = entry->guest_address;
+      }
+    }
+    auto* thread_context = ex->thread_context();
+    XELOGE(
+        "A64 AV: host_pc=0x{:016X} guest_pc=0x{:08X} host_off=0x{:X} "
+        "fault=0x{:016X} op={} helper={} helper_off=0x{:X} trampoline={} "
+        "x0=0x{:016X} x1=0x{:016X} x2=0x{:016X} x9=0x{:016X} "
+        "x16=0x{:016X} x20=0x{:016X} x21=0x{:016X}",
+        host_pc, guest_pc, host_offset, fault_address,
+        static_cast<int>(ex->access_violation_operation()),
+        helper_name ? helper_name : "-",
+        helper_name ? helper_offset : 0, in_trampoline_stub,
+        thread_context ? thread_context->x[0] : 0,
+        thread_context ? thread_context->x[1] : 0,
+        thread_context ? thread_context->x[2] : 0,
+        thread_context ? thread_context->x[9] : 0,
+        thread_context ? thread_context->x[16] : 0,
+        thread_context ? thread_context->x[20] : 0,
+        thread_context ? thread_context->x[21] : 0);
+#if XE_PLATFORM_MAC || XE_PLATFORM_LINUX || XE_PLATFORM_IOS
+    if (!function && !helper_name && !in_trampoline_stub) {
+      const uint64_t code_base = code_cache_->execute_base_address();
+      const uint64_t code_end = code_base + code_cache_->total_size();
+      XELOGE("A64 AV: host_pc in code cache range? {} base=0x{:016X} end=0x{:016X}",
+             (host_pc >= code_base && host_pc < code_end), code_base, code_end);
+      Dl_info info;
+      if (dladdr(reinterpret_cast<void*>(host_pc), &info) && info.dli_fname) {
+        XELOGE("A64 AV: dladdr image={} sym={}",
+               info.dli_fname, info.dli_sname ? info.dli_sname : "unknown");
+      }
+    }
+#endif
+    return false;
+  }
   if (ex->code() != Exception::Code::kIllegalInstruction) {
     return false;
   }
 
-  // Verify it's our BRK #0 instruction.
-  auto instruction_bytes =
-      xe::load<uint32_t>(reinterpret_cast<void*>(ex->pc()));
-  if (instruction_bytes != kArm64Brk0) {
+  const uint64_t host_pc = ex->pc();
+  const auto instruction_bytes =
+      xe::load<uint32_t>(reinterpret_cast<void*>(host_pc));
+  if ((instruction_bytes & kArm64BrkMask) != kArm64BrkFixed) {
+    return false;
+  }
+
+  const uint32_t trap_imm = (instruction_bytes >> 5) & 0xFFFF;
+  uint32_t host_offset = 0;
+  uint32_t helper_offset = 0;
+  uint64_t guest_pc = 0;
+  bool in_trampoline_stub = false;
+  const char* helper_name = LookupHelperThunk(host_pc, &helper_offset);
+  if (guest_trampoline_memory_) {
+    const uint64_t tramp_base =
+        reinterpret_cast<uint64_t>(guest_trampoline_memory_);
+    const uint64_t tramp_end =
+        tramp_base + static_cast<uint64_t>(kGuestTrampolineSize) *
+                         static_cast<uint64_t>(MAX_GUEST_TRAMPOLINES);
+    if (host_pc >= tramp_base && host_pc < tramp_end) {
+      const size_t stub_index =
+          static_cast<size_t>((host_pc - tramp_base) / kGuestTrampolineSize);
+      guest_pc = GUEST_TRAMPOLINE_BASE +
+                 static_cast<uint32_t>(stub_index) * GUEST_TRAMPOLINE_MIN_LEN;
+      in_trampoline_stub = true;
+    }
+  }
+  auto* function = code_cache_->LookupFunction(host_pc);
+  if (function && function->machine_code()) {
+    const uint64_t function_pc =
+        reinterpret_cast<uint64_t>(function->machine_code());
+    host_offset = static_cast<uint32_t>(host_pc - function_pc);
+    if (const auto* entry = function->LookupMachineCodeOffset(host_offset)) {
+      guest_pc = entry->guest_address;
+    }
+  }
+
+  if (trap_imm != 0) {
+    auto* thread_context = ex->thread_context();
+    XELOGE(
+        "A64 BRK: imm=0x{:X} host_pc=0x{:016X} guest_pc=0x{:08X} "
+        "host_off=0x{:X} helper={} helper_off=0x{:X} trampoline={} "
+        "x0=0x{:016X} x1=0x{:016X} x2=0x{:016X} x9=0x{:016X} "
+        "x16=0x{:016X} x20=0x{:016X} x21=0x{:016X}",
+        trap_imm, host_pc, guest_pc, host_offset, helper_name ? helper_name : "-",
+        helper_name ? helper_offset : 0, in_trampoline_stub,
+        thread_context ? thread_context->x[0] : 0,
+        thread_context ? thread_context->x[1] : 0,
+        thread_context ? thread_context->x[2] : 0,
+        thread_context ? thread_context->x[9] : 0,
+        thread_context ? thread_context->x[16] : 0,
+        thread_context ? thread_context->x[20] : 0,
+        thread_context ? thread_context->x[21] : 0);
+    if (function) {
+      XELOGE("A64 BRK: function='{}' range=[0x{:08X},0x{:08X})",
+             function->name(), function->address(), function->end_address());
+    }
+#if XE_PLATFORM_MAC || XE_PLATFORM_LINUX || XE_PLATFORM_IOS
+    if (!function && !helper_name && !in_trampoline_stub) {
+      const uint64_t code_base = code_cache_->execute_base_address();
+      const uint64_t code_end = code_base + code_cache_->total_size();
+      XELOGE(
+          "A64 BRK: host_pc in code cache range? {} base=0x{:016X} end=0x{:016X}",
+          (host_pc >= code_base && host_pc < code_end), code_base, code_end);
+      Dl_info info;
+      if (dladdr(reinterpret_cast<void*>(host_pc), &info) && info.dli_fname) {
+        XELOGE("A64 BRK: dladdr image={} sym={}", info.dli_fname,
+               info.dli_sname ? info.dli_sname : "unknown");
+      }
+    }
+#endif
     return false;
   }
 

--- a/src/xenia/cpu/backend/a64/a64_backend.cc
+++ b/src/xenia/cpu/backend/a64/a64_backend.cc
@@ -529,20 +529,10 @@ A64Backend::A64Backend() {
   code_cache_ = A64CodeCache::Create();
 
   // Allocate executable memory for guest trampolines.
-  uint32_t base_address = 0x10000;
-  void* buf = nullptr;
-  while (base_address < 0x80000000) {
-    buf = memory::AllocFixed(
-        reinterpret_cast<void*>(static_cast<uintptr_t>(base_address)),
-        kGuestTrampolineSize * MAX_GUEST_TRAMPOLINES,
-        xe::memory::AllocationType::kReserveCommit,
-        xe::memory::PageAccess::kExecuteReadWrite);
-    if (!buf) {
-      base_address += 65536;
-    } else {
-      break;
-    }
-  }
+  void* buf =
+      memory::AllocFixed(nullptr, kGuestTrampolineSize * MAX_GUEST_TRAMPOLINES,
+                         xe::memory::AllocationType::kReserveCommit,
+                         xe::memory::PageAccess::kExecuteReadWrite);
   xenia_assert(buf);
   guest_trampoline_memory_ = reinterpret_cast<uint8_t*>(buf);
   guest_trampoline_address_bitmap_.Resize(MAX_GUEST_TRAMPOLINES);

--- a/src/xenia/cpu/backend/a64/a64_backend.cc
+++ b/src/xenia/cpu/backend/a64/a64_backend.cc
@@ -126,6 +126,12 @@ HostToGuestThunk A64HelperEmitter::EmitHostToGuestThunk() {
   // x21 = virtual_membase (loaded from context)
   ldr(x21, ptr(x20, static_cast<int32_t>(
                         offsetof(ppc::PPCContext, virtual_membase))));
+  // Restore the guest scalar FPCR on every host->guest entry so host-side
+  // work done before the call can't leak a stale rounding / non-IEEE mode.
+  sub(x10, x20, static_cast<uint32_t>(sizeof(A64BackendContext)));
+  ldr(w11,
+      ptr(x10, static_cast<uint32_t>(offsetof(A64BackendContext, fpcr_fpu))));
+  msr(3, 3, 4, 4, 0, x11);
   // x0 still holds target, x2 holds return address.
   // The guest function's prolog stores x0 to GUEST_RET_ADDR on its stack
   // frame. Move the target to a scratch reg and put the guest return
@@ -238,6 +244,13 @@ GuestToHostThunk A64HelperEmitter::EmitGuestToHostThunk() {
   mov(x0, x20);  // x0 = PPCContext* (our context reg)
   // x1, x2, x3 already hold args from the caller.
   blr(x9);
+
+  // Host callbacks may change FPCR. Restore the guest scalar FPCR before
+  // resuming the JIT so later guest ops observe the cached PPC mode.
+  sub(x10, x20, static_cast<uint32_t>(sizeof(A64BackendContext)));
+  ldr(w11,
+      ptr(x10, static_cast<uint32_t>(offsetof(A64BackendContext, fpcr_fpu))));
+  msr(3, 3, 4, 4, 0, x11);
 
   code_offsets.epilog = getSize();
 
@@ -698,6 +711,10 @@ void A64Backend::InitializeBackendContext(void* ctx) {
       a64_ctx->stackpoints = new A64BackendStackpoint[max_stackpoints]();
     }
   }
+
+  // Reset the live host FPCR for a fresh PPC context so one test's rounding
+  // state does not leak into the next on the shared PPC test runner thread.
+  SetGuestRoundingMode(ctx, 0);
 }
 
 void A64Backend::DeinitializeBackendContext(void* ctx) {
@@ -781,15 +798,18 @@ void A64Backend::SetGuestRoundingMode(void* ctx, unsigned int mode) {
   A64BackendContext* bctx = BackendContextForGuestContext(ctx);
   uint32_t control = mode & 7;
   uint32_t fpcr_val = fpcr_table[control];
-#if XE_ARCH_ARM64
 #if XE_COMPILER_MSVC
   // MSVC ARM64 intrinsic: ARM64_FPCR = register ID 0x5A20.
   _WriteStatusReg(0x5A20, static_cast<uint64_t>(fpcr_val));
 #else
   __asm__ volatile("msr fpcr, %0" : : "r"(static_cast<uint64_t>(fpcr_val)));
 #endif
-#endif
   bctx->fpcr_fpu = fpcr_val;
+  if (control & 0b100) {
+    bctx->flags |= (1u << kA64BackendNonIEEEMode);
+  } else {
+    bctx->flags &= ~(1u << kA64BackendNonIEEEMode);
+  }
   auto ppc_context = reinterpret_cast<ppc::PPCContext*>(ctx);
   ppc_context->fpscr.bits.rn = control;
   ppc_context->fpscr.bits.ni = control >> 2;

--- a/src/xenia/cpu/backend/a64/a64_backend.h
+++ b/src/xenia/cpu/backend/a64/a64_backend.h
@@ -143,6 +143,7 @@ class A64Backend : public Backend {
   void RecordMMIOExceptionForGuestInstruction(void* host_address);
 
  private:
+  const char* LookupHelperThunk(uint64_t host_pc, uint32_t* offset_out) const;
   static bool ExceptionCallbackThunk(Exception* ex, void* data);
   bool ExceptionCallback(Exception* ex);
 
@@ -155,6 +156,10 @@ class A64Backend : public Backend {
   GuestToHostThunk guest_to_host_thunk_ = nullptr;
   ResolveFunctionThunk resolve_function_thunk_ = nullptr;
   void* synchronize_guest_and_host_stack_helper_ = nullptr;
+  uint32_t host_to_guest_thunk_size_ = 0;
+  uint32_t guest_to_host_thunk_size_ = 0;
+  uint32_t resolve_function_thunk_size_ = 0;
+  uint32_t synchronize_guest_and_host_stack_helper_size_ = 0;
 
  public:
   void* try_acquire_reservation_helper_ = nullptr;

--- a/src/xenia/cpu/backend/a64/a64_code_cache.cc
+++ b/src/xenia/cpu/backend/a64/a64_code_cache.cc
@@ -9,17 +9,326 @@
 
 #include "xenia/cpu/backend/a64/a64_code_cache.h"
 
+#include <cstring>
+
+#if XE_PLATFORM_MAC && XE_ARCH_ARM64
+#include <pthread.h>
+#endif
+
 #include "xenia/base/platform.h"
 #if XE_PLATFORM_WIN32
 #include "xenia/base/platform_win.h"
 #endif
+#include "xenia/base/assert.h"
+#include "xenia/base/literals.h"
+#include "xenia/base/logging.h"
+#include "xenia/base/math.h"
 
 namespace xe {
 namespace cpu {
 namespace backend {
 namespace a64 {
 
-bool A64CodeCache::Initialize() { return CodeCacheBase::Initialize(); }
+A64CodeCache::~A64CodeCache() {
+#if XE_A64_INDIRECTION_64BIT
+  if (indirection_table_base_) {
+    xe::memory::DeallocFixed(indirection_table_base_, kA64IndirectionTableSize,
+                             xe::memory::DeallocationType::kRelease);
+    indirection_table_base_ = nullptr;
+  }
+#endif
+#if XE_PLATFORM_MAC && XE_ARCH_ARM64
+  // The macOS ARM64 JIT path uses a direct MAP_JIT allocation instead of a
+  // shared file mapping, so free it here before the generic base teardown.
+  if (mapping_ == xe::memory::kFileMappingHandleInvalid &&
+      generated_code_execute_base_) {
+    xe::memory::DeallocFixed(generated_code_execute_base_, kGeneratedCodeSize,
+                             xe::memory::DeallocationType::kRelease);
+    generated_code_execute_base_ = nullptr;
+    generated_code_write_base_ = nullptr;
+  }
+#endif
+}
+
+bool A64CodeCache::InitializeEncodedIndirectionTableState() {
+#if XE_A64_INDIRECTION_64BIT
+  if (!indirection_table_base_) {
+    return false;
+  }
+  indirection_table_actual_base_ =
+      reinterpret_cast<uintptr_t>(indirection_table_base_);
+  indirection_table_base_bias_ = indirection_table_actual_base_ -
+                                 static_cast<uintptr_t>(kIndirectionTableBase);
+  external_indirection_targets_ = std::make_unique<uint64_t[]>(
+      static_cast<size_t>(kIndirectionExternalCapacity));
+  if (!external_indirection_targets_) {
+    XELOGE("Unable to allocate ARM64 external indirection target table");
+    return false;
+  }
+  external_indirection_target_count_.store(0, std::memory_order_relaxed);
+#endif
+  return true;
+}
+
+bool A64CodeCache::InitializeEncodedIndirectionTable() {
+#if XE_A64_INDIRECTION_64BIT
+  indirection_table_base_ = reinterpret_cast<uint8_t*>(xe::memory::AllocFixed(
+      nullptr, kA64IndirectionTableSize, xe::memory::AllocationType::kReserve,
+      xe::memory::PageAccess::kNoAccess));
+  if (!indirection_table_base_) {
+    XELOGE("Unable to reserve ARM64 indirection table");
+    return false;
+  }
+  return InitializeEncodedIndirectionTableState();
+#else
+  return true;
+#endif
+}
+
+bool A64CodeCache::Initialize() {
+#if XE_A64_INDIRECTION_64BIT
+#if XE_PLATFORM_MAC && XE_ARCH_ARM64
+  if (xe::memory::IsWritableExecutableMemoryPreferred()) {
+    if (!InitializeEncodedIndirectionTable()) {
+      return false;
+    }
+
+    generated_code_execute_base_ = reinterpret_cast<uint8_t*>(
+        xe::memory::AllocFixed(nullptr, kGeneratedCodeSize,
+                               xe::memory::AllocationType::kReserveCommit,
+                               xe::memory::PageAccess::kExecuteReadWrite));
+    generated_code_write_base_ = generated_code_execute_base_;
+    if (!generated_code_execute_base_) {
+      XELOGE("Unable to allocate macOS ARM64 JIT code cache");
+      return false;
+    }
+
+    generated_code_commit_mark_ = kGeneratedCodeSize;
+    generated_code_map_.reserve(kMaximumFunctionCount);
+    return true;
+  }
+#endif
+
+  if (!CodeCacheBase<A64CodeCache>::Initialize()) {
+    return false;
+  }
+  return InitializeEncodedIndirectionTableState();
+#else
+  return CodeCacheBase<A64CodeCache>::Initialize();
+#endif
+}
+
+void A64CodeCache::set_indirection_default(uint32_t default_value) {
+  CodeCacheBase<A64CodeCache>::set_indirection_default(default_value);
+}
+
+#if XE_A64_INDIRECTION_64BIT
+uint32_t A64CodeCache::EncodeIndirectionTarget(uint64_t host_address) {
+  const uintptr_t code_base = execute_base_address();
+  const uintptr_t code_end = code_base + kGeneratedCodeSize;
+  if (host_address >= code_base && host_address < code_end) {
+    return static_cast<uint32_t>(host_address - code_base);
+  }
+
+  if (!external_indirection_targets_) {
+    XELOGE("ARM64 external indirection table is unavailable");
+    return indirection_default_value_;
+  }
+
+  std::lock_guard<std::mutex> lock(external_indirection_mutex_);
+  const uint32_t current_count =
+      external_indirection_target_count_.load(std::memory_order_relaxed);
+  if (current_count >= kIndirectionExternalCapacity) {
+    XELOGE("ARM64 external indirection table overflow");
+    return indirection_default_value_;
+  }
+
+  external_indirection_targets_[current_count] = host_address;
+  external_indirection_target_count_.store(current_count + 1,
+                                           std::memory_order_release);
+  return kIndirectionExternalTag | current_count;
+}
+
+void A64CodeCache::set_indirection_default_64(uint64_t default_value) {
+  CodeCacheBase<A64CodeCache>::set_indirection_default(
+      EncodeIndirectionTarget(default_value));
+}
+#endif
+
+void A64CodeCache::AddIndirection(uint32_t guest_address,
+                                  uint32_t host_address) {
+#if XE_A64_INDIRECTION_64BIT
+  AddIndirection64(guest_address, host_address);
+#else
+  PublishIndirection(guest_address, host_address);
+#endif
+}
+
+#if XE_A64_INDIRECTION_64BIT
+void A64CodeCache::AddIndirection64(uint32_t guest_address,
+                                    uint64_t host_address) {
+  PublishIndirection(guest_address, host_address);
+}
+#endif
+
+void A64CodeCache::CommitExecutableRange(uint32_t guest_low,
+                                         uint32_t guest_high) {
+  if (!indirection_table_base_) {
+    return;
+  }
+
+#if XE_A64_INDIRECTION_64BIT
+  if (guest_low < kIndirectionTableBase || guest_high < guest_low) {
+    return;
+  }
+  const uint64_t start_offset =
+      uint64_t(guest_low) - uint64_t(kIndirectionTableBase);
+  const uint64_t size = uint64_t(guest_high) - uint64_t(guest_low);
+  if (start_offset + size > kA64IndirectionTableSize) {
+    return;
+  }
+  if (!xe::memory::AllocFixed(indirection_table_base_ + start_offset, size,
+                              xe::memory::AllocationType::kCommit,
+                              xe::memory::PageAccess::kReadWrite)) {
+    return;
+  }
+  auto* slots =
+      reinterpret_cast<uint32_t*>(indirection_table_base_ + start_offset);
+  const uint64_t entry_count = size / kA64IndirectionEntrySize;
+  for (uint64_t i = 0; i < entry_count; ++i) {
+    slots[i] = indirection_default_value_;
+  }
+#else
+  xe::memory::AllocFixed(
+      indirection_table_base_ + (guest_low - kIndirectionTableBase),
+      guest_high - guest_low, xe::memory::AllocationType::kCommit,
+      xe::memory::PageAccess::kReadWrite);
+  uint32_t* slots = reinterpret_cast<uint32_t*>(indirection_table_base_);
+  for (uint32_t address = guest_low; address < guest_high; address += 4) {
+    slots[(address - kIndirectionTableBase) / 4] = indirection_default_value_;
+  }
+#endif
+}
+
+void A64CodeCache::PlaceHostCode(uint32_t guest_address, void* machine_code,
+                                 const EmitFunctionInfo& func_info,
+                                 void*& code_execute_address_out,
+                                 void*& code_write_address_out) {
+  PlaceGuestCode(guest_address, machine_code, func_info, nullptr,
+                 code_execute_address_out, code_write_address_out);
+}
+
+void A64CodeCache::PlaceGuestCode(uint32_t guest_address, void* machine_code,
+                                  const EmitFunctionInfo& func_info,
+                                  GuestFunction* function_info,
+                                  void*& code_execute_address_out,
+                                  void*& code_write_address_out) {
+  size_t high_mark = 0;
+  uint8_t* code_execute_address = nullptr;
+  uint8_t* tail_execute_address = nullptr;
+  uint8_t* end_execute_address = nullptr;
+  UnwindReservation unwind_reservation;
+  {
+    auto global_lock = global_critical_region_.Acquire();
+
+    code_execute_address =
+        generated_code_execute_base_ + generated_code_offset_;
+    code_execute_address_out = code_execute_address;
+    uint8_t* code_write_address =
+        generated_code_write_base_ + generated_code_offset_;
+    code_write_address_out = code_write_address;
+    generated_code_offset_ += xe::round_up(func_info.code_size.total, 16);
+
+    uint8_t* tail_write_address =
+        generated_code_write_base_ + generated_code_offset_;
+    tail_execute_address =
+        generated_code_execute_base_ + generated_code_offset_;
+
+    unwind_reservation = RequestUnwindReservation(generated_code_write_base_ +
+                                                  generated_code_offset_);
+    generated_code_offset_ += xe::round_up(unwind_reservation.data_size, 16);
+
+    uint8_t* end_write_address =
+        generated_code_write_base_ + generated_code_offset_;
+    end_execute_address = generated_code_execute_base_ + generated_code_offset_;
+    high_mark = generated_code_offset_;
+
+    generated_code_map_.emplace_back(
+        (uint64_t(code_execute_address - generated_code_execute_base_) << 32) |
+            generated_code_offset_,
+        function_info);
+
+    EnsureCommitted(high_mark);
+
+#if XE_PLATFORM_MAC && XE_ARCH_ARM64
+    const bool jit_write =
+        generated_code_execute_base_ == generated_code_write_base_;
+    if (jit_write) {
+      pthread_jit_write_protect_np(0);
+    }
+#endif
+
+    std::memcpy(code_write_address, machine_code, func_info.code_size.total);
+    if (end_write_address > tail_write_address) {
+      FillCode(tail_write_address,
+               static_cast<size_t>(end_write_address - tail_write_address));
+    }
+    PlaceCode(guest_address, machine_code, func_info, code_execute_address,
+              unwind_reservation);
+
+#if XE_PLATFORM_MAC && XE_ARCH_ARM64
+    if (jit_write) {
+      pthread_jit_write_protect_np(1);
+    }
+#endif
+  }
+
+  FlushCodeRange(code_execute_address, func_info.code_size.total);
+  if (tail_execute_address < end_execute_address) {
+    FlushCodeRange(
+        tail_execute_address,
+        static_cast<size_t>(end_execute_address - tail_execute_address));
+  }
+
+  if (guest_address && indirection_table_base_) {
+    PublishIndirection(guest_address,
+                       reinterpret_cast<uint64_t>(code_execute_address));
+  }
+}
+
+uint32_t A64CodeCache::PlaceData(const void* data, size_t length) {
+  size_t high_mark = 0;
+  uint8_t* data_execute_address = nullptr;
+  uint8_t* data_write_address = nullptr;
+  {
+    auto global_lock = global_critical_region_.Acquire();
+    data_execute_address =
+        generated_code_execute_base_ + generated_code_offset_;
+    data_write_address = generated_code_write_base_ + generated_code_offset_;
+    generated_code_offset_ += xe::round_up(length, 16);
+    high_mark = generated_code_offset_;
+  }
+
+  EnsureCommitted(high_mark);
+
+#if XE_PLATFORM_MAC && XE_ARCH_ARM64
+  const bool jit_write =
+      generated_code_execute_base_ == generated_code_write_base_;
+  if (jit_write) {
+    pthread_jit_write_protect_np(0);
+  }
+#endif
+  std::memcpy(data_write_address, data, length);
+#if XE_PLATFORM_MAC && XE_ARCH_ARM64
+  if (jit_write) {
+    pthread_jit_write_protect_np(1);
+  }
+#endif
+
+  FlushCodeRange(data_execute_address, length);
+  return static_cast<uint32_t>(
+      reinterpret_cast<uintptr_t>(data_execute_address));
+}
 
 void A64CodeCache::FillCode(void* write_address, size_t size) {
   // Fill with BRK #0 (0xD4200000), 4-byte aligned.
@@ -39,6 +348,54 @@ void A64CodeCache::FlushCodeRange(void* address, size_t size) {
   __builtin___clear_cache(
       reinterpret_cast<char*>(address),
       reinterpret_cast<char*>(static_cast<uint8_t*>(address) + size));
+#endif
+}
+
+void A64CodeCache::EnsureCommitted(size_t high_mark) {
+  using namespace xe::literals;
+  size_t old_commit_mark = 0;
+  size_t new_commit_mark = 0;
+  do {
+    old_commit_mark = generated_code_commit_mark_;
+    if (high_mark <= old_commit_mark) {
+      break;
+    }
+    new_commit_mark = old_commit_mark + 16_MiB;
+    if (generated_code_execute_base_ == generated_code_write_base_) {
+      xe::memory::AllocFixed(generated_code_execute_base_, new_commit_mark,
+                             xe::memory::AllocationType::kCommit,
+                             xe::memory::PageAccess::kExecuteReadWrite);
+    } else {
+      xe::memory::AllocFixed(generated_code_execute_base_, new_commit_mark,
+                             xe::memory::AllocationType::kCommit,
+                             xe::memory::PageAccess::kExecuteReadOnly);
+      xe::memory::AllocFixed(generated_code_write_base_, new_commit_mark,
+                             xe::memory::AllocationType::kCommit,
+                             xe::memory::PageAccess::kReadWrite);
+    }
+  } while (generated_code_commit_mark_.compare_exchange_weak(old_commit_mark,
+                                                             new_commit_mark));
+}
+
+void A64CodeCache::PublishIndirection(uint32_t guest_address,
+                                      uint64_t host_address) {
+  if (!indirection_table_base_ || guest_address < kIndirectionTableBase) {
+    return;
+  }
+
+#if XE_A64_INDIRECTION_64BIT
+  const uint64_t guest_offset =
+      uint64_t(guest_address) - uint64_t(kIndirectionTableBase);
+  if (guest_offset + kA64IndirectionEntrySize > kA64IndirectionTableSize) {
+    return;
+  }
+  auto* slot =
+      reinterpret_cast<uint32_t*>(indirection_table_base_ + guest_offset);
+  *slot = EncodeIndirectionTarget(host_address);
+#else
+  auto* slot = reinterpret_cast<uint32_t*>(
+      indirection_table_base_ + (guest_address - kIndirectionTableBase));
+  *slot = static_cast<uint32_t>(host_address);
 #endif
 }
 

--- a/src/xenia/cpu/backend/a64/a64_code_cache.h
+++ b/src/xenia/cpu/backend/a64/a64_code_cache.h
@@ -10,7 +10,11 @@
 #ifndef XENIA_CPU_BACKEND_A64_A64_CODE_CACHE_H_
 #define XENIA_CPU_BACKEND_A64_A64_CODE_CACHE_H_
 
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
 #include <memory>
+#include <mutex>
 
 #include "xenia/cpu/backend/code_cache_base.h"
 
@@ -19,13 +23,57 @@ namespace cpu {
 namespace backend {
 namespace a64 {
 
+#if XE_ARCH_ARM64
+#define XE_A64_INDIRECTION_64BIT 1
+#else
+#define XE_A64_INDIRECTION_64BIT 0
+#endif
+
 class A64CodeCache : public CodeCacheBase<A64CodeCache> {
  public:
-  ~A64CodeCache() override = default;
+  ~A64CodeCache() override;
 
   static std::unique_ptr<A64CodeCache> Create();
 
   virtual bool Initialize();
+
+  void set_indirection_default(uint32_t default_value);
+#if XE_A64_INDIRECTION_64BIT
+  void set_indirection_default_64(uint64_t default_value);
+#endif
+  void AddIndirection(uint32_t guest_address, uint32_t host_address);
+#if XE_A64_INDIRECTION_64BIT
+  void AddIndirection64(uint32_t guest_address, uint64_t host_address);
+#endif
+  void CommitExecutableRange(uint32_t guest_low, uint32_t guest_high);
+  void PlaceHostCode(uint32_t guest_address, void* machine_code,
+                     const EmitFunctionInfo& func_info,
+                     void*& code_execute_address_out,
+                     void*& code_write_address_out);
+  void PlaceGuestCode(uint32_t guest_address, void* machine_code,
+                      const EmitFunctionInfo& func_info,
+                      GuestFunction* function_info,
+                      void*& code_execute_address_out,
+                      void*& code_write_address_out);
+  uint32_t PlaceData(const void* data, size_t length);
+
+  uintptr_t execute_base_address() const override {
+    return generated_code_execute_base_
+               ? reinterpret_cast<uintptr_t>(generated_code_execute_base_)
+               : CodeCacheBase<A64CodeCache>::execute_base_address();
+  }
+
+  uintptr_t indirection_table_base_address() const {
+    return indirection_table_actual_base_;
+  }
+#if XE_A64_INDIRECTION_64BIT
+  uintptr_t indirection_table_base_bias() const {
+    return indirection_table_base_bias_;
+  }
+  uintptr_t external_indirection_table_base_address() const {
+    return reinterpret_cast<uintptr_t>(external_indirection_targets_.get());
+  }
+#endif
 
   void* LookupUnwindInfo(uint64_t host_pc) override { return nullptr; }
 
@@ -44,6 +92,35 @@ class A64CodeCache : public CodeCacheBase<A64CodeCache> {
 
  protected:
   A64CodeCache() = default;
+
+ private:
+  void EnsureCommitted(size_t high_mark);
+  void PublishIndirection(uint32_t guest_address, uint64_t host_address);
+  bool InitializeEncodedIndirectionTable();
+  bool InitializeEncodedIndirectionTableState();
+  uint32_t EncodeIndirectionTarget(uint64_t host_address);
+
+#if XE_A64_INDIRECTION_64BIT
+  static constexpr size_t kA64IndirectionTableSize = 0x20000000ull;
+
+ public:
+  static constexpr size_t kA64IndirectionEntrySize = sizeof(uint32_t);
+  static constexpr uint32_t kIndirectionExternalTag = 0x80000000u;
+  static constexpr uint32_t kIndirectionExternalIndexMask = 0x7FFFFFFFu;
+  static constexpr uint32_t kIndirectionExternalCapacity = 0x00010000u;
+
+ private:
+  std::unique_ptr<uint64_t[]> external_indirection_targets_;
+  std::atomic<uint32_t> external_indirection_target_count_ = {0};
+  std::mutex external_indirection_mutex_;
+#else
+  static constexpr size_t kA64IndirectionTableSize = kIndirectionTableSize;
+  static constexpr size_t kA64IndirectionEntrySize = sizeof(uint32_t);
+#endif
+  uintptr_t indirection_table_actual_base_ = 0;
+#if XE_A64_INDIRECTION_64BIT
+  uintptr_t indirection_table_base_bias_ = 0;
+#endif
 };
 
 }  // namespace a64

--- a/src/xenia/cpu/backend/a64/a64_emitter.cc
+++ b/src/xenia/cpu/backend/a64/a64_emitter.cc
@@ -45,7 +45,8 @@ namespace a64 {
 using namespace Xbyak_aarch64;
 
 // Defined in a64_backend.cc.
-extern uint64_t ResolveFunction(void* raw_context, uint64_t target_address);
+extern uint64_t ResolveFunction(void* raw_context, uint64_t target_address,
+                                uint64_t host_return_address);
 
 static uint64_t UndefinedCallExtern(void* raw_context, uint64_t function_ptr) {
   auto function = reinterpret_cast<Function*>(function_ptr);
@@ -332,6 +333,12 @@ void A64Emitter::Call(const hir::Instr* instr, GuestFunction* function) {
   assert_not_null(function);
   ForgetFpcrMode();
   auto fn = static_cast<A64Function*>(function);
+  auto inline_resolve_target = [&](const Xbyak_aarch64::WReg& guest_target) {
+    mov(w1, guest_target);
+    mov(x2, x30);
+    CallNativeSafe(reinterpret_cast<void*>(&ResolveFunction));
+    mov(x9, x0);
+  };
 
   if (fn->machine_code()) {
     // Direct call — function is already compiled.
@@ -359,17 +366,17 @@ void A64Emitter::Call(const hir::Instr* instr, GuestFunction* function) {
 
   if (code_cache_->has_indirection_table()) {
     // Load host code address from indirection table.
-    mov(w16, function->address());
+    mov(w17, function->address());
 #if XE_A64_INDIRECTION_64BIT
     Label external_target;
     Label indirection_target_ready;
     mov(x9, code_cache_->indirection_table_base_bias());
-    add(x9, x9, x16);
+    add(x9, x9, w17, UXTW);
     ldr(w16, ptr(x9, static_cast<uint32_t>(0)));
     tbnz(w16, 31, external_target);
     mov(w15, w16);
     mov(x9, code_cache_->execute_base_address());
-    add(x9, x9, x15);
+    add(x9, x9, w15, UXTW);
     b(indirection_target_ready);
     L(external_target);
     and_(w15, w16, A64CodeCache::kIndirectionExternalIndexMask);
@@ -381,13 +388,16 @@ void A64Emitter::Call(const hir::Instr* instr, GuestFunction* function) {
 #else
     ldr(w9, ptr(x16, static_cast<uint32_t>(0)));
 #endif
+    auto& call_ready = NewCachedLabel();
+    mov(x15, reinterpret_cast<uint64_t>(backend()->resolve_function_thunk()));
+    cmp(x9, x15);
+    b(NE, call_ready);
+    inline_resolve_target(w17);
+    L(call_ready);
   } else {
     // Fallback: resolve at runtime.
-    mov(x0, x20);  // context
-    mov(x1, static_cast<uint64_t>(function->address()));
-    mov(x9, reinterpret_cast<uint64_t>(&ResolveFunction));
-    blr(x9);
-    mov(x9, x0);  // resolved address in x9
+    mov(w17, function->address());
+    inline_resolve_target(w17);
   }
 
   if (instr->flags & hir::CALL_TAIL) {
@@ -411,6 +421,12 @@ void A64Emitter::Call(const hir::Instr* instr, GuestFunction* function) {
 void A64Emitter::CallIndirect(const hir::Instr* instr, int reg_index) {
   ForgetFpcrMode();
   auto target_w = WReg(reg_index);
+  auto inline_resolve_target = [&](const Xbyak_aarch64::WReg& guest_target) {
+    mov(w1, guest_target);
+    mov(x2, x30);
+    CallNativeSafe(reinterpret_cast<void*>(&ResolveFunction));
+    mov(x9, x0);
+  };
 
   // Check if this is a possible return (e.g., PPC blr).
   if (instr->flags & hir::CALL_POSSIBLE_RETURN) {
@@ -422,17 +438,17 @@ void A64Emitter::CallIndirect(const hir::Instr* instr, int reg_index) {
 
   // Load host code address from indirection table.
   if (code_cache_->has_indirection_table()) {
-    mov(w16, target_w);  // w16 = guest address (also used by resolve thunk)
+    mov(w17, target_w);  // Preserve the guest target for the resolve thunk.
 #if XE_A64_INDIRECTION_64BIT
     Label external_target;
     Label indirection_target_ready;
     mov(x9, code_cache_->indirection_table_base_bias());
-    add(x9, x9, x16);
+    add(x9, x9, w17, UXTW);
     ldr(w16, ptr(x9, static_cast<uint32_t>(0)));
     tbnz(w16, 31, external_target);
     mov(w15, w16);
     mov(x9, code_cache_->execute_base_address());
-    add(x9, x9, x15);
+    add(x9, x9, w15, UXTW);
     b(indirection_target_ready);
     L(external_target);
     and_(w15, w16, A64CodeCache::kIndirectionExternalIndexMask);
@@ -445,14 +461,16 @@ void A64Emitter::CallIndirect(const hir::Instr* instr, int reg_index) {
     ldr(w9, ptr(x16, static_cast<uint32_t>(
                          0)));  // w9 = host code from indirection table
 #endif
+    auto& call_ready = NewCachedLabel();
+    mov(x15, reinterpret_cast<uint64_t>(backend()->resolve_function_thunk()));
+    cmp(x9, x15);
+    b(NE, call_ready);
+    inline_resolve_target(w17);
+    L(call_ready);
   } else {
     // Fallback: resolve at runtime.
-    mov(w16, target_w);
-    mov(x0, x20);  // context
-    mov(x1, x16);  // guest address
-    mov(x9, reinterpret_cast<uint64_t>(&ResolveFunction));
-    blr(x9);
-    mov(x9, x0);  // resolved address
+    mov(w17, target_w);
+    inline_resolve_target(w17);
   }
 
   if (instr->flags & hir::CALL_TAIL) {

--- a/src/xenia/cpu/backend/a64/a64_emitter.cc
+++ b/src/xenia/cpu/backend/a64/a64_emitter.cc
@@ -360,7 +360,27 @@ void A64Emitter::Call(const hir::Instr* instr, GuestFunction* function) {
   if (code_cache_->has_indirection_table()) {
     // Load host code address from indirection table.
     mov(w16, function->address());
+#if XE_A64_INDIRECTION_64BIT
+    Label external_target;
+    Label indirection_target_ready;
+    mov(x9, code_cache_->indirection_table_base_bias());
+    add(x9, x9, x16);
+    ldr(w16, ptr(x9, static_cast<uint32_t>(0)));
+    tbnz(w16, 31, external_target);
+    mov(w15, w16);
+    mov(x9, code_cache_->execute_base_address());
+    add(x9, x9, x15);
+    b(indirection_target_ready);
+    L(external_target);
+    and_(w15, w16, A64CodeCache::kIndirectionExternalIndexMask);
+    mov(x9, code_cache_->external_indirection_table_base_address());
+    lsl(x15, x15, 3);
+    add(x9, x9, x15);
+    ldr(x9, ptr(x9, static_cast<uint32_t>(0)));
+    L(indirection_target_ready);
+#else
     ldr(w9, ptr(x16, static_cast<uint32_t>(0)));
+#endif
   } else {
     // Fallback: resolve at runtime.
     mov(x0, x20);  // context
@@ -403,8 +423,28 @@ void A64Emitter::CallIndirect(const hir::Instr* instr, int reg_index) {
   // Load host code address from indirection table.
   if (code_cache_->has_indirection_table()) {
     mov(w16, target_w);  // w16 = guest address (also used by resolve thunk)
+#if XE_A64_INDIRECTION_64BIT
+    Label external_target;
+    Label indirection_target_ready;
+    mov(x9, code_cache_->indirection_table_base_bias());
+    add(x9, x9, x16);
+    ldr(w16, ptr(x9, static_cast<uint32_t>(0)));
+    tbnz(w16, 31, external_target);
+    mov(w15, w16);
+    mov(x9, code_cache_->execute_base_address());
+    add(x9, x9, x15);
+    b(indirection_target_ready);
+    L(external_target);
+    and_(w15, w16, A64CodeCache::kIndirectionExternalIndexMask);
+    mov(x9, code_cache_->external_indirection_table_base_address());
+    lsl(x15, x15, 3);
+    add(x9, x9, x15);
+    ldr(x9, ptr(x9, static_cast<uint32_t>(0)));
+    L(indirection_target_ready);
+#else
     ldr(w9, ptr(x16, static_cast<uint32_t>(
                          0)));  // w9 = host code from indirection table
+#endif
   } else {
     // Fallback: resolve at runtime.
     mov(w16, target_w);

--- a/src/xenia/cpu/backend/a64/a64_function.cc
+++ b/src/xenia/cpu/backend/a64/a64_function.cc
@@ -9,9 +9,24 @@
 
 #include "xenia/cpu/backend/a64/a64_function.h"
 
+#if XE_PLATFORM_APPLE && !XE_PLATFORM_IOS && defined(__aarch64__)
+#include <pthread.h>
+#endif
+
 #include "xenia/cpu/backend/a64/a64_backend.h"
 #include "xenia/cpu/processor.h"
 #include "xenia/cpu/thread_state.h"
+
+#if XE_PLATFORM_APPLE && !XE_PLATFORM_IOS && defined(__aarch64__)
+thread_local bool jit_thread_initialized = false;
+
+static void InitializeJITThread() {
+  if (!jit_thread_initialized) {
+    pthread_jit_write_protect_np(1);
+    jit_thread_initialized = true;
+  }
+}
+#endif
 
 namespace xe {
 namespace cpu {
@@ -26,18 +41,23 @@ A64Function::~A64Function() {
 }
 
 void A64Function::Setup(uint8_t* machine_code, size_t machine_code_length) {
-  machine_code_ = machine_code;
-  machine_code_length_ = machine_code_length;
+  machine_code_length_.store(machine_code_length, std::memory_order_relaxed);
+  machine_code_.store(machine_code, std::memory_order_release);
 }
 
 bool A64Function::CallImpl(ThreadState* thread_state, uint32_t return_address) {
+#if XE_PLATFORM_APPLE && !XE_PLATFORM_IOS && defined(__aarch64__)
+  InitializeJITThread();
+#endif
+
   auto backend =
       reinterpret_cast<A64Backend*>(thread_state->processor()->backend());
   auto thunk = backend->host_to_guest_thunk();
-  if (!thunk || !machine_code_) {
+  auto* code = machine_code_.load(std::memory_order_acquire);
+  if (!thunk || !code) {
     return false;
   }
-  thunk(machine_code_, thread_state->context(),
+  thunk(code, thread_state->context(),
         reinterpret_cast<void*>(uintptr_t(return_address)));
   return true;
 }

--- a/src/xenia/cpu/backend/a64/a64_function.h
+++ b/src/xenia/cpu/backend/a64/a64_function.h
@@ -10,6 +10,8 @@
 #ifndef XENIA_CPU_BACKEND_A64_A64_FUNCTION_H_
 #define XENIA_CPU_BACKEND_A64_A64_FUNCTION_H_
 
+#include <atomic>
+
 #include "xenia/cpu/function.h"
 #include "xenia/cpu/thread_state.h"
 
@@ -23,8 +25,12 @@ class A64Function : public GuestFunction {
   A64Function(Module* module, uint32_t address);
   ~A64Function() override;
 
-  uint8_t* machine_code() const override { return machine_code_; }
-  size_t machine_code_length() const override { return machine_code_length_; }
+  uint8_t* machine_code() const override {
+    return machine_code_.load(std::memory_order_acquire);
+  }
+  size_t machine_code_length() const override {
+    return machine_code_length_.load(std::memory_order_acquire);
+  }
 
   void Setup(uint8_t* machine_code, size_t machine_code_length);
 
@@ -32,8 +38,8 @@ class A64Function : public GuestFunction {
   bool CallImpl(ThreadState* thread_state, uint32_t return_address) override;
 
  private:
-  uint8_t* machine_code_ = nullptr;
-  size_t machine_code_length_ = 0;
+  std::atomic<uint8_t*> machine_code_{nullptr};
+  std::atomic<size_t> machine_code_length_{0};
 };
 
 }  // namespace a64

--- a/src/xenia/cpu/backend/a64/a64_seq_memory.cc
+++ b/src/xenia/cpu/backend/a64/a64_seq_memory.cc
@@ -21,8 +21,12 @@
 #include "xenia/cpu/hir/instr.h"
 #include "xenia/cpu/ppc/ppc_context.h"
 #include "xenia/cpu/processor.h"
+#include "xenia/cpu/xex_module.h"
 
+DECLARE_bool(emit_mmio_aware_stores_for_recorded_exception_addresses);
 DECLARE_bool(emit_inline_mmio_checks);
+DEFINE_bool(a64_force_mmio_aware_byteswap_loads, false,
+            "Force MMIO-aware helper loads for byte-swapped I32 loads.", "a64");
 
 namespace xe {
 namespace cpu {
@@ -30,6 +34,23 @@ namespace backend {
 namespace a64 {
 
 volatile int anchor_memory = 0;
+
+static bool IsPossibleMMIOInstruction(A64Emitter& e, const hir::Instr* i) {
+  if (!cvars::emit_mmio_aware_stores_for_recorded_exception_addresses) {
+    return false;
+  }
+  uint32_t guest_address = i->GuestAddressFor();
+  if (!guest_address) {
+    return false;
+  }
+
+  auto* guest_module = e.GuestModule();
+  if (!guest_module) {
+    return false;
+  }
+  auto* flags = guest_module->GetInstructionAddressFlags(guest_address);
+  return flags && flags->accessed_mmio;
+}
 
 // ============================================================================
 // OPCODE_DELAY_EXECUTION
@@ -151,6 +172,24 @@ struct LOAD_I16 : Sequence<LOAD_I16, I<OPCODE_LOAD, I16Op, I64Op>> {
 };
 struct LOAD_I32 : Sequence<LOAD_I32, I<OPCODE_LOAD, I32Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    const bool force_mmio_byteswap =
+        cvars::a64_force_mmio_aware_byteswap_loads &&
+        (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP);
+    if (force_mmio_byteswap || IsPossibleMMIOInstruction(e, i.instr)) {
+      void* mmio_fn = (void*)&MMIOAwareLoad<uint32_t, false>;
+      if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
+        mmio_fn = (void*)&MMIOAwareLoad<uint32_t, true>;
+      }
+      if (i.src1.is_constant) {
+        e.mov(e.w1,
+              static_cast<uint64_t>(static_cast<uint32_t>(i.src1.constant())));
+      } else {
+        e.mov(e.w1, WReg(i.src1.reg().getIdx()));
+      }
+      e.CallNativeSafe(mmio_fn);
+      e.mov(i.dest, e.w0);
+      return;
+    }
     if (cvars::emit_inline_mmio_checks) {
       if (i.src1.is_constant) {
         e.mov(e.w17,
@@ -277,6 +316,27 @@ struct STORE_I16 : Sequence<STORE_I16, I<OPCODE_STORE, VoidOp, I64Op, I16Op>> {
 };
 struct STORE_I32 : Sequence<STORE_I32, I<OPCODE_STORE, VoidOp, I64Op, I32Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP ||
+        IsPossibleMMIOInstruction(e, i.instr)) {
+      void* mmio_fn = (void*)&MMIOAwareStore<uint32_t, false>;
+      if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
+        mmio_fn = (void*)&MMIOAwareStore<uint32_t, true>;
+      }
+      if (i.src1.is_constant) {
+        e.mov(e.w1,
+              static_cast<uint64_t>(static_cast<uint32_t>(i.src1.constant())));
+      } else {
+        e.mov(e.w1, WReg(i.src1.reg().getIdx()));
+      }
+      if (i.src2.is_constant) {
+        e.mov(e.w2,
+              static_cast<uint64_t>(static_cast<uint32_t>(i.src2.constant())));
+      } else {
+        e.mov(e.w2, i.src2);
+      }
+      e.CallNativeSafe(mmio_fn);
+      return;
+    }
     if (cvars::emit_inline_mmio_checks) {
       if (i.src1.is_constant) {
         e.mov(e.w17,
@@ -473,26 +533,14 @@ EMITTER_OPCODE_TABLE(OPCODE_LOAD_CLOCK, LOAD_CLOCK);
 struct LOAD_OFFSET_I8
     : Sequence<LOAD_OFFSET_I8, I<OPCODE_LOAD_OFFSET, I8Op, I64Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    auto addr_reg = ComputeMemoryAddress(e, i.src1);
-    if (i.src2.is_constant) {
-      e.mov(e.x17, static_cast<uint64_t>(i.src2.constant()));
-      e.add(e.x0, addr_reg, e.x17);
-    } else {
-      e.add(e.x0, addr_reg, i.src2.reg());
-    }
+    AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
     e.ldrb(i.dest, ptr(e.GetMembaseReg(), e.x0));
   }
 };
 struct LOAD_OFFSET_I16
     : Sequence<LOAD_OFFSET_I16, I<OPCODE_LOAD_OFFSET, I16Op, I64Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    auto addr_reg = ComputeMemoryAddress(e, i.src1);
-    if (i.src2.is_constant) {
-      e.mov(e.x17, static_cast<uint64_t>(i.src2.constant()));
-      e.add(e.x0, addr_reg, e.x17);
-    } else {
-      e.add(e.x0, addr_reg, i.src2.reg());
-    }
+    AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
     e.ldrh(i.dest, ptr(e.GetMembaseReg(), e.x0));
     if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
       e.rev16(i.dest, i.dest);
@@ -502,6 +550,31 @@ struct LOAD_OFFSET_I16
 struct LOAD_OFFSET_I32
     : Sequence<LOAD_OFFSET_I32, I<OPCODE_LOAD_OFFSET, I32Op, I64Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    const bool force_mmio_byteswap =
+        cvars::a64_force_mmio_aware_byteswap_loads &&
+        (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP);
+    if (force_mmio_byteswap || IsPossibleMMIOInstruction(e, i.instr)) {
+      void* mmio_fn = (void*)&MMIOAwareLoad<uint32_t, false>;
+      if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
+        mmio_fn = (void*)&MMIOAwareLoad<uint32_t, true>;
+      }
+      if (i.src1.is_constant) {
+        e.mov(e.w1,
+              static_cast<uint64_t>(static_cast<uint32_t>(i.src1.constant())));
+      } else {
+        e.mov(e.w1, WReg(i.src1.reg().getIdx()));
+      }
+      if (i.src2.is_constant) {
+        e.mov(e.w17,
+              static_cast<uint64_t>(static_cast<uint32_t>(i.src2.constant())));
+      } else {
+        e.mov(e.w17, WReg(i.src2.reg().getIdx()));
+      }
+      e.add(e.w1, e.w1, e.w17);
+      e.CallNativeSafe(mmio_fn);
+      e.mov(i.dest, e.w0);
+      return;
+    }
     if (cvars::emit_inline_mmio_checks) {
       // Compute raw guest address (src1 + src2) in w17 for range check.
       if (i.src1.is_constant) {
@@ -538,13 +611,7 @@ struct LOAD_OFFSET_I32
       e.b(done);
       e.L(normal_access);
       {
-        auto addr_reg = ComputeMemoryAddress(e, i.src1);
-        if (i.src2.is_constant) {
-          e.mov(e.x17, static_cast<uint64_t>(i.src2.constant()));
-          e.add(e.x0, addr_reg, e.x17);
-        } else {
-          e.add(e.x0, addr_reg, i.src2.reg());
-        }
+        AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
         e.ldr(i.dest, ptr(e.GetMembaseReg(), e.x0));
         if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
           e.rev(i.dest, i.dest);
@@ -552,13 +619,7 @@ struct LOAD_OFFSET_I32
       }
       e.L(done);
     } else {
-      auto addr_reg = ComputeMemoryAddress(e, i.src1);
-      if (i.src2.is_constant) {
-        e.mov(e.x17, static_cast<uint64_t>(i.src2.constant()));
-        e.add(e.x0, addr_reg, e.x17);
-      } else {
-        e.add(e.x0, addr_reg, i.src2.reg());
-      }
+      AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
       e.ldr(i.dest, ptr(e.GetMembaseReg(), e.x0));
       if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
         e.rev(i.dest, i.dest);
@@ -569,13 +630,7 @@ struct LOAD_OFFSET_I32
 struct LOAD_OFFSET_I64
     : Sequence<LOAD_OFFSET_I64, I<OPCODE_LOAD_OFFSET, I64Op, I64Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    auto addr_reg = ComputeMemoryAddress(e, i.src1);
-    if (i.src2.is_constant) {
-      e.mov(e.x17, static_cast<uint64_t>(i.src2.constant()));
-      e.add(e.x0, addr_reg, e.x17);
-    } else {
-      e.add(e.x0, addr_reg, i.src2.reg());
-    }
+    AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
     e.ldr(i.dest, ptr(e.GetMembaseReg(), e.x0));
     if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
       e.rev(i.dest, i.dest);
@@ -589,13 +644,7 @@ struct STORE_OFFSET_I8
     : Sequence<STORE_OFFSET_I8,
                I<OPCODE_STORE_OFFSET, VoidOp, I64Op, I64Op, I8Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    auto addr_reg = ComputeMemoryAddress(e, i.src1);
-    if (i.src2.is_constant) {
-      e.mov(e.x17, static_cast<uint64_t>(i.src2.constant()));
-      e.add(e.x0, addr_reg, e.x17);
-    } else {
-      e.add(e.x0, addr_reg, i.src2.reg());
-    }
+    AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
     if (i.src3.is_constant) {
       e.mov(e.w17, static_cast<uint64_t>(i.src3.constant() & 0xFF));
       e.strb(e.w17, ptr(e.GetMembaseReg(), e.x0));
@@ -608,13 +657,7 @@ struct STORE_OFFSET_I16
     : Sequence<STORE_OFFSET_I16,
                I<OPCODE_STORE_OFFSET, VoidOp, I64Op, I64Op, I16Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    auto addr_reg = ComputeMemoryAddress(e, i.src1);
-    if (i.src2.is_constant) {
-      e.mov(e.x17, static_cast<uint64_t>(i.src2.constant()));
-      e.add(e.x0, addr_reg, e.x17);
-    } else {
-      e.add(e.x0, addr_reg, i.src2.reg());
-    }
+    AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
     if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
       if (i.src3.is_constant) {
         uint16_t val = xe::byte_swap(static_cast<uint16_t>(i.src3.constant()));
@@ -637,6 +680,34 @@ struct STORE_OFFSET_I32
     : Sequence<STORE_OFFSET_I32,
                I<OPCODE_STORE_OFFSET, VoidOp, I64Op, I64Op, I32Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
+    if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP ||
+        IsPossibleMMIOInstruction(e, i.instr)) {
+      void* mmio_fn = (void*)&MMIOAwareStore<uint32_t, false>;
+      if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
+        mmio_fn = (void*)&MMIOAwareStore<uint32_t, true>;
+      }
+      if (i.src1.is_constant) {
+        e.mov(e.w1,
+              static_cast<uint64_t>(static_cast<uint32_t>(i.src1.constant())));
+      } else {
+        e.mov(e.w1, WReg(i.src1.reg().getIdx()));
+      }
+      if (i.src2.is_constant) {
+        e.mov(e.w17,
+              static_cast<uint64_t>(static_cast<uint32_t>(i.src2.constant())));
+      } else {
+        e.mov(e.w17, WReg(i.src2.reg().getIdx()));
+      }
+      e.add(e.w1, e.w1, e.w17);
+      if (i.src3.is_constant) {
+        e.mov(e.w2,
+              static_cast<uint64_t>(static_cast<uint32_t>(i.src3.constant())));
+      } else {
+        e.mov(e.w2, i.src3);
+      }
+      e.CallNativeSafe(mmio_fn);
+      return;
+    }
     if (cvars::emit_inline_mmio_checks) {
       // Compute raw guest address (src1 + src2) in w17 for range check.
       if (i.src1.is_constant) {
@@ -678,13 +749,7 @@ struct STORE_OFFSET_I32
       e.b(done);
       e.L(normal_access);
       {
-        auto addr_reg = ComputeMemoryAddress(e, i.src1);
-        if (i.src2.is_constant) {
-          e.mov(e.x17, static_cast<uint64_t>(i.src2.constant()));
-          e.add(e.x0, addr_reg, e.x17);
-        } else {
-          e.add(e.x0, addr_reg, i.src2.reg());
-        }
+        AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
         if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
           if (i.src3.is_constant) {
             uint32_t val =
@@ -706,13 +771,7 @@ struct STORE_OFFSET_I32
       }
       e.L(done);
     } else {
-      auto addr_reg = ComputeMemoryAddress(e, i.src1);
-      if (i.src2.is_constant) {
-        e.mov(e.x17, static_cast<uint64_t>(i.src2.constant()));
-        e.add(e.x0, addr_reg, e.x17);
-      } else {
-        e.add(e.x0, addr_reg, i.src2.reg());
-      }
+      AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
       if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
         if (i.src3.is_constant) {
           uint32_t val =
@@ -738,13 +797,7 @@ struct STORE_OFFSET_I64
     : Sequence<STORE_OFFSET_I64,
                I<OPCODE_STORE_OFFSET, VoidOp, I64Op, I64Op, I64Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    auto addr_reg = ComputeMemoryAddress(e, i.src1);
-    if (i.src2.is_constant) {
-      e.mov(e.x17, static_cast<uint64_t>(i.src2.constant()));
-      e.add(e.x0, addr_reg, e.x17);
-    } else {
-      e.add(e.x0, addr_reg, i.src2.reg());
-    }
+    AddGuestMemoryOffset(e, ComputeMemoryAddress(e, i.src1), i.src2);
     if (i.instr->flags & LoadStoreFlags::LOAD_STORE_BYTE_SWAP) {
       if (i.src3.is_constant) {
         uint64_t val = xe::byte_swap(static_cast<uint64_t>(i.src3.constant()));

--- a/src/xenia/cpu/backend/a64/a64_seq_util.h
+++ b/src/xenia/cpu/backend/a64/a64_seq_util.h
@@ -85,9 +85,11 @@ inline XReg ComputeMemoryAddress(A64Emitter& e, const I64Op& guest) {
     e.mov(e.x0, static_cast<uint64_t>(address));
     return e.x0;
   } else {
+    auto src = guest.reg();
+    // Guest addresses are always 32-bit. Clear any stale upper bits before
+    // applying the host membase so guest pointers can't escape above 4 GB.
+    e.mov(e.w0, WReg(src.getIdx()));
     if (xe::memory::allocation_granularity() > 0x1000) {
-      auto src = guest.reg();
-      e.mov(e.w0, WReg(src.getIdx()));
       e.mov(e.w17, 0xE0000000u);
       e.cmp(e.w0, e.w17);
       auto& skip = e.NewCachedLabel();
@@ -96,10 +98,26 @@ inline XReg ComputeMemoryAddress(A64Emitter& e, const I64Op& guest) {
       e.mov(e.w17, 0x1000u);
       e.add(e.w0, e.w0, e.w17);
       e.L(skip);
-      return e.x0;
     }
-    return guest.reg();
+    return e.x0;
   }
+}
+
+template <typename OffsetOp>
+inline XReg AddGuestMemoryOffset(A64Emitter& e, const XReg& base,
+                                 const OffsetOp& offset) {
+  // Guest address arithmetic wraps at 32 bits before the host membase is
+  // applied. Keep the add in W registers so stale high bits can't escape into
+  // the final host pointer.
+  e.mov(e.w0, WReg(base.getIdx()));
+  if (offset.is_constant) {
+    e.mov(e.w17,
+          static_cast<uint64_t>(static_cast<uint32_t>(offset.constant())));
+    e.add(e.w0, e.w0, e.w17);
+  } else {
+    e.add(e.w0, e.w0, WReg(offset.reg().getIdx()));
+  }
+  return e.x0;
 }
 
 // Flush denormal float32 lanes to zero in a NEON register (in-place).

--- a/src/xenia/cpu/backend/a64/a64_seq_util.h
+++ b/src/xenia/cpu/backend/a64/a64_seq_util.h
@@ -29,6 +29,21 @@ using Xbyak_aarch64::VReg;
 using Xbyak_aarch64::WReg;
 using Xbyak_aarch64::XReg;
 
+template <typename Fn>
+inline void EmitWithVmxFpcr(A64Emitter& e, Fn&& emit_op) {
+  // VMX vector FP uses round-to-nearest with flush-to-zero, but the scalar
+  // PPC FP path keeps its own FPCR state. Save and restore around each VMX op
+  // so vector code doesn't leak FPCR changes into later scalar instructions.
+  e.mrs(e.x13, 3, 3, 4, 4, 0);
+  e.mov(e.x14, e.x13);
+  e.mov(e.x15, ~static_cast<uint64_t>(0b11u << 22));
+  e.and_(e.x14, e.x14, e.x15);
+  e.orr(e.x14, e.x14, static_cast<uint64_t>(1u << 24));
+  e.msr(3, 3, 4, 4, 0, e.x14);
+  emit_op();
+  e.msr(3, 3, 4, 4, 0, e.x13);
+}
+
 // Load a compile-time vec128_t constant into a NEON register.
 inline void LoadV128Const(A64Emitter& e, int vreg_idx, const vec128_t& val) {
   e.mov(e.x0, val.low);
@@ -302,36 +317,36 @@ enum class VmxFpBinOp { Add, Sub, Mul, Div };
 template <typename T1, typename T2>
 inline void EmitVmxFpBinOp_V128(A64Emitter& e, int dest_idx, const T1& src1,
                                 const T2& src2, VmxFpBinOp op) {
-  e.ChangeFpcrMode(FPCRMode::Vmx);
+  EmitWithVmxFpcr(e, [&] {
+    // Flush input denormals → v0=s1, v1=s2.
+    int s1, s2;
+    PrepareVmxFpSources(e, src1, src2, s1, s2);
 
-  // Flush input denormals → v0=s1, v1=s2.
-  int s1, s2;
-  PrepareVmxFpSources(e, src1, src2, s1, s2);
+    // Hardware FP op → v2.
+    switch (op) {
+      case VmxFpBinOp::Add:
+        e.fadd(VReg(2).s4, VReg(s1).s4, VReg(s2).s4);
+        break;
+      case VmxFpBinOp::Sub:
+        e.fsub(VReg(2).s4, VReg(s1).s4, VReg(s2).s4);
+        break;
+      case VmxFpBinOp::Mul:
+        e.fmul(VReg(2).s4, VReg(s1).s4, VReg(s2).s4);
+        break;
+      case VmxFpBinOp::Div:
+        e.fdiv(VReg(2).s4, VReg(s1).s4, VReg(s2).s4);
+        break;
+    }
 
-  // Hardware FP op → v2.
-  switch (op) {
-    case VmxFpBinOp::Add:
-      e.fadd(VReg(2).s4, VReg(s1).s4, VReg(s2).s4);
-      break;
-    case VmxFpBinOp::Sub:
-      e.fsub(VReg(2).s4, VReg(s1).s4, VReg(s2).s4);
-      break;
-    case VmxFpBinOp::Mul:
-      e.fmul(VReg(2).s4, VReg(s1).s4, VReg(s2).s4);
-      break;
-    case VmxFpBinOp::Div:
-      e.fdiv(VReg(2).s4, VReg(s1).s4, VReg(s2).s4);
-      break;
-  }
+    // PPC NaN propagation fixup (fast-path skip when no NaN).
+    FixupVmxNan_V128(e);
 
-  // PPC NaN propagation fixup (fast-path skip when no NaN).
-  FixupVmxNan_V128(e);
+    // Flush output denormals.
+    FlushDenormals_V128(e, 2, 0, 1);
 
-  // Flush output denormals.
-  FlushDenormals_V128(e, 2, 0, 1);
-
-  // Move to dest.
-  e.mov(VReg(dest_idx).b16, VReg(2).b16);
+    // Move to dest.
+    e.mov(VReg(dest_idx).b16, VReg(2).b16);
+  });
 }
 
 }  // namespace a64

--- a/src/xenia/cpu/backend/a64/a64_seq_vector.cc
+++ b/src/xenia/cpu/backend/a64/a64_seq_vector.cc
@@ -223,16 +223,17 @@ struct VECTOR_CONVERT_I2F
     : Sequence<VECTOR_CONVERT_I2F,
                I<OPCODE_VECTOR_CONVERT_I2F, V128Op, V128Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    e.ChangeFpcrMode(FPCRMode::Vmx);
-    int s = SrcVReg(e, i.src1, 0);
-    int d = i.dest.reg().getIdx();
-    if (i.instr->flags & ARITHMETIC_UNSIGNED) {
-      // ARM64 ucvtf does a single-step unsigned int->float conversion,
-      // avoiding the double-rounding issue that x64 has to work around.
-      e.ucvtf(VReg(d).s4, VReg(s).s4);
-    } else {
-      e.scvtf(VReg(d).s4, VReg(s).s4);
-    }
+    EmitWithVmxFpcr(e, [&] {
+      int s = SrcVReg(e, i.src1, 0);
+      int d = i.dest.reg().getIdx();
+      if (i.instr->flags & ARITHMETIC_UNSIGNED) {
+        // ARM64 ucvtf does a single-step unsigned int->float conversion,
+        // avoiding the double-rounding issue that x64 has to work around.
+        e.ucvtf(VReg(d).s4, VReg(s).s4);
+      } else {
+        e.scvtf(VReg(d).s4, VReg(s).s4);
+      }
+    });
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_VECTOR_CONVERT_I2F, VECTOR_CONVERT_I2F);
@@ -244,16 +245,17 @@ struct VECTOR_CONVERT_F2I
     : Sequence<VECTOR_CONVERT_F2I,
                I<OPCODE_VECTOR_CONVERT_F2I, V128Op, V128Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    e.ChangeFpcrMode(FPCRMode::Vmx);
-    int s = SrcVReg(e, i.src1, 0);
-    int d = i.dest.reg().getIdx();
-    if (i.instr->flags & ARITHMETIC_UNSIGNED) {
-      // ARM64 fcvtzu: NaN->0, negative->0, overflow->UINT_MAX.
-      e.fcvtzu(VReg(d).s4, VReg(s).s4);
-    } else {
-      // ARM64 fcvtzs: NaN->0, overflow saturates to INT_MIN/INT_MAX.
-      e.fcvtzs(VReg(d).s4, VReg(s).s4);
-    }
+    EmitWithVmxFpcr(e, [&] {
+      int s = SrcVReg(e, i.src1, 0);
+      int d = i.dest.reg().getIdx();
+      if (i.instr->flags & ARITHMETIC_UNSIGNED) {
+        // ARM64 fcvtzu: NaN->0, negative->0, overflow->UINT_MAX.
+        e.fcvtzu(VReg(d).s4, VReg(s).s4);
+      } else {
+        // ARM64 fcvtzs: NaN->0, overflow saturates to INT_MIN/INT_MAX.
+        e.fcvtzs(VReg(d).s4, VReg(s).s4);
+      }
+    });
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_VECTOR_CONVERT_F2I, VECTOR_CONVERT_F2I);
@@ -414,16 +416,18 @@ struct VECTOR_MAX
 
   template <typename T>
   static void EmitVmxFpMaxMin(A64Emitter& e, const T& i, bool is_min) {
-    e.ChangeFpcrMode(FPCRMode::Vmx);
-    int s1, s2;
-    PrepareVmxFpSources(e, i.src1, i.src2, s1, s2);
-    if (is_min)
-      e.fmin(VReg(2).s4, VReg(s1).s4, VReg(s2).s4);
-    else
-      e.fmax(VReg(2).s4, VReg(s1).s4, VReg(s2).s4);
-    FixupVmxMaxMinNan(e);
-    FlushDenormals_V128(e, 2, 0, 1);
-    e.mov(VReg(i.dest.reg().getIdx()).b16, VReg(2).b16);
+    EmitWithVmxFpcr(e, [&] {
+      int s1, s2;
+      PrepareVmxFpSources(e, i.src1, i.src2, s1, s2);
+      if (is_min) {
+        e.fmin(VReg(2).s4, VReg(s1).s4, VReg(s2).s4);
+      } else {
+        e.fmax(VReg(2).s4, VReg(s1).s4, VReg(s2).s4);
+      }
+      FixupVmxMaxMinNan(e);
+      FlushDenormals_V128(e, 2, 0, 1);
+      e.mov(VReg(i.dest.reg().getIdx()).b16, VReg(2).b16);
+    });
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_VECTOR_MAX, VECTOR_MAX);
@@ -491,8 +495,8 @@ struct VECTOR_COMPARE_EQ_V128
         e.cmeq(VReg(d).s4, VReg(s1).s4, VReg(s2).s4);
         break;
       case FLOAT32_TYPE:
-        e.ChangeFpcrMode(FPCRMode::Vmx);
-        e.fcmeq(VReg(d).s4, VReg(s1).s4, VReg(s2).s4);
+        EmitWithVmxFpcr(e,
+                        [&] { e.fcmeq(VReg(d).s4, VReg(s1).s4, VReg(s2).s4); });
         break;
       default:
         assert_unhandled_case(i.instr->flags);
@@ -523,8 +527,8 @@ struct VECTOR_COMPARE_SGT_V128
         e.cmgt(VReg(d).s4, VReg(s1).s4, VReg(s2).s4);
         break;
       case FLOAT32_TYPE:
-        e.ChangeFpcrMode(FPCRMode::Vmx);
-        e.fcmgt(VReg(d).s4, VReg(s1).s4, VReg(s2).s4);
+        EmitWithVmxFpcr(e,
+                        [&] { e.fcmgt(VReg(d).s4, VReg(s1).s4, VReg(s2).s4); });
         break;
       default:
         assert_unhandled_case(i.instr->flags);
@@ -555,8 +559,8 @@ struct VECTOR_COMPARE_SGE_V128
         e.cmge(VReg(d).s4, VReg(s1).s4, VReg(s2).s4);
         break;
       case FLOAT32_TYPE:
-        e.ChangeFpcrMode(FPCRMode::Vmx);
-        e.fcmge(VReg(d).s4, VReg(s1).s4, VReg(s2).s4);
+        EmitWithVmxFpcr(e,
+                        [&] { e.fcmge(VReg(d).s4, VReg(s1).s4, VReg(s2).s4); });
         break;
       default:
         assert_unhandled_case(i.instr->flags);

--- a/src/xenia/cpu/backend/a64/a64_sequences.cc
+++ b/src/xenia/cpu/backend/a64/a64_sequences.cc
@@ -35,7 +35,11 @@ namespace a64 {
 using namespace xe::cpu::hir;
 using namespace Xbyak_aarch64;
 
-std::unordered_map<uint32_t, SequenceSelectFn> sequence_table;
+std::unordered_map<uint32_t, SequenceSelectFn>& SequenceTable() {
+  static auto* sequence_table =
+      new std::unordered_map<uint32_t, SequenceSelectFn>();
+  return *sequence_table;
+}
 
 // ============================================================================
 // Debug validation helpers
@@ -4821,6 +4825,7 @@ static int anchor_vector_dest = anchor_vector;
 bool SelectSequence(A64Emitter* e, const hir::Instr* i,
                     const hir::Instr** new_tail) {
   const InstrKey key(i);
+  auto& sequence_table = SequenceTable();
   auto it = sequence_table.find(key);
   if (it != sequence_table.end()) {
     if (it->second(*e, i, InstrKeyValue(key))) {

--- a/src/xenia/cpu/backend/a64/a64_sequences.cc
+++ b/src/xenia/cpu/backend/a64/a64_sequences.cc
@@ -11,6 +11,7 @@
 
 #include <cmath>
 #include <cstdio>
+#include <cstring>
 #include <type_traits>
 
 #include "xenia/base/byte_order.h"
@@ -1434,9 +1435,10 @@ struct NEG_F64 : Sequence<NEG_F64, I<OPCODE_NEG, F64Op, F64Op>> {
 };
 struct NEG_V128 : Sequence<NEG_V128, I<OPCODE_NEG, V128Op, V128Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    e.ChangeFpcrMode(FPCRMode::Vmx);
-    int s = SrcVReg(e, i.src1, 0);
-    e.fneg(VReg(i.dest.reg().getIdx()).s4, VReg(s).s4);
+    EmitWithVmxFpcr(e, [&] {
+      int s = SrcVReg(e, i.src1, 0);
+      e.fneg(VReg(i.dest.reg().getIdx()).s4, VReg(s).s4);
+    });
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_NEG, NEG_I8, NEG_I16, NEG_I32, NEG_I64, NEG_F32,
@@ -1479,9 +1481,10 @@ struct ABS_F64 : Sequence<ABS_F64, I<OPCODE_ABS, F64Op, F64Op>> {
 };
 struct ABS_V128 : Sequence<ABS_V128, I<OPCODE_ABS, V128Op, V128Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    e.ChangeFpcrMode(FPCRMode::Vmx);
-    int s = SrcVReg(e, i.src1, 0);
-    e.fabs(VReg(i.dest.reg().getIdx()).s4, VReg(s).s4);
+    EmitWithVmxFpcr(e, [&] {
+      int s = SrcVReg(e, i.src1, 0);
+      e.fabs(VReg(i.dest.reg().getIdx()).s4, VReg(s).s4);
+    });
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_ABS, ABS_F32, ABS_F64, ABS_V128);
@@ -3192,14 +3195,15 @@ struct MAX_F64 : Sequence<MAX_F64, I<OPCODE_MAX, F64Op, F64Op, F64Op>> {
 };
 struct MAX_V128 : Sequence<MAX_V128, I<OPCODE_MAX, V128Op, V128Op, V128Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    e.ChangeFpcrMode(FPCRMode::Vmx);
-    int s1, s2;
-    PrepareVmxFpSources(e, i.src1, i.src2, s1, s2);
-    e.fmax(VReg(2).s4, VReg(s1).s4, VReg(s2).s4);
-    // PPC vmaxfp: if either input is NaN, result = src1 (vA).
-    FixupVmxMaxMinNan(e);
-    FlushDenormals_V128(e, 2, 0, 1);
-    e.mov(VReg(i.dest.reg().getIdx()).b16, VReg(2).b16);
+    EmitWithVmxFpcr(e, [&] {
+      int s1, s2;
+      PrepareVmxFpSources(e, i.src1, i.src2, s1, s2);
+      e.fmax(VReg(2).s4, VReg(s1).s4, VReg(s2).s4);
+      // PPC vmaxfp: if either input is NaN, result = src1 (vA).
+      FixupVmxMaxMinNan(e);
+      FlushDenormals_V128(e, 2, 0, 1);
+      e.mov(VReg(i.dest.reg().getIdx()).b16, VReg(2).b16);
+    });
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_MAX, MAX_F32, MAX_F64, MAX_V128);
@@ -3328,14 +3332,15 @@ struct MIN_F64 : Sequence<MIN_F64, I<OPCODE_MIN, F64Op, F64Op, F64Op>> {
 };
 struct MIN_V128 : Sequence<MIN_V128, I<OPCODE_MIN, V128Op, V128Op, V128Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    e.ChangeFpcrMode(FPCRMode::Vmx);
-    int s1, s2;
-    PrepareVmxFpSources(e, i.src1, i.src2, s1, s2);
-    e.fmin(VReg(2).s4, VReg(s1).s4, VReg(s2).s4);
-    // PPC vminfp: if either input is NaN, result = src1 (vA).
-    FixupVmxMaxMinNan(e);
-    FlushDenormals_V128(e, 2, 0, 1);
-    e.mov(VReg(i.dest.reg().getIdx()).b16, VReg(2).b16);
+    EmitWithVmxFpcr(e, [&] {
+      int s1, s2;
+      PrepareVmxFpSources(e, i.src1, i.src2, s1, s2);
+      e.fmin(VReg(2).s4, VReg(s1).s4, VReg(s2).s4);
+      // PPC vminfp: if either input is NaN, result = src1 (vA).
+      FixupVmxMaxMinNan(e);
+      FlushDenormals_V128(e, 2, 0, 1);
+      e.mov(VReg(i.dest.reg().getIdx()).b16, VReg(2).b16);
+    });
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_MIN, MIN_I8, MIN_I16, MIN_I32, MIN_I64, MIN_F32,
@@ -3562,28 +3567,29 @@ struct ROUND_F64 : Sequence<ROUND_F64, I<OPCODE_ROUND, F64Op, F64Op>> {
 };
 struct ROUND_V128 : Sequence<ROUND_V128, I<OPCODE_ROUND, V128Op, V128Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    e.ChangeFpcrMode(FPCRMode::Vmx);
-    int s = SrcVReg(e, i.src1, 0);
-    auto src = VReg(s).s4;
-    auto dst = VReg(i.dest.reg().getIdx()).s4;
-    switch (i.instr->flags) {
-      case ROUND_TO_ZERO:
-        e.frintz(dst, src);
-        break;
-      case ROUND_TO_NEAREST:
-        e.frintn(dst, src);
-        break;
-      case ROUND_TO_MINUS_INFINITY:
-        e.frintm(dst, src);
-        break;
-      case ROUND_TO_POSITIVE_INFINITY:
-        e.frintp(dst, src);
-        break;
-      default:
-        // ROUND_DYNAMIC - use current rounding mode.
-        e.frinti(dst, src);
-        break;
-    }
+    EmitWithVmxFpcr(e, [&] {
+      int s = SrcVReg(e, i.src1, 0);
+      auto src = VReg(s).s4;
+      auto dst = VReg(i.dest.reg().getIdx()).s4;
+      switch (i.instr->flags) {
+        case ROUND_TO_ZERO:
+          e.frintz(dst, src);
+          break;
+        case ROUND_TO_NEAREST:
+          e.frintn(dst, src);
+          break;
+        case ROUND_TO_MINUS_INFINITY:
+          e.frintm(dst, src);
+          break;
+        case ROUND_TO_POSITIVE_INFINITY:
+          e.frintp(dst, src);
+          break;
+        default:
+          // ROUND_DYNAMIC - use current rounding mode.
+          e.frinti(dst, src);
+          break;
+      }
+    });
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_ROUND, ROUND_F32, ROUND_F64, ROUND_V128);
@@ -3625,9 +3631,10 @@ struct SQRT_F64 : Sequence<SQRT_F64, I<OPCODE_SQRT, F64Op, F64Op>> {
 };
 struct SQRT_V128 : Sequence<SQRT_V128, I<OPCODE_SQRT, V128Op, V128Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    e.ChangeFpcrMode(FPCRMode::Vmx);
-    int s = SrcVReg(e, i.src1, 0);
-    e.fsqrt(VReg(i.dest.reg().getIdx()).s4, VReg(s).s4);
+    EmitWithVmxFpcr(e, [&] {
+      int s = SrcVReg(e, i.src1, 0);
+      e.fsqrt(VReg(i.dest.reg().getIdx()).s4, VReg(s).s4);
+    });
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_SQRT, SQRT_F32, SQRT_F64, SQRT_V128);
@@ -4039,38 +4046,39 @@ struct MUL_ADD_V128
     //   1. Flush s3 into v3, save to stack[32].
     //   2. Flush s1/s2 into v0/v1, save to stack[0]/stack[16].
     //   3. Restore s3 into v3, fmla into v2, NaN fixup, flush output.
-    e.ChangeFpcrMode(FPCRMode::Vmx);
-    int d = i.dest.reg().getIdx();
+    EmitWithVmxFpcr(e, [&] {
+      int d = i.dest.reg().getIdx();
 
-    // Flush s3 → v3, save to stack slot 2.
-    int s3 = SrcVReg(e, i.src3, 3);
-    if (s3 != 3) e.mov(VReg(3).b16, VReg(s3).b16);
-    FlushDenormals_V128(e, 3, 0, 1);
-    e.str(QReg(3),
-          Xbyak_aarch64::ptr(
-              e.sp, static_cast<int32_t>(StackLayout::GUEST_SCRATCH) + 32));
+      // Flush s3 → v3, save to stack slot 2.
+      int s3 = SrcVReg(e, i.src3, 3);
+      if (s3 != 3) e.mov(VReg(3).b16, VReg(s3).b16);
+      FlushDenormals_V128(e, 3, 0, 1);
+      e.str(QReg(3),
+            Xbyak_aarch64::ptr(
+                e.sp, static_cast<int32_t>(StackLayout::GUEST_SCRATCH) + 32));
 
-    // Flush s1/s2 → v0/v1, save to stack slots 0/1.
-    int s1, s2;
-    PrepareVmxFpSources(e, i.src1, i.src2, s1, s2);
-    e.str(QReg(0), Xbyak_aarch64::ptr(
-                       e.sp, static_cast<int32_t>(StackLayout::GUEST_SCRATCH)));
-    e.str(QReg(1),
-          Xbyak_aarch64::ptr(
-              e.sp, static_cast<int32_t>(StackLayout::GUEST_SCRATCH) + 16));
+      // Flush s1/s2 → v0/v1, save to stack slots 0/1.
+      int s1, s2;
+      PrepareVmxFpSources(e, i.src1, i.src2, s1, s2);
+      e.str(QReg(0), Xbyak_aarch64::ptr(e.sp, static_cast<int32_t>(
+                                                  StackLayout::GUEST_SCRATCH)));
+      e.str(QReg(1),
+            Xbyak_aarch64::ptr(
+                e.sp, static_cast<int32_t>(StackLayout::GUEST_SCRATCH) + 16));
 
-    // Restore flushed s3, compute fmla into v2 via copy.
-    e.ldr(QReg(2),
-          Xbyak_aarch64::ptr(
-              e.sp, static_cast<int32_t>(StackLayout::GUEST_SCRATCH) + 32));
-    e.fmla(VReg(2).s4, VReg(s1).s4, VReg(s2).s4);
+      // Restore flushed s3, compute fmla into v2 via copy.
+      e.ldr(QReg(2),
+            Xbyak_aarch64::ptr(
+                e.sp, static_cast<int32_t>(StackLayout::GUEST_SCRATCH) + 32));
+      e.fmla(VReg(2).s4, VReg(s1).s4, VReg(s2).s4);
 
-    // PPC NaN fixup (sources on stack at offsets 0/16/32).
-    FixupVmxNan_V128_Fma(e);
+      // PPC NaN fixup (sources on stack at offsets 0/16/32).
+      FixupVmxNan_V128_Fma(e);
 
-    // Flush output denormals.
-    FlushDenormals_V128(e, 2, 0, 1);
-    e.mov(VReg(d).b16, VReg(2).b16);
+      // Flush output denormals.
+      FlushDenormals_V128(e, 2, 0, 1);
+      e.mov(VReg(d).b16, VReg(2).b16);
+    });
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_MUL_ADD, MUL_ADD_F32, MUL_ADD_F64, MUL_ADD_V128);
@@ -4160,39 +4168,40 @@ struct MUL_SUB_V128
   static void Emit(A64Emitter& e, const EmitArgType& i) {
     // dest = s1*s2 - s3 with VMX denormal flushing + PPC NaN propagation.
     // Same as MUL_ADD but negate s3 before the fmla.
-    e.ChangeFpcrMode(FPCRMode::Vmx);
-    int d = i.dest.reg().getIdx();
+    EmitWithVmxFpcr(e, [&] {
+      int d = i.dest.reg().getIdx();
 
-    // Flush s3 → v3, save un-negated for NaN fixup.
-    int s3 = SrcVReg(e, i.src3, 3);
-    if (s3 != 3) e.mov(VReg(3).b16, VReg(s3).b16);
-    FlushDenormals_V128(e, 3, 0, 1);
-    e.str(QReg(3),
-          Xbyak_aarch64::ptr(
-              e.sp, static_cast<int32_t>(StackLayout::GUEST_SCRATCH) + 32));
+      // Flush s3 → v3, save un-negated for NaN fixup.
+      int s3 = SrcVReg(e, i.src3, 3);
+      if (s3 != 3) e.mov(VReg(3).b16, VReg(s3).b16);
+      FlushDenormals_V128(e, 3, 0, 1);
+      e.str(QReg(3),
+            Xbyak_aarch64::ptr(
+                e.sp, static_cast<int32_t>(StackLayout::GUEST_SCRATCH) + 32));
 
-    // Flush s1/s2 → v0/v1, save for NaN fixup.
-    int s1, s2;
-    PrepareVmxFpSources(e, i.src1, i.src2, s1, s2);
-    e.str(QReg(0), Xbyak_aarch64::ptr(
-                       e.sp, static_cast<int32_t>(StackLayout::GUEST_SCRATCH)));
-    e.str(QReg(1),
-          Xbyak_aarch64::ptr(
-              e.sp, static_cast<int32_t>(StackLayout::GUEST_SCRATCH) + 16));
+      // Flush s1/s2 → v0/v1, save for NaN fixup.
+      int s1, s2;
+      PrepareVmxFpSources(e, i.src1, i.src2, s1, s2);
+      e.str(QReg(0), Xbyak_aarch64::ptr(e.sp, static_cast<int32_t>(
+                                                  StackLayout::GUEST_SCRATCH)));
+      e.str(QReg(1),
+            Xbyak_aarch64::ptr(
+                e.sp, static_cast<int32_t>(StackLayout::GUEST_SCRATCH) + 16));
 
-    // Reload flushed s3, negate into v2, fmla: v2 = -s3 + s1*s2 = s1*s2 - s3.
-    e.ldr(QReg(2),
-          Xbyak_aarch64::ptr(
-              e.sp, static_cast<int32_t>(StackLayout::GUEST_SCRATCH) + 32));
-    e.fneg(VReg(2).s4, VReg(2).s4);
-    e.fmla(VReg(2).s4, VReg(s1).s4, VReg(s2).s4);
+      // Reload flushed s3, negate into v2, fmla: v2 = -s3 + s1*s2 = s1*s2 - s3.
+      e.ldr(QReg(2),
+            Xbyak_aarch64::ptr(
+                e.sp, static_cast<int32_t>(StackLayout::GUEST_SCRATCH) + 32));
+      e.fneg(VReg(2).s4, VReg(2).s4);
+      e.fmla(VReg(2).s4, VReg(s1).s4, VReg(s2).s4);
 
-    // PPC NaN fixup (sources on stack at offsets 0/16/32).
-    FixupVmxNan_V128_Fma(e);
+      // PPC NaN fixup (sources on stack at offsets 0/16/32).
+      FixupVmxNan_V128_Fma(e);
 
-    // Flush output denormals.
-    FlushDenormals_V128(e, 2, 0, 1);
-    e.mov(VReg(d).b16, VReg(2).b16);
+      // Flush output denormals.
+      FlushDenormals_V128(e, 2, 0, 1);
+      e.mov(VReg(d).b16, VReg(2).b16);
+    });
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_MUL_SUB, MUL_SUB_F32, MUL_SUB_F64, MUL_SUB_V128);
@@ -4274,15 +4283,16 @@ struct POW2_F64 : Sequence<POW2_F64, I<OPCODE_POW2, F64Op, F64Op>> {
 };
 struct POW2_V128 : Sequence<POW2_V128, I<OPCODE_POW2, V128Op, V128Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    e.ChangeFpcrMode(FPCRMode::Vmx);
-    int s = SrcVReg(e, i.src1, 0);
-    int d = i.dest.reg().getIdx();
-    e.str(QReg(s),
-          ptr(e.sp, static_cast<uint32_t>(StackLayout::GUEST_SCRATCH)));
-    e.add(e.x1, e.sp, static_cast<uint32_t>(StackLayout::GUEST_SCRATCH));
-    e.CallNativeSafe(reinterpret_cast<void*>(EmulatePow2));
-    e.ldr(QReg(d),
-          ptr(e.sp, static_cast<uint32_t>(StackLayout::GUEST_SCRATCH)));
+    EmitWithVmxFpcr(e, [&] {
+      int s = SrcVReg(e, i.src1, 0);
+      int d = i.dest.reg().getIdx();
+      e.str(QReg(s),
+            ptr(e.sp, static_cast<uint32_t>(StackLayout::GUEST_SCRATCH)));
+      e.add(e.x1, e.sp, static_cast<uint32_t>(StackLayout::GUEST_SCRATCH));
+      e.CallNativeSafe(reinterpret_cast<void*>(EmulatePow2));
+      e.ldr(QReg(d),
+            ptr(e.sp, static_cast<uint32_t>(StackLayout::GUEST_SCRATCH)));
+    });
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_POW2, POW2_F32, POW2_F64, POW2_V128);
@@ -4302,15 +4312,16 @@ struct LOG2_F64 : Sequence<LOG2_F64, I<OPCODE_LOG2, F64Op, F64Op>> {
 };
 struct LOG2_V128 : Sequence<LOG2_V128, I<OPCODE_LOG2, V128Op, V128Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    e.ChangeFpcrMode(FPCRMode::Vmx);
-    int s = SrcVReg(e, i.src1, 0);
-    int d = i.dest.reg().getIdx();
-    e.str(QReg(s),
-          ptr(e.sp, static_cast<uint32_t>(StackLayout::GUEST_SCRATCH)));
-    e.add(e.x1, e.sp, static_cast<uint32_t>(StackLayout::GUEST_SCRATCH));
-    e.CallNativeSafe(reinterpret_cast<void*>(EmulateLog2));
-    e.ldr(QReg(d),
-          ptr(e.sp, static_cast<uint32_t>(StackLayout::GUEST_SCRATCH)));
+    EmitWithVmxFpcr(e, [&] {
+      int s = SrcVReg(e, i.src1, 0);
+      int d = i.dest.reg().getIdx();
+      e.str(QReg(s),
+            ptr(e.sp, static_cast<uint32_t>(StackLayout::GUEST_SCRATCH)));
+      e.add(e.x1, e.sp, static_cast<uint32_t>(StackLayout::GUEST_SCRATCH));
+      e.CallNativeSafe(reinterpret_cast<void*>(EmulateLog2));
+      e.ldr(QReg(d),
+            ptr(e.sp, static_cast<uint32_t>(StackLayout::GUEST_SCRATCH)));
+    });
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_LOG2, LOG2_F32, LOG2_F64, LOG2_V128);
@@ -4322,39 +4333,40 @@ struct DOT_PRODUCT_3_V128
     : Sequence<DOT_PRODUCT_3_V128,
                I<OPCODE_DOT_PRODUCT_3, V128Op, V128Op, V128Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    e.ChangeFpcrMode(FPCRMode::Vmx);
-    // Inline NEON: multiply in double precision, sum 3 elements, convert back.
-    // Uses v0-v3 as scratch.
-    int s1 = SrcVReg(e, i.src1, 0);
-    int s2 = SrcVReg(e, i.src2, 1);
-    int d = i.dest.reg().getIdx();
-    // Widen low 2 floats of each source to double.
-    e.fcvtl(VReg(0).d2, VReg(s1).s2);            // v0 = {s1[0], s1[1]} as f64
-    e.fcvtl(VReg(1).d2, VReg(s2).s2);            // v1 = {s2[0], s2[1]} as f64
-    e.fmul(VReg(0).d2, VReg(0).d2, VReg(1).d2);  // v0 = {a0*b0, a1*b1}
-    // Widen high 2 floats (elements 2,3) to double.
-    e.fcvtl2(VReg(2).d2, VReg(s1).s4);           // v2 = {s1[2], s1[3]} as f64
-    e.fcvtl2(VReg(3).d2, VReg(s2).s4);           // v3 = {s2[2], s2[3]} as f64
-    e.fmul(VReg(2).d2, VReg(2).d2, VReg(3).d2);  // v2 = {a2*b2, a3*b3}
-    // Sum: d0 = v0[0] + v0[1] + v2[0] (skip v2[1] = element 3).
-    // faddp d1, v0.2d  → d1 = v0[0] + v0[1]
-    e.faddp(DReg(1), VReg(0).d2);
-    // fadd d1, d1, d2  → d1 = d1 + v2[0]
-    e.fadd(DReg(1), DReg(1), DReg(2));
-    // Convert back to float.
-    e.fcvt(SReg(0), DReg(1));
-    // Check for infinity → QNaN.
-    e.fabs(SReg(1), SReg(0));
-    e.mov(e.w17, 0x7F800000u);  // +inf
-    e.fmov(SReg(2), e.w17);
-    e.fcmp(SReg(1), SReg(2));
-    auto& not_inf = e.NewCachedLabel();
-    e.b(Xbyak_aarch64::NE, not_inf);
-    e.mov(e.w17, 0x7FC00000u);  // QNaN
-    e.fmov(SReg(0), e.w17);
-    e.L(not_inf);
-    // Splat result to all 4 lanes.
-    e.dup(VReg(d).s4, VReg(0).s4[0]);
+    EmitWithVmxFpcr(e, [&] {
+      // Inline NEON: multiply in double precision, sum 3 elements, convert
+      // back. Uses v0-v3 as scratch.
+      int s1 = SrcVReg(e, i.src1, 0);
+      int s2 = SrcVReg(e, i.src2, 1);
+      int d = i.dest.reg().getIdx();
+      // Widen low 2 floats of each source to double.
+      e.fcvtl(VReg(0).d2, VReg(s1).s2);            // v0 = {s1[0], s1[1]} as f64
+      e.fcvtl(VReg(1).d2, VReg(s2).s2);            // v1 = {s2[0], s2[1]} as f64
+      e.fmul(VReg(0).d2, VReg(0).d2, VReg(1).d2);  // v0 = {a0*b0, a1*b1}
+      // Widen high 2 floats (elements 2,3) to double.
+      e.fcvtl2(VReg(2).d2, VReg(s1).s4);           // v2 = {s1[2], s1[3]} as f64
+      e.fcvtl2(VReg(3).d2, VReg(s2).s4);           // v3 = {s2[2], s2[3]} as f64
+      e.fmul(VReg(2).d2, VReg(2).d2, VReg(3).d2);  // v2 = {a2*b2, a3*b3}
+      // Sum: d0 = v0[0] + v0[1] + v2[0] (skip v2[1] = element 3).
+      // faddp d1, v0.2d  → d1 = v0[0] + v0[1]
+      e.faddp(DReg(1), VReg(0).d2);
+      // fadd d1, d1, d2  → d1 = d1 + v2[0]
+      e.fadd(DReg(1), DReg(1), DReg(2));
+      // Convert back to float.
+      e.fcvt(SReg(0), DReg(1));
+      // Check for infinity → QNaN.
+      e.fabs(SReg(1), SReg(0));
+      e.mov(e.w17, 0x7F800000u);  // +inf
+      e.fmov(SReg(2), e.w17);
+      e.fcmp(SReg(1), SReg(2));
+      auto& not_inf = e.NewCachedLabel();
+      e.b(Xbyak_aarch64::NE, not_inf);
+      e.mov(e.w17, 0x7FC00000u);  // QNaN
+      e.fmov(SReg(0), e.w17);
+      e.L(not_inf);
+      // Splat result to all 4 lanes.
+      e.dup(VReg(d).s4, VReg(0).s4[0]);
+    });
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_DOT_PRODUCT_3, DOT_PRODUCT_3_V128);
@@ -4366,37 +4378,38 @@ struct DOT_PRODUCT_4_V128
     : Sequence<DOT_PRODUCT_4_V128,
                I<OPCODE_DOT_PRODUCT_4, V128Op, V128Op, V128Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    e.ChangeFpcrMode(FPCRMode::Vmx);
-    // Inline NEON: multiply in double precision, sum all 4 elements.
-    int s1 = SrcVReg(e, i.src1, 0);
-    int s2 = SrcVReg(e, i.src2, 1);
-    int d = i.dest.reg().getIdx();
-    // Widen low 2 floats to double, multiply.
-    e.fcvtl(VReg(0).d2, VReg(s1).s2);
-    e.fcvtl(VReg(1).d2, VReg(s2).s2);
-    e.fmul(VReg(0).d2, VReg(0).d2, VReg(1).d2);
-    // Widen high 2 floats to double, multiply.
-    e.fcvtl2(VReg(2).d2, VReg(s1).s4);
-    e.fcvtl2(VReg(3).d2, VReg(s2).s4);
-    e.fmul(VReg(2).d2, VReg(2).d2, VReg(3).d2);
-    // Sum all 4 products: v0 = {a0*b0+a2*b2, a1*b1+a3*b3}
-    e.fadd(VReg(0).d2, VReg(0).d2, VReg(2).d2);
-    // faddp d1, v0.2d → d1 = sum of both lanes
-    e.faddp(DReg(1), VReg(0).d2);
-    // Convert back to float.
-    e.fcvt(SReg(0), DReg(1));
-    // Check for infinity → QNaN.
-    e.fabs(SReg(1), SReg(0));
-    e.mov(e.w17, 0x7F800000u);
-    e.fmov(SReg(2), e.w17);
-    e.fcmp(SReg(1), SReg(2));
-    auto& not_inf = e.NewCachedLabel();
-    e.b(Xbyak_aarch64::NE, not_inf);
-    e.mov(e.w17, 0x7FC00000u);
-    e.fmov(SReg(0), e.w17);
-    e.L(not_inf);
-    // Splat result to all 4 lanes.
-    e.dup(VReg(d).s4, VReg(0).s4[0]);
+    EmitWithVmxFpcr(e, [&] {
+      // Inline NEON: multiply in double precision, sum all 4 elements.
+      int s1 = SrcVReg(e, i.src1, 0);
+      int s2 = SrcVReg(e, i.src2, 1);
+      int d = i.dest.reg().getIdx();
+      // Widen low 2 floats to double, multiply.
+      e.fcvtl(VReg(0).d2, VReg(s1).s2);
+      e.fcvtl(VReg(1).d2, VReg(s2).s2);
+      e.fmul(VReg(0).d2, VReg(0).d2, VReg(1).d2);
+      // Widen high 2 floats to double, multiply.
+      e.fcvtl2(VReg(2).d2, VReg(s1).s4);
+      e.fcvtl2(VReg(3).d2, VReg(s2).s4);
+      e.fmul(VReg(2).d2, VReg(2).d2, VReg(3).d2);
+      // Sum all 4 products: v0 = {a0*b0+a2*b2, a1*b1+a3*b3}
+      e.fadd(VReg(0).d2, VReg(0).d2, VReg(2).d2);
+      // faddp d1, v0.2d → d1 = sum of both lanes
+      e.faddp(DReg(1), VReg(0).d2);
+      // Convert back to float.
+      e.fcvt(SReg(0), DReg(1));
+      // Check for infinity → QNaN.
+      e.fabs(SReg(1), SReg(0));
+      e.mov(e.w17, 0x7F800000u);
+      e.fmov(SReg(2), e.w17);
+      e.fcmp(SReg(1), SReg(2));
+      auto& not_inf = e.NewCachedLabel();
+      e.b(Xbyak_aarch64::NE, not_inf);
+      e.mov(e.w17, 0x7FC00000u);
+      e.fmov(SReg(0), e.w17);
+      e.L(not_inf);
+      // Splat result to all 4 lanes.
+      e.dup(VReg(d).s4, VReg(0).s4[0]);
+    });
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_DOT_PRODUCT_4, DOT_PRODUCT_4_V128);
@@ -4476,61 +4489,215 @@ struct SET_ROUNDING_MODE
 };
 EMITTER_OPCODE_TABLE(OPCODE_SET_ROUNDING_MODE, SET_ROUNDING_MODE);
 
+inline uint32_t CountLeadingZeros32(uint32_t value) {
+  return value ? static_cast<uint32_t>(xe::lzcnt(value)) : 32u;
+}
+
+inline uint32_t CountLeadingZeros64(uint64_t value) {
+  return value ? static_cast<uint32_t>(xe::lzcnt(value)) : 64u;
+}
+
+inline float BitsToFloat(uint32_t bits) {
+  float value;
+  std::memcpy(&value, &bits, sizeof(value));
+  return value;
+}
+
+inline double BitsToDouble(uint64_t bits) {
+  double value;
+  std::memcpy(&value, &bits, sizeof(value));
+  return value;
+}
+
+// Copied from the x64 backend to match PPC estimate behavior, including
+// denormal, NaN, and reciprocal-square-root table semantics.
+static constexpr uint32_t kVrsqrteTable[32] = {
+    0x0568B4FDu, 0x04F3AF97u, 0x048DAAA5u, 0x0435A618u, 0x03E7A1E4u,
+    0x03A29DFEu, 0x03659A5Cu, 0x032E96F8u, 0x02FC93CAu, 0x02D090CEu,
+    0x02A88DFEu, 0x02838B57u, 0x026188D4u, 0x02438673u, 0x02268431u,
+    0x020B820Bu, 0x03D27FFAu, 0x03807C29u, 0x033878AAu, 0x02F97572u,
+    0x02C27279u, 0x02926FB7u, 0x02666D26u, 0x023F6AC0u, 0x021D6881u,
+    0x01FD6665u, 0x01E16468u, 0x01C76287u, 0x01AF60C1u, 0x01995F12u,
+    0x01855D79u, 0x01735BF4u,
+};
+
+static constexpr uint8_t kFrsqrteTable[16] = {
+    241u, 216u, 192u, 168u, 152u, 136u, 128u, 112u,
+    96u,  76u,  60u,  48u,  32u,  24u,  16u,  8u,
+};
+
+inline uint32_t EmulateVrsqrteScalarBits(uint32_t src_bits,
+                                         bool njm_enabled = true) {
+  uint32_t r8d = src_bits;
+  float input = BitsToFloat(r8d);
+  uint32_t ecx = r8d & 0x7FFFFFu;
+  uint32_t edx = ecx;
+  int32_t eax = 0;
+  uint32_t r9d = 0;
+
+  if (r8d == 0xFF800000u) {
+    return 0x7FC00000u;
+  }
+
+  if ((r8d & 0x7F800000u) == 0 && ecx != 0) {
+    if (!njm_enabled) {
+      r9d = r8d & 0x7FFFFFFFu;
+      if (r9d == 0x00400000u) {
+        return ((~r8d >> 31) != 0) ? 0x5F34FD00u : 0x7FC00000u;
+      }
+      ecx = CountLeadingZeros32(ecx);
+      r9d = 9;
+      eax = -118;
+      edx = static_cast<uint32_t>(static_cast<int32_t>(ecx) - 8);
+      r9d -= ecx;
+      eax -= static_cast<int32_t>(ecx);
+      edx = r8d << edx;
+      edx &= 0x7FFFFEu;
+      goto compute_from_fields;
+    }
+    return ((~r8d >> 31) != 0) ? 0x7F800000u : 0xFF800000u;
+  }
+
+  r9d = (r8d >> 23) & 0xFFu;
+  eax = static_cast<int32_t>(r9d) - 127;
+  if (r9d == 255u) {
+    if (!(input < 0.0f || std::isnan(input))) {
+      if (ecx == 0) {
+        return 0u;
+      }
+    }
+    return r8d | 0x00400000u;
+  }
+
+compute_from_fields:
+  if (eax == 128) {
+    if (0.0f > input) {
+      if (edx == 0) {
+        return 0x7FC00000u;
+      }
+      return r8d | 0x00400000u;
+    }
+  }
+
+  if (edx == 0) {
+    if (r9d == 0u) {
+      return ((~r8d >> 31) != 0) ? 0x7F800000u : 0xFF800000u;
+    }
+  } else if (eax == 128) {
+    return r8d | 0x00400000u;
+  }
+
+  if (0.0f > input) {
+    return 0x7FC00000u;
+  }
+
+  ecx = 127;
+  eax <<= 4;
+  ecx -= static_cast<int32_t>(r9d);
+  r9d = edx;
+  eax &= 16;
+  edx >>= 9;
+  r9d >>= 19;
+  edx &= 1023;
+  ecx >>= 1;
+  eax |= static_cast<int32_t>(r9d);
+  eax ^= 16;
+
+  uint32_t table_entry = kVrsqrteTable[static_cast<uint32_t>(eax) & 31];
+  eax = static_cast<int32_t>(table_entry);
+  r9d = table_entry >> 16;
+  edx *= r9d;
+  eax <<= 10;
+  eax &= 0x3FFFC00;
+  eax -= static_cast<int32_t>(edx);
+  if (((static_cast<uint32_t>(eax) >> 25) & 1u) == 0) {
+    edx = static_cast<uint32_t>(eax) & 0x1FFFFFFu;
+    ecx += 6;
+    uint32_t lz = CountLeadingZeros32(edx);
+    r9d = lz - 6;
+    ecx -= static_cast<int32_t>(lz);
+    eax = static_cast<int32_t>(static_cast<uint32_t>(eax) << r9d);
+  }
+
+  if ((eax & 0x5) != 0 && (eax & 0x2) != 0) {
+    eax += 4;
+  }
+
+  ecx <<= 23;
+  r8d &= 0x80000000u;
+  eax = static_cast<int32_t>(static_cast<uint32_t>(eax) >> 2);
+  ecx += 0x3F800000;
+  eax &= 0x7FFFFF;
+  uint32_t out = static_cast<uint32_t>(ecx) | r8d | static_cast<uint32_t>(eax);
+  if ((out & 0x7F800000u) == 0 && (out & 0x007FFFFFu) != 0) {
+    out &= 0x80000000u;
+  }
+  return out;
+}
+
+inline uint64_t EmulateFrsqrteBits(uint64_t src_bits,
+                                   bool non_ieee_mode = false) {
+  uint64_t rax = src_bits;
+  constexpr uint64_t kSignMask = 0x8000000000000000ULL;
+  constexpr uint64_t kExpMask = 0x7FF0000000000000ULL;
+
+  if (non_ieee_mode) {
+    uint64_t shifted = rax << 12;
+    if (shifted != 0 && (rax & kExpMask) == 0) {
+      return (rax & kSignMask) | kExpMask;
+    }
+  }
+
+  uint64_t rcx = rax + rax;
+  if (rcx == 0) {
+    return (rax & kSignMask) | kExpMask;
+  }
+
+  if (((~rax) & kExpMask) == 0) {
+    if (rax == kExpMask) {
+      return 0ULL;
+    }
+    uint64_t shifted = rax << 12;
+    if (shifted == 0 && BitsToDouble(rax) < 0.0) {
+      return 0x7FF8000000000000ULL;
+    }
+    return rax | 0x7FF8000000000000ULL;
+  }
+
+  if (0.0 > BitsToDouble(rax)) {
+    return 0x7FF8000000000000ULL;
+  }
+
+  uint64_t exponent = (rax >> 52) & 0x7FFULL;
+  uint64_t mantissa = rax & 0x000FFFFFFFFFFFFFULL;
+
+  if (mantissa != 0 && exponent == 0) {
+    uint32_t lz = CountLeadingZeros64(mantissa);
+    mantissa <<= static_cast<uint32_t>(static_cast<int32_t>(lz) - 11);
+    exponent = static_cast<uint64_t>(12 - static_cast<int32_t>(lz));
+  }
+
+  uint32_t edx = static_cast<uint32_t>(exponent * 8);
+  uint32_t eax = static_cast<uint32_t>(mantissa >> 49) & 7u;
+  int32_t exp_unbiased = static_cast<int32_t>(exponent) - 1023;
+  edx &= 8u;
+  exp_unbiased >>= 1;
+  eax |= edx;
+  edx = static_cast<uint32_t>(1022 - exp_unbiased);
+  eax ^= 8u;
+  return (static_cast<uint64_t>(edx) << 52) |
+         (static_cast<uint64_t>(kFrsqrteTable[eax & 15u]) << 44);
+}
+
 // PPC frsqrte lookup table implementation (PowerISA Table E-5).
 // Matches the x64 backend's EmitFrsqrteHelper.
 static uint64_t PpcFrsqrte(void* raw_context) {
   auto* ctx = reinterpret_cast<ppc::PPCContext*>(raw_context);
-  uint64_t bits = ctx->scratch;
-
-  uint32_t sign = (uint32_t)(bits >> 63);
-  uint32_t exp = (uint32_t)((bits >> 52) & 0x7FF);
-  uint64_t mantissa = bits & 0x000FFFFFFFFFFFFFULL;
-
-  // NaN → QNaN (quiet it, preserve sign and payload)
-  if (exp == 0x7FF && mantissa != 0) {
-    return bits | (1ULL << 51);
-  }
-  // ±0 → ±inf
-  if (exp == 0 && mantissa == 0) {
-    return sign ? 0xFFF0000000000000ULL : 0x7FF0000000000000ULL;
-  }
-  // +inf → +0
-  if (exp == 0x7FF && !sign) {
-    return 0;
-  }
-  // -inf or negative → QNaN
-  if (sign) {
-    return 0x7FF8000000000000ULL;
-  }
-
-  // Denormal: normalize (matching x64 EmitFrsqrteHelper L25).
-  int32_t effective_exp = (int32_t)exp;
-  uint64_t norm_mantissa = mantissa;
-  if (exp == 0) {
-    int lz = (int)xe::lzcnt(mantissa);  // leading zeros in 64-bit
-    norm_mantissa = mantissa << (lz - 11);
-    effective_exp = 12 - lz;
-  }
-
-  // PPC frsqrte lookup table (16 entries, 8 bits each).
-  static constexpr uint8_t table[] = {241, 216, 192, 168, 152, 136, 128, 112,
-                                      96,  76,  60,  48,  32,  24,  16,  8};
-
-  // Index: bit 3 = !(exp & 1), bits 2:0 = top 3 mantissa bits.
-  // For denormals, norm_mantissa has implicit 1 at bit 52; & 7 masks it out.
-  uint32_t top3 = (uint32_t)(norm_mantissa >> 49) & 7;
-  uint32_t index = (((uint32_t)effective_exp & 1) << 3) | top3;
-  index ^= 8;
-
-  // Result exponent = 1022 - floor((effective_exp - 1023) / 2).
-  int32_t unbiased = effective_exp - 1023;
-  int32_t half = unbiased >> 1;  // arithmetic shift = floor division
-  uint32_t result_exp = (uint32_t)(1022 - half);
-
-  // Construct result: exponent in bits 62:52, table value in bits 51:44.
-  uint64_t result =
-      ((uint64_t)result_exp << 52) | ((uint64_t)table[index] << 44);
-  return result;
+  auto* backend_context = reinterpret_cast<A64BackendContext*>(
+      reinterpret_cast<uint8_t*>(raw_context) - sizeof(A64BackendContext));
+  bool non_ieee_mode =
+      (backend_context->flags & (1u << kA64BackendNonIEEEMode)) != 0;
+  return EmulateFrsqrteBits(ctx->scratch, non_ieee_mode);
 }
 
 // ============================================================================
@@ -4579,115 +4746,42 @@ struct RSQRT_F64 : Sequence<RSQRT_F64, I<OPCODE_RSQRT, F64Op, F64Op>> {
 // PPC vrsqrtefp per-lane implementation.
 // Uses the same 32-entry lookup table + interpolation as x64's
 // EmitScalarVRsqrteHelper.
-static uint32_t PpcVrsqrtefpLane(uint32_t bits) {
-  static constexpr uint32_t table[32] = {
-      0x0568B4FD, 0x04F3AF97, 0x048DAAA5, 0x0435A618, 0x03E7A1E4, 0x03A29DFE,
-      0x03659A5C, 0x032E96F8, 0x02FC93CA, 0x02D090CE, 0x02A88DFE, 0x02838B57,
-      0x026188D4, 0x02438673, 0x02268431, 0x020B820B, 0x03D27FFA, 0x03807C29,
-      0x033878AA, 0x02F97572, 0x02C27279, 0x02926FB7, 0x02666D26, 0x023F6AC0,
-      0x021D6881, 0x01FD6665, 0x01E16468, 0x01C76287, 0x01AF60C1, 0x01995F12,
-      0x01855D79, 0x01735BF4,
-  };
-
-  uint32_t sign = bits >> 31;
-  uint32_t biased_exp = (bits >> 23) & 0xFF;
-  uint32_t mantissa = bits & 0x007FFFFF;
-
-  // -Inf → QNaN
-  if (bits == 0xFF800000u) return 0x7FC00000u;
-
-  // Denormal or zero (exp == 0)
-  if (biased_exp == 0) {
-    // ±0 or denormal with NJM on → flush to ±0 → ±Inf
-    return sign ? 0xFF800000u : 0x7F800000u;
-  }
-
-  // NaN/Inf (exp == 255)
-  if (biased_exp == 255) {
-    if (mantissa == 0) {
-      // +Inf → +0 (-Inf already handled above)
-      return 0;
-    }
-    // NaN: quiet it (set bit 22), preserve sign and payload
-    return bits | 0x00400000u;
-  }
-
-  // Negative normal → QNaN
-  if (sign) return 0x7FC00000u;
-
-  // Normal positive: table lookup + interpolation
-  int32_t unbiased_exp = (int32_t)biased_exp - 127;
-
-  // Table index: exp parity selects half, top 4 mantissa bits select entry
-  uint32_t exp_parity = ((uint32_t)(unbiased_exp << 4)) & 16;
-  uint32_t top4 = mantissa >> 19;
-  uint32_t index = (exp_parity | top4) ^ 16;
-
-  // 10-bit interpolation factor from mantissa
-  uint32_t interp = (mantissa >> 9) & 1023;
-
-  // Result exponent (arithmetic shift)
-  int32_t result_exp = (127 - (int32_t)biased_exp) >> 1;
-
-  // Lookup + linear interpolation
-  uint32_t entry = table[index];
-  uint32_t slope = entry >> 16;
-  uint32_t base = (entry << 10) & 0x3FFFC00u;
-  int32_t raw = (int32_t)base - (int32_t)(interp * slope);
-
-  // Normalize if bit 25 not set
-  if (!(raw & (1 << 25))) {
-    uint32_t val = (uint32_t)raw & 0x1FFFFFF;
-    uint32_t lz = (uint32_t)xe::lzcnt(val);
-    int32_t shift = (int32_t)lz - 6;
-    result_exp += 6;
-    result_exp -= (int32_t)lz;
-    raw <<= shift;
-  }
-
-  // Rounding
-  if ((raw & 5) && (raw & 2)) raw += 4;
-
-  // Assemble result
-  uint32_t res_exp = (uint32_t)((result_exp << 23) + 0x3F800000);
-  uint32_t res_man = ((uint32_t)raw >> 2) & 0x7FFFFF;
-  uint32_t result = res_exp | res_man;
-
-  // DAZ: flush denormal output to +0
-  if (((result >> 23) & 0xFF) == 0 && (result & 0x7FFFFF)) {
-    result = 0;
-  }
-
-  return result;
+static uint32_t PpcVrsqrtefpLane(uint32_t bits, bool njm_enabled = true) {
+  return EmulateVrsqrteScalarBits(bits, njm_enabled);
 }
 
 static uint64_t PpcVrsqrtefpHelper(void* raw_context) {
   auto* ctx = reinterpret_cast<ppc::PPCContext*>(raw_context);
-  return (uint64_t)PpcVrsqrtefpLane((uint32_t)ctx->scratch);
+  auto* backend_context = reinterpret_cast<A64BackendContext*>(
+      reinterpret_cast<uint8_t*>(raw_context) - sizeof(A64BackendContext));
+  bool njm_enabled = (backend_context->flags & (1u << kA64BackendNJMOn)) != 0;
+  return static_cast<uint64_t>(
+      PpcVrsqrtefpLane(static_cast<uint32_t>(ctx->scratch), njm_enabled));
 }
 
 struct RSQRT_V128 : Sequence<RSQRT_V128, I<OPCODE_RSQRT, V128Op, V128Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    e.ChangeFpcrMode(FPCRMode::Vmx);
-    // Save source to stack scratch (survives CallNative).
-    int src_idx = SrcVReg(e, i.src1, 0);
-    e.str(QReg(src_idx),
-          Xbyak_aarch64::ptr(e.sp,
-                             static_cast<int32_t>(StackLayout::GUEST_SCRATCH)));
-    int dest_idx = i.dest.reg().getIdx();
-    for (int lane = 0; lane < 4; lane++) {
-      // Load float32 bits from saved source.
-      e.ldr(e.w0, Xbyak_aarch64::ptr(
-                      e.sp, static_cast<int32_t>(StackLayout::GUEST_SCRATCH) +
-                                lane * 4));
-      // Store to PPCContext::scratch for helper.
-      e.str(e.x0, Xbyak_aarch64::ptr(e.GetContextReg(),
-                                     static_cast<int32_t>(
-                                         offsetof(ppc::PPCContext, scratch))));
-      e.CallNative(reinterpret_cast<void*>(PpcVrsqrtefpHelper));
-      // Insert result lane into dest (allocated reg, survives CallNative).
-      e.ins(VReg(dest_idx).s4[lane], e.w0);
-    }
+    EmitWithVmxFpcr(e, [&] {
+      // Save source to stack scratch (survives CallNative).
+      int src_idx = SrcVReg(e, i.src1, 0);
+      e.str(QReg(src_idx),
+            Xbyak_aarch64::ptr(
+                e.sp, static_cast<int32_t>(StackLayout::GUEST_SCRATCH)));
+      int dest_idx = i.dest.reg().getIdx();
+      for (int lane = 0; lane < 4; lane++) {
+        // Load float32 bits from saved source.
+        e.ldr(e.w0, Xbyak_aarch64::ptr(
+                        e.sp, static_cast<int32_t>(StackLayout::GUEST_SCRATCH) +
+                                  lane * 4));
+        // Store to PPCContext::scratch for helper.
+        e.str(e.x0, Xbyak_aarch64::ptr(e.GetContextReg(),
+                                       static_cast<int32_t>(offsetof(
+                                           ppc::PPCContext, scratch))));
+        e.CallNative(reinterpret_cast<void*>(PpcVrsqrtefpHelper));
+        // Insert result lane into dest (allocated reg, survives CallNative).
+        e.ins(VReg(dest_idx).s4[lane], e.w0);
+      }
+    });
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_RSQRT, RSQRT_F32, RSQRT_F64, RSQRT_V128);
@@ -4731,21 +4825,22 @@ struct RECIP_F64 : Sequence<RECIP_F64, I<OPCODE_RECIP, F64Op, F64Op>> {
 };
 struct RECIP_V128 : Sequence<RECIP_V128, I<OPCODE_RECIP, V128Op, V128Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    e.ChangeFpcrMode(FPCRMode::Vmx);
-    if (i.src1.is_constant) {
-      LoadV128Const(e, 1, i.src1.constant());
-    } else {
-      e.mov(VReg(1).b16, VReg(i.src1.reg().getIdx()).b16);
-    }
-    // Flush input denormals.
-    FlushDenormals_V128(e, 1);  // scratch v2, v3
-    auto d = VReg(i.dest.reg().getIdx()).s4;
-    // Load 1.0f vector.
-    e.mov(e.w0, static_cast<uint64_t>(0x3F800000u));
-    e.dup(VReg(0).s4, e.w0);
-    e.fdiv(d, VReg(0).s4, VReg(1).s4);
-    // Flush output denormals.
-    FlushDenormals_V128(e, i.dest.reg().getIdx(), 0, 1);
+    EmitWithVmxFpcr(e, [&] {
+      if (i.src1.is_constant) {
+        LoadV128Const(e, 1, i.src1.constant());
+      } else {
+        e.mov(VReg(1).b16, VReg(i.src1.reg().getIdx()).b16);
+      }
+      // Flush input denormals.
+      FlushDenormals_V128(e, 1);  // scratch v2, v3
+      auto d = VReg(i.dest.reg().getIdx()).s4;
+      // Load 1.0f vector.
+      e.mov(e.w0, static_cast<uint64_t>(0x3F800000u));
+      e.dup(VReg(0).s4, e.w0);
+      e.fdiv(d, VReg(0).s4, VReg(1).s4);
+      // Flush output denormals.
+      FlushDenormals_V128(e, i.dest.reg().getIdx(), 0, 1);
+    });
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_RECIP, RECIP_F32, RECIP_F64, RECIP_V128);
@@ -4779,32 +4874,27 @@ EMITTER_OPCODE_TABLE(OPCODE_TO_SINGLE, TOSINGLE);
 // ============================================================================
 struct SET_NJM : Sequence<SET_NJM, I<OPCODE_SET_NJM, VoidOp, I8Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
-    // NJM (Non-Java Mode) maps to ARM64 FPCR FZ (Flush-to-Zero) bit (bit 24).
-    // When NJM=1, enable flush-to-zero. When NJM=0, disable.
-    // mrs x0, FPCR  (op0=3, op1=3, CRn=4, CRm=4, op2=0)
-    e.mrs(e.x0, 3, 3, 4, 4, 0);
+    // NJM feeds the PPC estimate helpers through backend context state, not the
+    // live host FPCR. VMX ops force their own scoped FPCR settings separately.
+    e.sub(e.x17, e.GetContextReg(),
+          static_cast<uint32_t>(sizeof(A64BackendContext)));
+    e.ldr(e.w0, ptr(e.x17,
+                    static_cast<uint32_t>(offsetof(A64BackendContext, flags))));
+    e.mov(e.w1, 1u << kA64BackendNJMOn);
     if (i.src1.is_constant) {
       if (i.src1.constant()) {
-        e.orr(e.x0, e.x0, (1u << 24));  // Set FZ bit
+        e.orr(e.w0, e.w0, e.w1);
       } else {
-        e.and_(e.x0, e.x0, ~(1ull << 24));  // Clear FZ bit
+        e.bic(e.w0, e.w0, e.w1);
       }
     } else {
-      // Dynamic: test src1, set/clear FZ accordingly.
-      auto& set_fz = e.NewCachedLabel();
-      auto& done = e.NewCachedLabel();
-      e.cbnz(i.src1, set_fz);
-      // NJM=0: clear FZ
-      e.and_(e.x0, e.x0, ~(1ull << 24));
-      e.b(done);
-      e.L(set_fz);
-      // NJM=1: set FZ
-      e.orr(e.x0, e.x0, (1u << 24));
-      e.L(done);
+      e.bic(e.w0, e.w0, e.w1);
+      e.tst(i.src1, 1);
+      e.csel(e.w1, e.w1, e.wzr, Xbyak_aarch64::Cond::NE);
+      e.orr(e.w0, e.w0, e.w1);
     }
-    // msr FPCR, x0  (op0=3, op1=3, CRn=4, CRm=4, op2=0)
-    e.msr(3, 3, 4, 4, 0, e.x0);
-    e.ForgetFpcrMode();
+    e.str(e.w0, ptr(e.x17,
+                    static_cast<uint32_t>(offsetof(A64BackendContext, flags))));
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_SET_NJM, SET_NJM);

--- a/src/xenia/cpu/backend/a64/a64_sequences.h
+++ b/src/xenia/cpu/backend/a64/a64_sequences.h
@@ -22,11 +22,11 @@ namespace a64 {
 class A64Emitter;
 
 typedef bool (*SequenceSelectFn)(A64Emitter&, const hir::Instr*, uint32_t ikey);
-extern std::unordered_map<uint32_t, SequenceSelectFn> sequence_table;
+std::unordered_map<uint32_t, SequenceSelectFn>& SequenceTable();
 
 template <typename T>
 bool Register() {
-  sequence_table.insert({T::head_key(), T::Select});
+  SequenceTable().insert({T::head_key(), T::Select});
   return true;
 }
 

--- a/src/xenia/cpu/backend/code_cache_base.h
+++ b/src/xenia/cpu/backend/code_cache_base.h
@@ -224,7 +224,17 @@ class CodeCacheBase : public CodeCache {
   }
 
   GuestFunction* LookupFunction(uint64_t host_pc) override {
-    uint32_t key = uint32_t(host_pc - kGeneratedCodeExecuteBase);
+    if (generated_code_map_.empty()) {
+      return nullptr;
+    }
+
+    const uint64_t code_base = execute_base_address();
+    const uint64_t code_end = code_base + total_size();
+    if (host_pc < code_base || host_pc >= code_end) {
+      return nullptr;
+    }
+
+    uint32_t key = uint32_t(host_pc - code_base);
     void* fn_entry = std::bsearch(
         &key, generated_code_map_.data(), generated_code_map_.size(),
         sizeof(std::pair<uint32_t, Function*>),

--- a/src/xenia/cpu/testing/storage_flags.cc
+++ b/src/xenia/cpu/testing/storage_flags.cc
@@ -1,0 +1,14 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2026 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/base/cvar.h"
+
+DEFINE_bool(mount_scratch, false, "Enable scratch mount", "Storage");
+DEFINE_bool(mount_cache, true, "Enable cache mount", "Storage");
+UPDATE_from_bool(mount_cache, 2024, 8, 31, 20, false);

--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -1282,7 +1282,6 @@ bool Emulator::ExceptionCallback(Exception* ex) {
   assert_not_null(current_thread);
 
   auto guest_function = code_cache->LookupFunction(ex->pc());
-  assert_not_null(guest_function);
 
   auto context = current_thread->thread_state()->context();
 
@@ -1293,9 +1292,19 @@ bool Emulator::ExceptionCallback(Exception* ex) {
                                current_thread->thread_id()));
   crash_msg.append(
       fmt::format("Thread Handle: 0x{:08X}\n", current_thread->handle()));
-  crash_msg.append(
-      fmt::format("PC: 0x{:08X}\n",
-                  guest_function->MapMachineCodeToGuestAddress(ex->pc())));
+  crash_msg.append(fmt::format("Host PC: 0x{:016X}\n", ex->pc()));
+  if (guest_function) {
+    crash_msg.append(
+        fmt::format("PC: 0x{:08X}\n",
+                    guest_function->MapMachineCodeToGuestAddress(ex->pc())));
+    crash_msg.append(fmt::format(
+        "Guest Function: '{}' [0x{:08X}, 0x{:08X})\n", guest_function->name(),
+        guest_function->address(), guest_function->end_address()));
+  } else {
+    crash_msg.append("PC: <unresolved>\n");
+    crash_msg.append(
+        "Guest Function: <host helper or unmapped code-cache location>\n");
+  }
   if (ex->code() == Exception::Code::kAccessViolation) {
     const char* op_str = "unknown";
     if (ex->access_violation_operation() ==


### PR DESCRIPTION
## Summary
- port the new A64 backend runtime bring-up to macOS, including trampoline allocation and helper trap handling for crash reporting
- restore PPC FP / VMX state handling and harden runtime resolve + MMIO recording paths needed for stable execution on Apple Silicon
- add MMIO-aware memory sequences and the small testing support needed by the backend port

## Testing
- not run (clean cherry-pick branch prepared for PR)