### PR TITLE
[a64] Miscellaneous constant optimizations

### DIFF
--- a/src/xenia/cpu/backend/a64/a64_seq_util.h
+++ b/src/xenia/cpu/backend/a64/a64_seq_util.h
@@ -133,11 +133,9 @@ inline void FlushDenormals_V128(A64Emitter& e, int vreg, int sa = 2,
   // denorms→[0x00000001,0x00FFFFFD]. Denormal iff ((val<<1) - 1) < 0x00FFFFFF
   // (unsigned).
   e.shl(VReg(sa).s4, VReg(vreg).s4, 1);
-  e.mov(e.w0, static_cast<uint64_t>(1u));
-  e.dup(VReg(sb).s4, e.w0);
+  e.movi(VReg(sb).s4, 1u);
   e.sub(VReg(sa).s4, VReg(sa).s4, VReg(sb).s4);
-  e.mov(e.w0, static_cast<uint64_t>(0x00FFFFFFu));
-  e.dup(VReg(sb).s4, e.w0);
+  e.mvni(VReg(sb).s4, 0xFFu, LSL, 24);  // 0x00FFFFFF
   e.cmhi(VReg(sb).s4, VReg(sb).s4,
          VReg(sa).s4);  // mask: all-1s for denormal lanes
   // Clear only bits 30:0 (preserve sign bit 31) so -denormal → -0, +denormal →

--- a/src/xenia/cpu/backend/a64/a64_seq_vector.cc
+++ b/src/xenia/cpu/backend/a64/a64_seq_vector.cc
@@ -1444,8 +1444,7 @@ struct PACK : Sequence<PACK, I<OPCODE_PACK, V128Op, V128Op, V128Op>> {
     int d = i.dest.reg().getIdx();
     // Clamp to [3.0f, 3.0f + 255*2^-22].
     // fmaxnm/fminnm: NaN operand returns the non-NaN value (pack NaN as zero).
-    e.mov(e.w0, 0x40400000u);  // 3.0f
-    e.dup(VReg(0).s4, e.w0);
+    e.fmov(VReg(0).s4, 3.0f);
     e.fmaxnm(VReg(d).s4, VReg(s).s4, VReg(0).s4);
     e.mov(e.w0, 0x404000FFu);  // 3.0f + 255*2^-22
     e.dup(VReg(0).s4, e.w0);
@@ -1676,8 +1675,7 @@ struct UNPACK : Sequence<UNPACK, I<OPCODE_UNPACK, V128Op, V128Op>> {
     int d = i.dest.reg().getIdx();
     if (i.src1.is_constant && i.src1.value->IsConstantZero()) {
       // Zero -> 1.0f in all lanes.
-      e.mov(e.w0, 0x3F800000u);
-      e.dup(VReg(d).s4, e.w0);
+      e.fmov(VReg(d).s4, 1.0f);
       return;
     }
     // TBL: extract bytes from packed D3DCOLOR -> one byte per lane.
@@ -1690,8 +1688,7 @@ struct UNPACK : Sequence<UNPACK, I<OPCODE_UNPACK, V128Op, V128Op>> {
     LoadV128Const(e, 1, ctrl);
     e.tbl(VReg(d).b16, VReg(s).b16, 1, VReg(1).b16);
     // OR with 1.0f (0x3F800000) to form the magic float.
-    e.mov(e.w0, 0x3F800000u);
-    e.dup(VReg(0).s4, e.w0);
+    e.fmov(VReg(0).s4, 1.0f);
     e.orr(VReg(d).b16, VReg(d).b16, VReg(0).b16);
   }
   static void EmitCallHelper(A64Emitter& e, const EmitArgType& i, void* fn) {

--- a/src/xenia/cpu/backend/a64/a64_sequences.cc
+++ b/src/xenia/cpu/backend/a64/a64_sequences.cc
@@ -4717,8 +4717,7 @@ struct RECIP_F32 : Sequence<RECIP_F32, I<OPCODE_RECIP, F32Op, F32Op>> {
       e.mov(e.w0, static_cast<uint64_t>(c.u));
       e.fmov(e.s0, e.w0);
     }
-    e.mov(e.w0, static_cast<uint64_t>(0x3F800000u));
-    e.fmov(e.s2, e.w0);
+    e.fmov(e.s2, 1.0f);
     e.fdiv(i.dest, e.s2, src);
   }
 };
@@ -4734,8 +4733,7 @@ struct RECIP_F64 : Sequence<RECIP_F64, I<OPCODE_RECIP, F64Op, F64Op>> {
       e.mov(e.x0, c.u);
       e.fmov(e.d0, e.x0);
     }
-    e.mov(e.x0, static_cast<uint64_t>(0x3FF0000000000000ull));
-    e.fmov(e.d2, e.x0);
+    e.fmov(e.d2, 1.0);
     e.fdiv(i.dest, e.d2, src);
   }
 };
@@ -4751,8 +4749,7 @@ struct RECIP_V128 : Sequence<RECIP_V128, I<OPCODE_RECIP, V128Op, V128Op>> {
       FlushDenormals_V128(e, 1);  // scratch v2, v3
       auto d = VReg(i.dest.reg().getIdx()).s4;
       // Load 1.0f vector.
-      e.mov(e.w0, static_cast<uint64_t>(0x3F800000u));
-      e.dup(VReg(0).s4, e.w0);
+      e.fmov(VReg(0).s4, 1.0f);
       e.fdiv(d, VReg(0).s4, VReg(1).s4);
       // Flush output denormals.
       FlushDenormals_V128(e, i.dest.reg().getIdx(), 0, 1);


### PR DESCRIPTION
Found some other spots where `mov`+`dup` idioms could be collapsed into a singular `fmov` or `mvni` instructions.