### PR TITLE
Maybe fix Ninja Gaiden 2 audio

### DIFF
--- a/src/xenia/apu/xma_context_new.cc
+++ b/src/xenia/apu/xma_context_new.cc
@@ -143,16 +143,21 @@ bool XmaContextNew::Work() {
   }
 
   // Minimum free blocks needed before attempting a decode.
-  // Use the number of subframes Consume() will actually write per iteration
-  // (= subframe_decode_count, clamped to 1) plus any headroom requested by
-  // output_buffer_padding.  Using a full-frame worth of space (the old
-  // formula) was far too restrictive: games like TGM Ace use
-  // subframe_decode_count=2 on a small ring buffer and never had 8 free
-  // blocks available, causing the decoder to permanently stall.
+  // Use only the number of subframes Consume() will actually write per
+  // iteration (= subframe_decode_count, clamped to 1).
+  //
+  // The bits we currently expose as output_buffer_padding in
+  // XMA_CONTEXT_DATA are still a guess. Treating that guessed field as a hard
+  // admission requirement stalls contexts that still have enough room to make
+  // forward progress (for example, 4 writable subframes with a guessed padding
+  // value of 3 would incorrectly require 7 free blocks before any decode).
+  //
+  // Keep any padding reservation best-effort in Consume(), but don't block the
+  // decoder from producing audio solely because of it.
   const uint32_t effective_sdc =
       std::max(static_cast<uint32_t>(1), data.subframe_decode_count);
   const int32_t minimum_subframe_decode_count =
-      static_cast<int32_t>(effective_sdc) + data.output_buffer_padding;
+      static_cast<int32_t>(effective_sdc);
 
   // We don't have enough space to even make one pass
   // Waiting for decoder to return more space.
@@ -337,12 +342,18 @@ void XmaContextNew::Consume(RingBuffer* XE_RESTRICT output_rb,
       raw_frame_.data() + (kOutputBytesPerBlock * raw_frame_read_offset),
       subframes_to_write * kOutputBytesPerBlock);
 
-  // Reserve extra blocks as headroom when unk_skip_decode is set.
-  // Only apply when the frame is fully consumed to avoid double-counting.
-  const int8_t headroom =
-      (current_frame_remaining_subframes_ - subframes_to_write == 0)
-          ? data->output_buffer_padding
-          : 0;
+  // Reserve extra blocks as headroom on a best-effort basis when the frame is
+  // fully consumed. This field is still only a guess, so don't let it drive
+  // the accounting negative or block otherwise valid writes.
+  int8_t headroom = 0;
+  if (current_frame_remaining_subframes_ - subframes_to_write == 0) {
+    const int32_t remaining_after_write =
+        remaining_subframe_blocks_in_output_buffer_ - subframes_to_write;
+    if (remaining_after_write > 0) {
+      headroom = static_cast<int8_t>(std::min<int32_t>(
+          data->output_buffer_padding, remaining_after_write));
+    }
+  }
 
   remaining_subframe_blocks_in_output_buffer_ -= subframes_to_write + headroom;
   current_frame_remaining_subframes_ -= subframes_to_write;

--- a/src/xenia/apu/xma_context_new.cc
+++ b/src/xenia/apu/xma_context_new.cc
@@ -33,6 +33,16 @@ extern "C" {
 namespace xe {
 namespace apu {
 
+namespace {
+
+bool ShouldLogStallSummary(uint32_t consecutive_count) {
+  return consecutive_count == 1 || consecutive_count == 8 ||
+         consecutive_count == 64 ||
+         (consecutive_count >= 256 && consecutive_count % 256 == 0);
+}
+
+}  // namespace
+
 XmaContextNew::XmaContextNew() = default;
 
 XmaContextNew::~XmaContextNew() {
@@ -110,6 +120,63 @@ RingBuffer XmaContextNew::PrepareOutputRingBuffer(XMA_CONTEXT_DATA* data) {
   return output_rb;
 }
 
+void XmaContextNew::NoteNoSpaceStall(const XMA_CONTEXT_DATA& data,
+                                     int32_t minimum_subframe_decode_count) {
+  consecutive_no_space_stalls_++;
+  total_no_space_stalls_++;
+  if (!ShouldLogStallSummary(consecutive_no_space_stalls_)) {
+    return;
+  }
+  XELOGW(
+      "XmaContext {}: output-space stall x{} (total {}): need {} blocks, "
+      "have {}, read {} write {}, sdc {}, padding {}, last progress input {} "
+      "output {}/{}",
+      id(), consecutive_no_space_stalls_, total_no_space_stalls_,
+      minimum_subframe_decode_count,
+      remaining_subframe_blocks_in_output_buffer_,
+      data.output_buffer_read_offset, data.output_buffer_write_offset,
+      data.subframe_decode_count, data.output_buffer_padding,
+      last_progress_input_offset_, last_progress_output_read_offset_,
+      last_progress_output_write_offset_);
+}
+
+void XmaContextNew::NoteNoProgressStall(const XMA_CONTEXT_DATA& data) {
+  consecutive_no_progress_stalls_++;
+  total_no_progress_stalls_++;
+  if (!ShouldLogStallSummary(consecutive_no_progress_stalls_)) {
+    return;
+  }
+  XELOGW(
+      "XmaContext {}: no-progress stall x{} (total {}): input {}, current "
+      "buffer {}, output {}/{}, last progress input {} output {}/{}",
+      id(), consecutive_no_progress_stalls_, total_no_progress_stalls_,
+      data.input_buffer_read_offset, data.current_buffer,
+      data.output_buffer_read_offset, data.output_buffer_write_offset,
+      last_progress_input_offset_, last_progress_output_read_offset_,
+      last_progress_output_write_offset_);
+}
+
+void XmaContextNew::NoteProgress(const XMA_CONTEXT_DATA& data,
+                                 const RingBuffer& output_rb,
+                                 uint32_t previous_input_offset) {
+  if (consecutive_no_space_stalls_ || consecutive_no_progress_stalls_) {
+    XELOGW(
+        "XmaContext {}: recovered after stalls (no-space {}, no-progress {}), "
+        "input {} -> {}, output {}/{}",
+        id(), consecutive_no_space_stalls_, consecutive_no_progress_stalls_,
+        previous_input_offset, data.input_buffer_read_offset,
+        data.output_buffer_read_offset,
+        output_rb.write_offset() / kOutputBytesPerBlock);
+  }
+  consecutive_no_space_stalls_ = 0;
+  consecutive_no_progress_stalls_ = 0;
+  total_progress_events_++;
+  last_progress_input_offset_ = data.input_buffer_read_offset;
+  last_progress_output_read_offset_ = data.output_buffer_read_offset;
+  last_progress_output_write_offset_ =
+      output_rb.write_offset() / kOutputBytesPerBlock;
+}
+
 bool XmaContextNew::Work() {
   if (!is_enabled() || !is_allocated()) {
     return false;
@@ -166,6 +233,7 @@ bool XmaContextNew::Work() {
     XELOGD("XmaContext {}: No space for subframe decoding {}/{}!", id(),
            minimum_subframe_decode_count,
            remaining_subframe_blocks_in_output_buffer_);
+    NoteNoSpaceStall(data, minimum_subframe_decode_count);
     StoreContextMerged(data, initial_data, context_ptr);
     return true;
   }
@@ -183,9 +251,18 @@ bool XmaContextNew::Work() {
 
     const uint32_t pre_decode_offset = data.input_buffer_read_offset;
     const uint8_t pre_remaining_subframes = current_frame_remaining_subframes_;
+    const uint32_t pre_output_write_offset = output_rb.write_offset();
 
     Decode(&data);
     Consume(&output_rb, &data);
+
+    const bool made_progress =
+        data.input_buffer_read_offset != pre_decode_offset ||
+        current_frame_remaining_subframes_ != pre_remaining_subframes ||
+        output_rb.write_offset() != pre_output_write_offset;
+    if (made_progress) {
+      NoteProgress(data, output_rb, pre_decode_offset);
+    }
 
     if (!data.IsAnyInputBufferValid() || data.error_status == 4) {
       XELOGAPU(
@@ -202,6 +279,7 @@ bool XmaContextNew::Work() {
     if (pre_remaining_subframes == 0 &&
         data.input_buffer_read_offset == pre_decode_offset &&
         current_frame_remaining_subframes_ == 0) {
+      NoteNoProgressStall(data);
       XELOGAPU(
           "XmaContext {}: Decode stalled at offset {} (no progress), "
           "waiting for next buffer",
@@ -254,6 +332,14 @@ void XmaContextNew::ClearLocked(XMA_CONTEXT_DATA* data) {
   current_frame_remaining_subframes_ = 0;
   loop_frame_output_limit_ = 0;
   loop_start_skip_pending_ = false;
+  consecutive_no_space_stalls_ = 0;
+  consecutive_no_progress_stalls_ = 0;
+  total_no_space_stalls_ = 0;
+  total_no_progress_stalls_ = 0;
+  total_progress_events_ = 0;
+  last_progress_input_offset_ = kBitsPerPacketHeader;
+  last_progress_output_read_offset_ = 0;
+  last_progress_output_write_offset_ = 0;
 }
 
 void XmaContextNew::Disable() { set_is_enabled(false); }
@@ -266,6 +352,14 @@ void XmaContextNew::Release() {
   set_is_allocated(false);
   auto context_ptr = memory()->TranslateVirtual(guest_ptr());
   std::memset(context_ptr, 0, sizeof(XMA_CONTEXT_DATA));  // Zero it.
+  consecutive_no_space_stalls_ = 0;
+  consecutive_no_progress_stalls_ = 0;
+  total_no_space_stalls_ = 0;
+  total_no_progress_stalls_ = 0;
+  total_progress_events_ = 0;
+  last_progress_input_offset_ = kBitsPerPacketHeader;
+  last_progress_output_read_offset_ = 0;
+  last_progress_output_write_offset_ = 0;
 }
 
 int XmaContextNew::GetSampleRate(int id) {

--- a/src/xenia/apu/xma_context_new.h
+++ b/src/xenia/apu/xma_context_new.h
@@ -60,6 +60,12 @@ class XmaContextNew : public XmaContext {
   void Release();
 
  private:
+  void NoteNoSpaceStall(const XMA_CONTEXT_DATA& data,
+                        int32_t minimum_subframe_decode_count);
+  void NoteNoProgressStall(const XMA_CONTEXT_DATA& data);
+  void NoteProgress(const XMA_CONTEXT_DATA& data, const RingBuffer& output_rb,
+                    uint32_t previous_input_offset);
+
   void ClearLocked(XMA_CONTEXT_DATA* data);
   static void SwapInputBuffer(XMA_CONTEXT_DATA* data);
   // Convert sampling rate from ID to frequency.
@@ -119,6 +125,15 @@ class XmaContextNew : public XmaContext {
   // When true, the next decoded frame should skip leading subframes per
   // loop_subframe_skip (loop start adjustment).
   bool loop_start_skip_pending_ = false;
+
+  uint32_t consecutive_no_space_stalls_ = 0;
+  uint32_t consecutive_no_progress_stalls_ = 0;
+  uint32_t total_no_space_stalls_ = 0;
+  uint32_t total_no_progress_stalls_ = 0;
+  uint32_t total_progress_events_ = 0;
+  uint32_t last_progress_input_offset_ = kBitsPerPacketHeader;
+  uint8_t last_progress_output_read_offset_ = 0;
+  uint8_t last_progress_output_write_offset_ = 0;
 };
 
 }  // namespace apu


### PR DESCRIPTION
I tried fixing the audio in Ninja Gaiden 2 with the help of Codex. I reviewed and tested it. It seems reasonable and the audio still works. I don't know if it really fixes the bug. Only community testing can verify. Even if it doesn't fix the problem, the added logging should help fix the problem.

---

This PR improves XMA decode behavior in `XmaContextNew` and adds targeted diagnostics for long-running audio stalls.

The functional change stops treating `output_buffer_padding` as a hard precondition for decoding. That field is still only a guessed interpretation of the guest XMA context, and in practice it could block valid decode work even when there was enough room to write the requested subframes. In NG2 this showed up as repeated stalls such as `No space for subframe decoding 15/14!`, followed by audio eventually falling silent. The decoder now requires space only for the subframes it will actually write in the current pass, while keeping padding reservation as best-effort headroom when a frame is fully consumed.

The second change adds low-noise stall diagnostics to `XmaContextNew`. Instead of relying on huge trace logs and inferring failure from the last APU line, the decoder now emits warning-level summaries when a context repeatedly stalls on output space or makes no forward progress, and logs when it later recovers. This should make rare long-session audio failures much easier to diagnose without requiring a deterministic repro.
