### PR TITLE
[Vulkan] AC6 rendering fixes: depth, clip/cull, vbuf sync

### DIFF
--- a/src/xenia/gpu/spirv_shader_translator.cc
+++ b/src/xenia/gpu/spirv_shader_translator.cc
@@ -145,6 +145,8 @@ void SpirvShaderTranslator::Reset() {
   var_main_fsi_color_written_ = spv::NoResult;
   std::fill(output_fragment_data_.begin(), output_fragment_data_.end(),
             spv::NoResult);
+  output_or_var_fragment_depth_ = spv::NoResult;
+  output_fragment_depth_ = spv::NoResult;
 
   main_switch_op_.reset();
   main_switch_next_pc_phi_operands_.clear();
@@ -1324,13 +1326,17 @@ void SpirvShaderTranslator::StartVertexOrTessEvalShaderBeforeMain() {
   struct_per_vertex_members.reserve(kOutputPerVertexMemberCount);
   struct_per_vertex_members.push_back(type_float4_);
 
-  // Only allocate ClipDistance/CullDistance arrays when user clip planes are
-  // actually enabled (count > 0).
+  // Only declare the Clip/Cull arrays we actually write. An unwritten BuiltIn
+  // array still participates in clipping/culling with undefined values.
   uint32_t user_clip_plane_count =
       shader_modification.vertex.user_clip_plane_count;
+  bool user_clip_plane_cull = shader_modification.vertex.user_clip_plane_cull;
+  uint32_t clip_distance_count =
+      user_clip_plane_cull ? 0 : user_clip_plane_count;
+  uint32_t cull_distance_count =
+      user_clip_plane_cull ? user_clip_plane_count : 0;
   output_per_vertex_clip_distance_member_index_ = 0;
   output_per_vertex_cull_distance_member_index_ = 0;
-  constexpr uint32_t kMaxUserClipPlanes = 6;
   if (user_clip_plane_count > 0) {
     // Create separate uniform buffer for clip planes.
     spv::Id type_float4_array_6 = builder_->makeArrayType(
@@ -1356,16 +1362,18 @@ void SpirvShaderTranslator::StartVertexOrTessEvalShaderBeforeMain() {
     if (features_.spirv_version >= spv::Spv_1_4) {
       main_interface_.push_back(uniform_clip_plane_constants_);
     }
-
+  }
+  if (clip_distance_count > 0) {
     output_per_vertex_clip_distance_member_index_ =
         static_cast<unsigned int>(struct_per_vertex_members.size());
     struct_per_vertex_members.push_back(builder_->makeArrayType(
-        type_float_, builder_->makeUintConstant(user_clip_plane_count), 0));
-
+        type_float_, builder_->makeUintConstant(clip_distance_count), 0));
+  }
+  if (cull_distance_count > 0) {
     output_per_vertex_cull_distance_member_index_ =
         static_cast<unsigned int>(struct_per_vertex_members.size());
     struct_per_vertex_members.push_back(builder_->makeArrayType(
-        type_float_, builder_->makeUintConstant(user_clip_plane_count), 0));
+        type_float_, builder_->makeUintConstant(cull_distance_count), 0));
   }
 
   spv::Id type_struct_per_vertex =
@@ -1376,15 +1384,15 @@ void SpirvShaderTranslator::StartVertexOrTessEvalShaderBeforeMain() {
       type_struct_per_vertex, kOutputPerVertexMemberPosition,
       spv::DecorationBuiltIn, static_cast<int>(spv::BuiltIn::Position));
 
-  // Decorate clip/cull arrays only if allocated.
-  if (user_clip_plane_count > 0) {
+  if (clip_distance_count > 0) {
     builder_->addMemberName(type_struct_per_vertex,
                             output_per_vertex_clip_distance_member_index_,
                             "gl_ClipDistance");
     builder_->addMemberDecoration(
         type_struct_per_vertex, output_per_vertex_clip_distance_member_index_,
         spv::DecorationBuiltIn, static_cast<int>(spv::BuiltIn::ClipDistance));
-
+  }
+  if (cull_distance_count > 0) {
     builder_->addMemberName(type_struct_per_vertex,
                             output_per_vertex_cull_distance_member_index_,
                             "gl_CullDistance");
@@ -2276,6 +2284,19 @@ void SpirvShaderTranslator::StartFragmentShaderBeforeMain() {
     }
   }
 
+  // Fragment depth output (gl_FragDepth) for the FBO path.
+  // Created when the guest pixel shader writes oDepth.
+  // FSI manages its own depth and does not need an Output.
+  if (!edram_fragment_shader_interlock_ && !is_depth_only_fragment_shader_ &&
+      current_shader().writes_depth()) {
+    output_fragment_depth_ = builder_->createVariable(
+        spv::NoPrecision, spv::StorageClassOutput, type_float_, "gl_FragDepth");
+    builder_->addDecoration(output_fragment_depth_, spv::DecorationBuiltIn,
+                            static_cast<int>(spv::BuiltIn::FragDepth));
+    builder_->addDecoration(output_fragment_depth_, spv::DecorationInvariant);
+    main_interface_.push_back(output_fragment_depth_);
+  }
+
   // Sample mask output for alpha-to-coverage.
   // Only needed for non-FSI mode. FSI uses main_fsi_sample_mask_ instead.
   output_fragment_sample_mask_ = spv::NoResult;
@@ -2352,14 +2373,14 @@ void SpirvShaderTranslator::StartFragmentShaderInMain() {
         "xe_var_color_written", const_uint_0_);
   }
 
-  if (edram_fragment_shader_interlock_) {
-    // Initialize depth output variable with fragment shader interlock.
-    output_or_var_fragment_depth_ = spv::NoResult;
-    if (current_shader().writes_depth()) {
-      output_or_var_fragment_depth_ = builder_->createVariable(
-          spv::NoPrecision, spv::StorageClassFunction, type_float_,
-          "xe_var_fragment_depth", const_float_0_);
-    }
+  // Staging variable for guest oDepth writes.
+  // Created whenever the shader uses oDepth:
+  //   * FSI reads it during its EDRAM depth write inside the interlock.
+  //   * FBO copies it to gl_FragDepth at the end of the shader.
+  if (current_shader().writes_depth()) {
+    output_or_var_fragment_depth_ = builder_->createVariable(
+        spv::NoPrecision, spv::StorageClassFunction, type_float_,
+        "xe_var_fragment_depth", const_float_0_);
   }
 
   if (edram_fragment_shader_interlock_ && FSI_IsDepthStencilEarly()) {
@@ -2964,6 +2985,15 @@ void SpirvShaderTranslator::StoreResult(const InstructionResult& result,
                                            << result.storage_index)),
             var_main_memexport_data_written_);
       }
+    } break;
+    case InstructionStorageTarget::kDepth: {
+      assert_true(is_pixel_shader());
+      assert_true(current_shader().writes_depth());
+      // Function-scoped staging variable for guest oDepth writes. The FBO
+      // path copies it to the gl_FragDepth Output in
+      // CompleteFragmentShader_DSV_DepthTo24Bit; the FSI path writes it to
+      // EDRAM later inside the interlock critical section.
+      target_pointer = output_or_var_fragment_depth_;
     } break;
     default:
       // TODO(Triang3l): All storage targets.

--- a/src/xenia/gpu/spirv_shader_translator.h
+++ b/src/xenia/gpu/spirv_shader_translator.h
@@ -563,6 +563,11 @@ class SpirvShaderTranslator : public ShaderTranslator {
   void StartFragmentShaderInMain();
   void CompleteFragmentShaderInMain();
 
+  // Writes gl_FragDepth at the end of an FBO pixel shader, remapping the
+  // guest 0...1 oDepth value to host 0...0.5 when the bound depth buffer is
+  // float24. No-op for FSI and for shaders that don't write oDepth.
+  void CompleteFragmentShader_DSV_DepthTo24Bit();
+
   // Updates the current flow control condition (to be called in the beginning
   // of exec and in jumps), closing the previous conditionals if needed.
   // However, if the condition is not different, the instruction-level predicate
@@ -960,10 +965,15 @@ class SpirvShaderTranslator : public ShaderTranslator {
   // output_or_var_fragment_data_.
   std::array<spv::Id, xenos::kMaxColorRenderTargets> output_fragment_data_;
 
-  // Fragment shader depth output (gl_FragDepth).
-  // With fragment shader interlock, a variable in the main function.
-  // Otherwise, the depth output (only created if shader writes depth).
+  // Function-scoped staging variable for guest oDepth writes. Used by both
+  // FSI (which writes the value to the EDRAM buffer inside the interlock)
+  // and FBO (copied to output_fragment_depth_ at the end of the shader,
+  // remapping guest 0...1 to host 0...0.5 when the depth format is float24).
   spv::Id output_or_var_fragment_depth_;
+
+  // FBO only: actual gl_FragDepth Output.
+  // Written at the end of the pixel shader from output_or_var_fragment_depth_.
+  spv::Id output_fragment_depth_;
 
   // Fragment shader sample mask output (gl_SampleMask).
   // Only used for alpha-to-coverage in non-FSI mode.

--- a/src/xenia/gpu/spirv_shader_translator_fetch.cc
+++ b/src/xenia/gpu/spirv_shader_translator_fetch.cc
@@ -19,6 +19,8 @@
 #include "xenia/gpu/render_target_cache.h"
 #include "xenia/gpu/spirv_compatibility.h"
 
+DECLARE_bool(ac6_ground_fix);
+
 namespace xe {
 namespace gpu {
 
@@ -81,6 +83,12 @@ void SpirvShaderTranslator::ProcessVertexFetchInstruction(
       if (instr.attributes.is_index_rounded) {
         index = builder_->createNoContractionBinOp(
             spv::OpFAdd, type_float_, index, builder_->makeFloatConstant(0.5f));
+      } else if (cvars::ac6_ground_fix) {
+        // UGLY HACK for AC6 copied from the DXBC translator.
+        // Proper fix requires accurate RCP implementation.
+        index = builder_->createNoContractionBinOp(
+            spv::OpFAdd, type_float_, index,
+            builder_->makeFloatConstant(0.00025f));
       }
       index = builder_->createUnaryOp(
           spv::OpConvertFToS, type_int_,

--- a/src/xenia/gpu/spirv_shader_translator_rb.cc
+++ b/src/xenia/gpu/spirv_shader_translator_rb.cc
@@ -1483,6 +1483,10 @@ void SpirvShaderTranslator::CompleteFragmentShaderInMain() {
     }
   }
 
+  // Copies the staged depth to the FBO gl_FragDepth output.
+  // No-op for FSI and when no host depth output was declared.
+  CompleteFragmentShader_DSV_DepthTo24Bit();
+
   if (edram_fragment_shader_interlock_) {
     if (block_fsi_if_after_depth_stencil_merge) {
       builder_->createBranch(block_fsi_if_after_depth_stencil_merge);
@@ -1501,6 +1505,36 @@ void SpirvShaderTranslator::CompleteFragmentShaderInMain() {
 
     builder_->createNoResultOp(spv::OpEndInvocationInterlockEXT);
   }
+}
+
+void SpirvShaderTranslator::CompleteFragmentShader_DSV_DepthTo24Bit() {
+  // FSI manages its own depth via the EDRAM buffer - this hook is FBO-only.
+  // Likewise, if no Output FragDepth was declared, there is nothing to write.
+  if (edram_fragment_shader_interlock_ ||
+      output_fragment_depth_ == spv::NoResult) {
+    return;
+  }
+  if (!current_shader().writes_depth()) {
+    return;
+  }
+  // The shader writes depth explicitly, for float24, need to scale it from
+  // guest 0...1 to host 0...0.5 to support reinterpretation round trips as
+  // viewport scaling doesn't apply to oDepth.
+  spv::Id depth_value =
+      builder_->createLoad(output_or_var_fragment_depth_, spv::NoPrecision);
+  spv::Id depth_float24_flag = builder_->createBinOp(
+      spv::OpINotEqual, type_bool_,
+      builder_->createBinOp(spv::OpBitwiseAnd, type_uint_,
+                            main_system_constant_flags_,
+                            builder_->makeUintConstant(kSysFlag_DepthFloat24)),
+      const_uint_0_);
+  spv::Id depth_scaled = builder_->createBinOp(
+      spv::OpFMul, type_float_, depth_value, builder_->makeFloatConstant(0.5f));
+  spv::Id depth_remapped =
+      builder_->createTriOp(spv::OpSelect, type_float_, depth_float24_flag,
+                            depth_scaled, depth_value);
+  // Write the depth from the temporary to the system depth output.
+  builder_->createStore(depth_remapped, output_fragment_depth_);
 }
 
 spv::Id SpirvShaderTranslator::LoadMsaaSamplesFromFlags() {

--- a/src/xenia/gpu/vulkan/vulkan_command_processor.cc
+++ b/src/xenia/gpu/vulkan/vulkan_command_processor.cc
@@ -2667,15 +2667,8 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type,
           return false;
       }
 
-      // Check if address/size changed - if same as cached, just mark in sync
       uint32_t address = vfetch_constant.address;
       uint32_t size = vfetch_constant.size;
-      VertexBufferState& state = vertex_buffer_states_[vfetch_index];
-      if (state.address == address && state.size == size) {
-        // Same buffer, already resident - just mark in sync
-        vertex_buffers_in_sync_[vfetch_index >> 6] |= vfetch_bit;
-        continue;
-      }
 
       // New or changed buffer - need to request range
       if (!shared_memory_->RequestRange(address << 2, size << 2)) {
@@ -2688,8 +2681,6 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type,
       }
 
       // Update cache
-      state.address = address;
-      state.size = size;
       vertex_buffers_in_sync_[vfetch_index >> 6] |= vfetch_bit;
     }
   }

--- a/src/xenia/gpu/vulkan/vulkan_command_processor.h
+++ b/src/xenia/gpu/vulkan/vulkan_command_processor.h
@@ -743,16 +743,9 @@ class VulkanCommandProcessor final : public CommandProcessor {
   uint64_t current_float_constant_map_pixel_[4];
 
   // Vertex buffer residency caching - avoids redundant RequestRange calls.
-  // Bit is set when the vertex buffer at that index has been validated and
-  // is resident in shared memory with the current address/size.
-  uint64_t vertex_buffers_in_sync_[2] =
-      {};  // 96 bits for 96 vertex fetch constants
-  // Cached address and size for each vertex fetch constant to detect changes.
-  struct VertexBufferState {
-    uint32_t address = 0;
-    uint32_t size = 0;
-  };
-  std::array<VertexBufferState, 96> vertex_buffer_states_ = {};
+  // Bit is set when the vertex buffer at that index has been requested in
+  // the current frame. Cleared between frames and on fetch constant writes.
+  uint64_t vertex_buffers_in_sync_[2] = {};
 
   // System shader constants.
   SpirvShaderTranslator::SystemConstants system_constants_;


### PR DESCRIPTION
- Emit gl_FragDepth in the SPIR-V FBO path.
- Only declare the clip-distance or cull-distance array that is written; the unused one produced view-dependent garbage cuts.
- Port ac6_ground_fix vertex-fetch nudge to SPIR-V.
- Partially revert Vertex buffer residency caching - it was causing regressions in AC 6

Fixes missing missile trails;
Fixes missing Jet mesh in the hangar;
