### PR TITLE
[Kernel] XFile: Added check for FILE_NO_INTERMEDIATE_BUFFERING

### DIFF
--- a/src/xenia/kernel/xam/content_manager.cc
+++ b/src/xenia/kernel/xam/content_manager.cc
@@ -43,8 +43,8 @@ ContentPackage::ContentPackage(KernelState* kernel_state,
   content_data_ = data;
 
   auto fs = kernel_state_->file_system();
-  auto device =
-      std::make_unique<vfs::HostPathDevice>(device_path_, package_path, false);
+  auto device = std::make_unique<vfs::HostPathDevice>(
+      device_path_, package_path, false, true);
   device->Initialize();
   fs->RegisterDevice(std::move(device));
   fs->RegisterSymbolicLink(root_name_ + ":", device_path_);

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_io.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_io.cc
@@ -29,6 +29,7 @@ struct CreateOptions {
   static constexpr uint32_t FILE_DIRECTORY_FILE = 0x00000001;
   // Optimization - files access will be sequential, not random.
   static constexpr uint32_t FILE_SEQUENTIAL_ONLY = 0x00000004;
+  static constexpr uint32_t FILE_NO_INTERMEDIATE_BUFFERING = 0x00000008;
   static constexpr uint32_t FILE_SYNCHRONOUS_IO_ALERT = 0x00000010;
   static constexpr uint32_t FILE_SYNCHRONOUS_IO_NONALERT = 0x00000020;
   static constexpr uint32_t FILE_NON_DIRECTORY_FILE = 0x00000040;
@@ -94,7 +95,11 @@ dword_result_t NtCreateFile_entry(lpdword_t handle_out, dword_t desired_access,
     bool synchronous =
         (create_options & CreateOptions::FILE_SYNCHRONOUS_IO_ALERT) ||
         (create_options & CreateOptions::FILE_SYNCHRONOUS_IO_NONALERT);
-    file = object_ref<XFile>(new XFile(kernel_state(), vfs_file, synchronous));
+
+    bool allow_buffering =
+        !(create_options & CreateOptions::FILE_NO_INTERMEDIATE_BUFFERING);
+    file = object_ref<XFile>(
+        new XFile(kernel_state(), vfs_file, synchronous, allow_buffering));
 
     // Handle ref is incremented, so return that.
     handle = file->handle();
@@ -148,8 +153,10 @@ dword_result_t NtReadFile_entry(dword_t file_handle, dword_t event_handle,
           buffer.guest_address(), buffer_length,
           byte_offset_ptr ? static_cast<uint64_t>(*byte_offset_ptr) : -1,
           &bytes_read, apc_context);
+
       if (io_status_block) {
-        io_status_block->status = result;
+        io_status_block->status =
+            result == X_STATUS_PENDING ? X_STATUS_SUCCESS : result;
         io_status_block->information = bytes_read;
       }
 
@@ -157,15 +164,11 @@ dword_result_t NtReadFile_entry(dword_t file_handle, dword_t event_handle,
       // though were are completing immediately.
       // Low bit probably means do not queue to IO ports.
       if ((uint32_t)apc_routine_ptr & ~1) {
-        if (apc_context && result == X_STATUS_SUCCESS) {
+        if (apc_context && XSUCCEEDED(result)) {
           auto thread = XThread::GetCurrentThread();
           thread->EnqueueApc(static_cast<uint32_t>(apc_routine_ptr) & ~1u,
                              apc_context, io_status_block, 0);
         }
-      }
-
-      if (!file->is_synchronous() && result != X_STATUS_END_OF_FILE) {
-        result = X_STATUS_PENDING;
       }
 
       // Mark that we should signal the event now. We do this after
@@ -210,7 +213,6 @@ dword_result_t NtReadFile_entry(dword_t file_handle, dword_t event_handle,
   if (ev && signal_event) {
     ev->Set(0, false);
   }
-
   return result;
 }
 DECLARE_XBOXKRNL_EXPORT2(NtReadFile, kFileSystem, kImplemented, kHighFrequency);

--- a/src/xenia/kernel/xfile.cc
+++ b/src/xenia/kernel/xfile.cc
@@ -13,13 +13,17 @@
 #include "xenia/base/byte_stream.h"
 #include "xenia/kernel/kernel_state.h"
 
+#include "xenia/vfs/devices/host_path_device.h"
+
 namespace xe {
 namespace kernel {
 
-XFile::XFile(KernelState* kernel_state, vfs::File* file, bool synchronous)
+XFile::XFile(KernelState* kernel_state, vfs::File* file, bool synchronous,
+             bool allow_buffering)
     : XObject(kernel_state, kObjectType),
       file_(file),
-      is_synchronous_(synchronous) {
+      is_synchronous_(synchronous),
+      allow_buffering_(allow_buffering) {
   async_event_ = threading::Event::CreateAutoResetEvent(false);
   assert_not_null(async_event_);
 }
@@ -177,6 +181,30 @@ X_STATUS XFile::ReadInternal(uint32_t buffer_guest_address,
               position_ = byte_offset;
             }
             position_ += bytes_read;
+          }
+
+          if (result == X_STATUS_END_OF_FILE) {
+            // Special handling for packages. This is until real stfs handling
+            // is implemented
+            if (const auto dev = dynamic_cast<vfs::HostPathDevice*>(device())) {
+              // STFS support caching, but for whatever reason it should return
+              // pending.
+              if (dev->is_package_mounted()) {
+                result = X_STATUS_SUCCESS;
+              }
+            }
+          }
+
+          if (!is_synchronous_ && result == X_STATUS_SUCCESS) {
+            if (!allow_buffering_) {
+              result = X_STATUS_PENDING;
+            }
+
+            if (const auto dev = dynamic_cast<vfs::HostPathDevice*>(device())) {
+              if (dev->is_package_mounted() && allow_buffering_) {
+                result = X_STATUS_PENDING;
+              }
+            }
           }
         }
       }

--- a/src/xenia/kernel/xfile.h
+++ b/src/xenia/kernel/xfile.h
@@ -132,7 +132,8 @@ class XFile : public XObject {
  public:
   static const XObject::Type kObjectType = XObject::Type::File;
 
-  XFile(KernelState* kernel_state, vfs::File* file, bool synchronous);
+  XFile(KernelState* kernel_state, vfs::File* file, bool synchronous,
+        bool allow_buffering = false);
   ~XFile() override;
 
   vfs::Device* device() const { return file_->entry()->device(); }
@@ -175,6 +176,7 @@ class XFile : public XObject {
                                    ByteStream* stream);
 
   bool is_synchronous() const { return is_synchronous_; }
+  bool is_buffered() const { return allow_buffering_; }
 
  protected:
   void NotifyIOCompletionPorts(XIOCompletion::IONotification& notification);
@@ -205,6 +207,7 @@ class XFile : public XObject {
   size_t find_index_ = 0;
 
   bool is_synchronous_ = false;
+  bool allow_buffering_ = false;
 };
 
 }  // namespace kernel

--- a/src/xenia/vfs/devices/host_path_device.cc
+++ b/src/xenia/vfs/devices/host_path_device.cc
@@ -20,11 +20,12 @@ namespace vfs {
 
 HostPathDevice::HostPathDevice(const std::string_view mount_path,
                                const std::filesystem::path& host_path,
-                               bool read_only)
+                               bool read_only, bool package)
     : Device(mount_path),
-      name_("STFS"),
+      name_(package ? "STFS" : "FATX"),
       host_path_(host_path),
-      read_only_(read_only) {}
+      read_only_(read_only),
+      is_package_(package) {}
 
 HostPathDevice::~HostPathDevice() = default;
 

--- a/src/xenia/vfs/devices/host_path_device.h
+++ b/src/xenia/vfs/devices/host_path_device.h
@@ -22,7 +22,8 @@ class HostPathEntry;
 class HostPathDevice : public Device {
  public:
   HostPathDevice(const std::string_view mount_path,
-                 const std::filesystem::path& host_path, bool read_only);
+                 const std::filesystem::path& host_path, bool read_only,
+                 bool package = false);
   ~HostPathDevice() override;
 
   bool Initialize() override;
@@ -40,6 +41,8 @@ class HostPathDevice : public Device {
   uint32_t sectors_per_allocation_unit() const override { return 1; }
   uint32_t bytes_per_sector() const override { return 0x200; }
 
+  bool is_package_mounted() const { return is_package_; }
+
  protected:
   friend class HostPathEntry;
   std::filesystem::path host_path() const { return host_path_; }
@@ -51,6 +54,8 @@ class HostPathDevice : public Device {
   std::filesystem::path host_path_;
   std::unique_ptr<Entry> root_entry_;
   bool read_only_;
+  // Used while mounting directory as a STFS like package
+  bool is_package_;
 };
 
 }  // namespace vfs

--- a/src/xenia/vfs/devices/host_path_file.cc
+++ b/src/xenia/vfs/devices/host_path_file.cc
@@ -8,6 +8,7 @@
  */
 
 #include "xenia/vfs/devices/host_path_file.h"
+#include "xenia/vfs/devices/host_path_device.h"
 
 #include "xenia/vfs/devices/host_path_entry.h"
 


### PR DESCRIPTION
Assume that even async call will return 0 if buffering is enabled.

Fixes: King Kong, DreamWorks Kartz
Breaks: Might affect any game + saving, so requires through verification