### PR TITLE
[Emulator] Load title plugins before main thread execution begins

### DIFF
--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -1707,6 +1707,11 @@ X_STATUS Emulator::CompleteLaunch(const std::filesystem::path& path,
     }
   }
 
+  // Resume the main thread now.
+  // If the debugger has requested a suspend this will just decrement the
+  // suspend count without resuming it until the debugger wants.
+  main_thread_->Resume();
+
   return X_STATUS_SUCCESS;
 }
 

--- a/src/xenia/kernel/kernel_state.cc
+++ b/src/xenia/kernel/kernel_state.cc
@@ -426,11 +426,6 @@ object_ref<XThread> KernelState::LaunchModule(object_ref<UserModule> module) {
   // Waits for a debugger client, if desired.
   emulator()->processor()->PreLaunch();
 
-  // Resume the thread now.
-  // If the debugger has requested a suspend this will just decrement the
-  // suspend count without resuming it until the debugger wants.
-  thread->Resume();
-
   return thread;
 }
 


### PR DESCRIPTION
This keeps the title thread suspended until plugins are loaded, allowing early init and hook setup before guest code starts running.

I have tested a plugin using this and I can now reliably hook the game executables main export function! Previously it wasn't possible to do this.