### PR TITLE
[a64] Add opportunistic `LoadV128Const` splat optimizations

### DIFF
--- a/src/xenia/cpu/backend/a64/a64_seq_util.h
+++ b/src/xenia/cpu/backend/a64/a64_seq_util.h
@@ -45,7 +45,9 @@ inline void EmitWithVmxFpcr(A64Emitter& e, Fn&& emit_op) {
 }
 
 // Load a compile-time vec128_t constant into a NEON register.
-inline void LoadV128Const(A64Emitter& e, int vreg_idx, const vec128_t& val) {
+// May clobber the provided GPR scratch-register
+inline void LoadV128Const(A64Emitter& e, int vreg_idx, const vec128_t& val,
+                          int gpr_scratch_idx = 0) {
   if (!val.low && !val.high) {
     // 0000...
     e.movi(VReg2D(vreg_idx), 0);
@@ -82,8 +84,8 @@ inline void LoadV128Const(A64Emitter& e, int vreg_idx, const vec128_t& val) {
       } else if ((splat_u16 & 0x00'FF) == 0) {
         e.movi(VReg(vreg_idx).h8, static_cast<uint8_t>(splat_u16 >> 8), LSL, 8);
       } else {
-        e.movz(e.w0, splat_u16);
-        e.dup(VReg(vreg_idx).h8, e.w0);
+        e.movz(WReg(gpr_scratch_idx), splat_u16);
+        e.dup(VReg(vreg_idx).h8, WReg(gpr_scratch_idx));
       }
       return;
     }
@@ -108,8 +110,8 @@ inline void LoadV128Const(A64Emitter& e, int vreg_idx, const vec128_t& val) {
         e.movi(VReg(vreg_idx).s4, static_cast<uint8_t>(splat_u32 >> 24), LSL,
                24);
       } else {
-        e.mov(e.w0, splat_u32);
-        e.dup(VReg(vreg_idx).s4, e.w0);
+        e.mov(WReg(gpr_scratch_idx), splat_u32);
+        e.dup(VReg(vreg_idx).s4, WReg(gpr_scratch_idx));
       }
       return;
     }
@@ -117,20 +119,16 @@ inline void LoadV128Const(A64Emitter& e, int vreg_idx, const vec128_t& val) {
     const bool all_equal_u64 = val.low == val.high;
     const uint64_t splat_u64 = val.u64[0];
     if (all_equal_u64) {
-      e.mov(e.x0, splat_u64);
-      e.dup(VReg(vreg_idx).d2, e.x0);
+      e.mov(XReg(gpr_scratch_idx), splat_u64);
+      e.dup(VReg(vreg_idx).d2, XReg(gpr_scratch_idx));
       return;
     }
   }
 
-  e.mov(e.x0, val.low);
-  e.mov(e.x1, val.high);
-  e.stp(e.x0, e.x1,
-        Xbyak_aarch64::ptr(e.sp,
-                           static_cast<int32_t>(StackLayout::GUEST_SCRATCH)));
-  e.ldr(QReg(vreg_idx),
-        Xbyak_aarch64::ptr(e.sp,
-                           static_cast<int32_t>(StackLayout::GUEST_SCRATCH)));
+  e.mov(XReg(gpr_scratch_idx), val.low);
+  e.fmov(DReg(vreg_idx), XReg(gpr_scratch_idx));
+  e.mov(XReg(gpr_scratch_idx), val.high);
+  e.ins(VReg(vreg_idx).d2[1], XReg(gpr_scratch_idx));
 }
 
 // Resolve a V128 operand to a register index, loading constants into

--- a/src/xenia/cpu/backend/a64/a64_seq_util.h
+++ b/src/xenia/cpu/backend/a64/a64_seq_util.h
@@ -46,6 +46,83 @@ inline void EmitWithVmxFpcr(A64Emitter& e, Fn&& emit_op) {
 
 // Load a compile-time vec128_t constant into a NEON register.
 inline void LoadV128Const(A64Emitter& e, int vreg_idx, const vec128_t& val) {
+  if (!val.low && !val.high) {
+    // 0000...
+    e.movi(VReg2D(vreg_idx), 0);
+    return;
+  } else if (val.low == ~uint64_t(0) && val.high == ~uint64_t(0)) {
+    // 1111...
+    e.movi(VReg2D(vreg_idx), ~0ULL);
+    return;
+  } else {
+    bool all_equal_u8 = true;
+    const uint8_t splat_u8 = val.u8[0];
+    for (unsigned i = 1; i < 16; ++i) {
+      if (val.u8[i] != splat_u8) {
+        all_equal_u8 = false;
+        break;
+      }
+    }
+    if (all_equal_u8) {
+      e.movi(VReg(vreg_idx).b16, static_cast<uint8_t>(splat_u8));
+      return;
+    }
+
+    bool all_equal_u16 = true;
+    const uint16_t splat_u16 = val.u16[0];
+    for (unsigned i = 1; i < 8; ++i) {
+      if (val.u16[i] != splat_u16) {
+        all_equal_u16 = false;
+        break;
+      }
+    }
+    if (all_equal_u16) {
+      if ((splat_u16 & 0xFF'00) == 0) {
+        e.movi(VReg(vreg_idx).h8, static_cast<uint8_t>(splat_u16));
+      } else if ((splat_u16 & 0x00'FF) == 0) {
+        e.movi(VReg(vreg_idx).h8, static_cast<uint8_t>(splat_u16 >> 8), LSL, 8);
+      } else {
+        e.movz(e.w0, splat_u16);
+        e.dup(VReg(vreg_idx).h8, e.w0);
+      }
+      return;
+    }
+
+    bool all_equal_u32 = true;
+    const uint32_t splat_u32 = val.u32[0];
+    for (unsigned i = 1; i < 4; ++i) {
+      if (val.u32[i] != splat_u32) {
+        all_equal_u32 = false;
+        break;
+      }
+    }
+    if (all_equal_u32) {
+      if ((splat_u32 & 0xFF'FF'FF'00) == 0) {
+        e.movi(VReg(vreg_idx).s4, static_cast<uint8_t>(splat_u32));
+      } else if ((splat_u32 & 0xFF'FF'00'FF) == 0) {
+        e.movi(VReg(vreg_idx).s4, static_cast<uint8_t>(splat_u32 >> 8), LSL, 8);
+      } else if ((splat_u32 & 0xFF'00'FF'FF) == 0) {
+        e.movi(VReg(vreg_idx).s4, static_cast<uint8_t>(splat_u32 >> 16), LSL,
+               16);
+      } else if ((splat_u32 & 0x00'FF'FF'FF) == 0) {
+        e.movi(VReg(vreg_idx).s4, static_cast<uint8_t>(splat_u32 >> 24), LSL,
+               24);
+      } else {
+        e.mov(e.w0, splat_u32);
+        e.dup(VReg(vreg_idx).s4, e.w0);
+      }
+      return;
+    }
+
+    const bool all_equal_u64 = val.low == val.high;
+    const uint64_t splat_u64 = val.u64[0];
+    if (all_equal_u64) {
+      e.mov(e.x0, splat_u64);
+      e.dup(VReg(vreg_idx).d2, e.x0);
+      return;
+    }
+  }
+
   e.mov(e.x0, val.low);
   e.mov(e.x1, val.high);
   e.stp(e.x0, e.x1,

--- a/src/xenia/cpu/backend/a64/a64_seq_vector.cc
+++ b/src/xenia/cpu/backend/a64/a64_seq_vector.cc
@@ -31,8 +31,7 @@ volatile int anchor_vector = 0;
 struct SPLAT_I8 : Sequence<SPLAT_I8, I<OPCODE_SPLAT, V128Op, I8Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
     if (i.src1.is_constant) {
-      e.movi(VReg(i.dest.reg().getIdx()).b16,
-             static_cast<uint8_t>(i.src1.constant()));
+      LoadV128Const(e, i.dest.reg().getIdx(), vec128b(i.src1.constant()));
     } else {
       e.dup(VReg(i.dest.reg().getIdx()).b16, i.src1);
     }
@@ -41,8 +40,7 @@ struct SPLAT_I8 : Sequence<SPLAT_I8, I<OPCODE_SPLAT, V128Op, I8Op>> {
 struct SPLAT_I16 : Sequence<SPLAT_I16, I<OPCODE_SPLAT, V128Op, I16Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
     if (i.src1.is_constant) {
-      e.mov(e.w0, static_cast<uint64_t>(i.src1.constant() & 0xFFFF));
-      e.dup(VReg(i.dest.reg().getIdx()).h8, e.w0);
+      LoadV128Const(e, i.dest.reg().getIdx(), vec128s(i.src1.constant()));
     } else {
       e.dup(VReg(i.dest.reg().getIdx()).h8, i.src1);
     }
@@ -51,10 +49,7 @@ struct SPLAT_I16 : Sequence<SPLAT_I16, I<OPCODE_SPLAT, V128Op, I16Op>> {
 struct SPLAT_I32 : Sequence<SPLAT_I32, I<OPCODE_SPLAT, V128Op, I32Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
     if (i.src1.is_constant) {
-      uint32_t val = static_cast<uint32_t>(i.src1.constant());
-      // Use movz/movn via mov(xreg, uint64) for full 32-bit range.
-      e.mov(e.x0, static_cast<uint64_t>(val));
-      e.dup(VReg(i.dest.reg().getIdx()).s4, e.w0);
+      LoadV128Const(e, i.dest.reg().getIdx(), vec128i(i.src1.constant()));
     } else {
       e.dup(VReg(i.dest.reg().getIdx()).s4, i.src1);
     }
@@ -63,13 +58,8 @@ struct SPLAT_I32 : Sequence<SPLAT_I32, I<OPCODE_SPLAT, V128Op, I32Op>> {
 struct SPLAT_F32 : Sequence<SPLAT_F32, I<OPCODE_SPLAT, V128Op, F32Op>> {
   static void Emit(A64Emitter& e, const EmitArgType& i) {
     if (i.src1.is_constant) {
-      union {
-        float f;
-        uint32_t u;
-      } c;
-      c.f = i.src1.constant();
-      e.mov(e.w0, static_cast<uint64_t>(c.u));
-      e.dup(VReg(i.dest.reg().getIdx()).s4, e.w0);
+      LoadV128Const(e, i.dest.reg().getIdx(),
+                    vec128i(std::bit_cast<uint32_t, float>(i.src1.constant())));
     } else {
       int src_idx = i.src1.reg().getIdx();
       e.dup(VReg(i.dest.reg().getIdx()).s4, VReg(src_idx).s4[0]);


### PR DESCRIPTION
Try to detect opportunities to use the `movi` instruction for generating 128-bit constants. Also avoids writing/reading scratch memory by using `fmov` + `ins` to move 64-bit GPR values to NEON registers directly.