### PR TITLE
[a64] Fix MSVC-ARM64 `MemoryBarrier` preprocessor conflict

### DIFF
--- a/src/xenia/cpu/hir/hir_builder.h
+++ b/src/xenia/cpu/hir/hir_builder.h
@@ -24,6 +24,11 @@
 #include "xenia/cpu/hir/value.h"
 #include "xenia/cpu/mmio_handler.h"
 
+#if defined(XE_COMPILER_MSVC) && defined(XE_ARCH_ARM64)
+// winnt.h defines `MemoryBarrier` as a macro on ARM-MSVC
+#undef MemoryBarrier
+#endif
+
 namespace xe {
 namespace cpu {
 namespace hir {


### PR DESCRIPTION
Fixes a build error on MSVC when building for ARM. Though there might be a better way to fix this.
```
hir_builder.h(206,8): error C2061: syntax error: identifier '_ARM64_BARRIER_SY'
```
`MemoryBarrier` resolves into a preprocessor when building on MSVC-ARM64 in particular.

Seems to be the same issue here:
https://github.com/copperspice/copperspice/issues/303