### PR TITLE
Add Windows ARM 64 GitHub Build Action

### DIFF
--- a/.github/workflows/Create_release.yml
+++ b/.github/workflows/Create_release.yml
@@ -87,6 +87,13 @@ jobs:
           name: xenia_canary_windows
           path: artifacts/windows/xenia_canary
 
+      - name: Download Windows ARM64 artifacts
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: xenia_canary_windows_arm64
+          path: artifacts/windows_arm64/xenia_canary
+
       - name: Download Linux artifacts
         uses: actions/download-artifact@v8
         with:
@@ -116,6 +123,13 @@ jobs:
           if [ -d "artifacts/windows/xenia_canary" ]; then
             cd artifacts/windows/xenia_canary
             zip -r ../../../release_assets/xenia_canary_windows.zip . -x "*.pdb"
+            cd ../../..
+          fi
+
+          # Windows ARM64
+          if [ -d "artifacts/windows_arm64/xenia_canary" ]; then
+            cd artifacts/windows_arm64/xenia_canary
+            zip -r ../../../release_assets/xenia_canary_windows_arm64.zip . -x "*.pdb"
             cd ../../..
           fi
 

--- a/.github/workflows/Orchestrator.yml
+++ b/.github/workflows/Orchestrator.yml
@@ -40,17 +40,17 @@ jobs:
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/Windows_x86.yml
 
-  build-linux:
-    name: Linux (x86-64)
-    needs: [lint, commit-message]
-    if: ${{ !failure() && !cancelled() }}
-    uses: ./.github/workflows/Linux_x86.yml
-
   build-windows-arm64:
     name: Windows (ARM64)
     needs: [lint, commit-message]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/Windows_arm64.yml
+
+  build-linux:
+    name: Linux (x86-64)
+    needs: [lint, commit-message]
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/Linux_x86.yml
 
   # Uncomment when platform support is ready:
   # build-linux-arm64:

--- a/.github/workflows/Orchestrator.yml
+++ b/.github/workflows/Orchestrator.yml
@@ -46,12 +46,13 @@ jobs:
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/Linux_x86.yml
 
-  # Uncomment when platform support is ready:
-  # build-windows-arm64:
-  #   name: Windows-ARM64
-  #   needs: [lint]
-  #   uses: ./.github/workflows/build-win_arm64.yml
+  build-windows-arm64:
+    name: Windows (ARM64)
+    needs: [lint, commit-message]
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/Windows_arm64.yml
 
+  # Uncomment when platform support is ready:
   # build-linux-arm64:
   #   name: Linux-ARM64
   #   needs: [lint]
@@ -72,7 +73,7 @@ jobs:
   # ===========================================================================
   release:
     name: Create Release
-    needs: [build-windows, build-linux]
+    needs: [build-windows, build-windows-arm64, build-linux]
     if: |
       always() &&
       github.repository == 'xenia-canary/xenia-canary' &&

--- a/.github/workflows/Windows_arm64.yml
+++ b/.github/workflows/Windows_arm64.yml
@@ -1,0 +1,92 @@
+name: Windows (ARM64)
+
+on:
+  workflow_call:
+    inputs:
+      config:
+        description: 'Build configuration (Release)'
+        required: false
+        default: 'release'
+        type: string
+
+jobs:
+  build:
+    runs-on: windows-11-arm
+
+    env:
+      POWERSHELL_TELEMETRY_OPTOUT: 1
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Cache Vulkan SDK
+        id: cache-vulkan-sdk
+        uses: actions/cache@v5
+        with:
+          path: C:\VulkanSDK
+          key: ${{ runner.os }}-${{ runner.arch }}-vulkan-sdk-${{ hashFiles('**/vulkan-sdk.exe') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-vulkan-sdk-
+
+      - name: Install Vulkan SDK
+        run: |
+          # Install Vulkan SDK with spirv-tools
+          if (Test-Path -Path "C:\VulkanSDK") {
+            echo "Vulkan SDK found in cache."
+          } else {
+            Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe" -OutFile "vulkan-sdk.exe"
+            Start-Process -FilePath "vulkan-sdk.exe" -ArgumentList "--accept-licenses", "--default-answer", "--confirm-command", "install" -Wait
+          }
+          $env:VULKAN_SDK = "C:\VulkanSDK\$(Get-ChildItem -Path 'C:\VulkanSDK' -Directory | Select-Object -First 1 -ExpandProperty Name)"
+          $env:PATH = "$env:VULKAN_SDK\Bin;$env:PATH"
+          echo "VULKAN_SDK=$env:VULKAN_SDK" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "$env:VULKAN_SDK\Bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+          # Verify shader tools are available
+          foreach ($tool in @("glslangValidator", "spirv-opt", "spirv-dis")) {
+            $toolPath = "$env:VULKAN_SDK\Bin\$tool.exe"
+            if (Test-Path $toolPath) {
+              echo "$tool found at: $toolPath"
+              & $toolPath --version 2>$null
+            } else {
+              echo "Warning: $tool.exe not found at expected location"
+            }
+          }
+
+          # Verify FXC is available (from Windows SDK)
+          $fxcPaths = Get-ChildItem -Path "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\arm64\fxc.exe" -ErrorAction SilentlyContinue | Sort-Object FullName
+          if ($fxcPaths) {
+            $fxcPath = $fxcPaths[-1].FullName
+            echo "FXC found at: $fxcPath"
+          } else {
+            echo "Warning: fxc.exe not found in Windows SDK"
+          }
+
+      - name: Download submodules
+        run: git submodule update --init --depth=1 -j $env:NUMBER_OF_PROCESSORS
+
+      - name: Build Xenia
+        run: python xenia-build.py build --config=Release --target=xenia-app
+
+      - name: Prepare artifacts
+        id: prepare_artifacts
+        run: |
+          if ((Get-Item 'build\bin\Windows\Release\xenia_canary.exe').Length -le 100000) {
+            echo "::error:: Executable is too small."
+            exit 1
+          }
+          robocopy . build\bin\Windows\Release                                             LICENSE /r:0 /w:0
+          robocopy   build\bin\Windows\Release artifacts\xenia_canary   xenia_canary.exe   LICENSE /r:0 /w:0
+          If ($LastExitCode -le 7) { echo "LastExitCode = $LastExitCode";$LastExitCode = 0 }
+
+      - name: Upload Xenia Canary artifact
+        if: steps.prepare_artifacts.outcome == 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          name: xenia_canary_windows_arm64
+          path: artifacts\xenia_canary
+          if-no-files-found: error
+          retention-days: 7


### PR DESCRIPTION
With recent merges adding experimental Windows ARM 64 support I've added a Windows ARM build into the build orchestrator.

Tested the Windows ARM 64 .exe built from this action on my fork using a Snapdragon X Elite device (Lenovo Yoga Slim 7x). Had a black screen/no video issues solved by changing the following values in xenia-canary.config.toml:

d3d12_adapter = 1
vulkan_device = 1

DirectX 12 is unusably slow but stable.
Vulkan is speedy but very unstable.

These video renderer issues seems identical no matter if I ran the x64 (through Prism emulator) or ARM64 version on my Snapdragon X device.