### PR TITLE
[GPU] Improved fake ZPD for QueryBatch titles

### DIFF
--- a/src/xenia/gpu/gpu_flags.cc
+++ b/src/xenia/gpu/gpu_flags.cc
@@ -59,11 +59,11 @@ DEFINE_bool(
     "when MSAA is used with fullscreen passes.",
     "GPU");
 
-DEFINE_bool(query_occlusion_batched, false,
-            "Increment the sample count total by a fixed amount on every "
-            "EVENT_WRITE_ZPD. This provides an approximate batched occlusion "
-            "query implementation for many titles.",
-            "GPU");
+DEFINE_int32(query_occlusion_querybatch_range, 0,
+             "Range of fake ZPD sample count values to cycle for titles that "
+             "use D3D QueryBatch. 0 disables this behavior entirely. Any non-"
+             "zero values should only be used if required for specific titles.",
+             "GPU");
 DEFINE_int32(query_occlusion_sample_lower_threshold, 80,
              "If set to -1 no sample counts are written, games may hang. Else, "
              "the sample count of every tile will be incremented on every "

--- a/src/xenia/gpu/gpu_flags.h
+++ b/src/xenia/gpu/gpu_flags.h
@@ -26,7 +26,7 @@ DECLARE_bool(non_seamless_cube_map);
 
 DECLARE_bool(half_pixel_offset);
 
-DECLARE_bool(query_occlusion_batched);
+DECLARE_int32(query_occlusion_querybatch_range);
 
 DECLARE_int32(query_occlusion_sample_lower_threshold);
 

--- a/src/xenia/gpu/pm4_command_processor_implement.h
+++ b/src/xenia/gpu/pm4_command_processor_implement.h
@@ -988,11 +988,18 @@ bool COMMAND_PROCESSOR::ExecutePacketType3_EVENT_WRITE_ZPD(
   // every query. Each ISSUE snapshots the sample count into a new slot and
   // recovers the total by looking at differences between slots.
   // END detection isn't sufficient here.
-  if (cvars::query_occlusion_batched) {
+  if (cvars::query_occlusion_querybatch_range > 0) {
     // Mimic batched behavior by reporting a running count and writing it on
     // every event.
-    const uint32_t step = std::max(uint32_t(1), samples);
-    batched_samples = std::min(batched_samples, UINT32_MAX - step) + step;
+    const uint32_t base =
+        static_cast<uint32_t>(cvars::query_occlusion_sample_lower_threshold);
+    const uint32_t range =
+        static_cast<uint32_t>(cvars::query_occlusion_querybatch_range);
+    if (batched_samples < base || batched_samples - base + 1 >= range) {
+      batched_samples = base;
+    } else {
+      ++batched_samples;
+    }
     pSampleCounts->ZPass_A = batched_samples;
     pSampleCounts->Total_A = batched_samples;
   } else if (is_end_via_z_pass || is_end_via_z_fail) {


### PR DESCRIPTION
The current fake QueryBatch samples start at 0 and kept incrementing toward UINT32_MAX, which is sloppy and can interact badly with titles that expect stable behavior.

Instead, if cvar > 0, writeback starts at the lower threshold cvar and walks a small bounded range before wrapping, staying consistently visible without letting the fake count drift indefinitely.

Let me know if you would prefer a bool as well. I figure the less cvars, the better. But lmk.