### PR TITLE
[Compilation] Fix Clang 23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,7 @@ else()
   # C-specific warnings
   add_compile_options(
     $<$<COMPILE_LANGUAGE:C>:-Wno-implicit-function-declaration>
+    $<$<COMPILE_LANGUAGE:C>:-Wno-incompatible-pointer-types>
   )
 
   if(APPLE)

--- a/src/xenia/cpu/backend/assembler.h
+++ b/src/xenia/cpu/backend/assembler.h
@@ -10,6 +10,7 @@
 #ifndef XENIA_CPU_BACKEND_ASSEMBLER_H_
 #define XENIA_CPU_BACKEND_ASSEMBLER_H_
 
+#include <cstdint>
 #include <memory>
 
 namespace xe {


### PR DESCRIPTION
Fix some errors while compiling on Linux with Clang 23:

- Fix error while compiling FFMPEG
- Fix error because it is not finding `uint32_t`