### PR TITLE
[XAM] Fixed XEX swap failing to remove prefix

### DIFF
--- a/src/xenia/kernel/xam/xam_module.cc
+++ b/src/xenia/kernel/xam/xam_module.cc
@@ -111,7 +111,8 @@ void XamModule::SaveLoaderData() {
   std::string launch_path = loader_data_.launch_path;
 
   auto remove_prefix = [&launch_path](std::string_view prefix) {
-    if (launch_path.compare(0, prefix.length(), prefix) == 0) {
+    if (xe::utf8::lower_ascii(launch_path)
+            .starts_with(xe::utf8::lower_ascii(prefix))) {
       launch_path = launch_path.substr(prefix.length());
     }
   };


### PR DESCRIPTION
Fixed [Splinter Cell: Double Agent](https://github.com/xenia-canary/game-compatibility/issues/172) xex swapping from singleplayer to multiplayer.