### PR TITLE
[a64] Fix debug break trap codes

### DIFF
--- a/src/xenia/cpu/backend/a64/a64_backend.cc
+++ b/src/xenia/cpu/backend/a64/a64_backend.cc
@@ -335,9 +335,9 @@ ResolveFunctionThunk A64HelperEmitter::EmitResolveFunctionThunk() {
   ldp(x29, x30, ptr(sp, 0x50));
   add(sp, sp, static_cast<uint32_t>(thunk_stack));
 
-  cbz(x9, 8);  // skip br x9 if null, fall through to brk
-  br(x9);      // Jump to the resolved function (tail call — preserves LR).
-  brk(0xF0);   // Resolution failed — trap for debugging.
+  cbz(x9, 8);   // skip br x9 if null, fall through to brk
+  br(x9);       // Jump to the resolved function (tail call — preserves LR).
+  brk(0xF000);  // Resolution failed — trap for debugging.
 
   code_offsets.tail = getSize();
 
@@ -446,7 +446,7 @@ void* A64HelperEmitter::EmitGuestAndHostSynchronizeStackHelper() {
 
   L(underflow);
   // Should be impossible — stackpoint array underflowed.
-  brk(0xF1);
+  brk(0xF001);  // assertion failure
 
   code_offsets.epilog = getSize();
   code_offsets.tail = getSize();

--- a/src/xenia/cpu/backend/a64/a64_emitter.cc
+++ b/src/xenia/cpu/backend/a64/a64_emitter.cc
@@ -318,7 +318,7 @@ void A64Emitter::MarkSourceOffset(const hir::Instr* i) {
   entry->code_offset = static_cast<uint32_t>(getSize());
 }
 
-void A64Emitter::DebugBreak() { brk(0); }
+void A64Emitter::DebugBreak() { brk(0xF000); }
 
 void A64Emitter::Trap(uint16_t trap_type) { brk(trap_type); }
 


### PR DESCRIPTION
The `BRK` instruction code needs to be specified correctly so that a debugger can handle it properly(and continue from it). `brk 0xF000` implements a debug-breakpoint that can be continued from, and `brk 0xF001` is implemented as an assertion failing. Any other codes like `0` and `0xF1` will not be able to be continued from or handled correctly by debuggers.

These seem to be standard brk codes:
```
Breakpoint    0xF000
Assert        0xF001
Debug Service 0xF002
Fastfail      0xF003
Divide by 0   0xF004
```