### PR TITLE
[GPU] Use real fma - better accuracy, fixes ground in AC6 without the hack.

### DIFF
--- a/src/xenia/gpu/dxbc_shader_translator_alu.cc
+++ b/src/xenia/gpu/dxbc_shader_translator_alu.cc
@@ -90,33 +90,49 @@ void DxbcShaderTranslator::ProcessVectorAluOperation(
       break;
     case AluVectorOpcode::kMul:
     case AluVectorOpcode::kMad: {
-      // Not using DXBC mad to prevent fused multiply-add (mul followed by add
-      // may be optimized into non-fused mad by the driver in the identical
-      // operands case also).
-      a_.OpMul(per_component_dest, operands[0], operands[1]);
+      bool is_mad = instr.vector_opcode == AluVectorOpcode::kMad;
+      // Fused-multiply-add instead of separate Mul+Add
+      // is assumed to be closer to the real hardware
+      // (fixes black ground in AC6).
+      // DXBC `mad` stays fused because Xenia does not set
+      // kGlobalFlagRefactoringAllowed.
+      if (is_mad) {
+        a_.OpMAd(per_component_dest, operands[0], operands[1], operands[2]);
+      } else {
+        a_.OpMul(per_component_dest, operands[0], operands[1]);
+      }
       uint32_t multiplicands_different =
           used_result_components &
           ~instr.vector_operands[0].GetIdenticalComponents(
               instr.vector_operands[1]);
       if (multiplicands_different) {
-        // Shader Model 3: +-0 or denormal * anything = +0.
+        // SM3 forces 0 * anything = +0, but the FMA would propagate NaN
+        // through `0 * NaN + c`. For `mad`, substitute `+0 + c` (not just `c`)
+        // so signed-zero semantics preserve `+0 + (-0) = +0`.
+        // For `mul`, the substitute is plain +0.
         uint32_t is_zero_temp = PushSystemTemp();
         a_.OpMin(dxbc::Dest::R(is_zero_temp, multiplicands_different),
                  operands[0].Abs(), operands[1].Abs());
         // min isn't required to flush denormals, eq is.
         a_.OpEq(dxbc::Dest::R(is_zero_temp, multiplicands_different),
                 dxbc::Src::R(is_zero_temp), dxbc::Src::LF(0.0f));
-        // Not replacing true `0 + term` with movc of the term because +0 + -0
-        // should result in +0, not -0.
+        dxbc::Src replacement = dxbc::Src::LF(0.0f);
+        if (is_mad) {
+          uint32_t zero_plus_addend_temp = PushSystemTemp();
+          a_.OpAdd(
+              dxbc::Dest::R(zero_plus_addend_temp, multiplicands_different),
+              dxbc::Src::LF(0.0f), operands[2]);
+          replacement = dxbc::Src::R(zero_plus_addend_temp);
+        }
         a_.OpMovC(dxbc::Dest::R(system_temp_result_, multiplicands_different),
-                  dxbc::Src::R(is_zero_temp), dxbc::Src::LF(0.0f),
+                  dxbc::Src::R(is_zero_temp), replacement,
                   dxbc::Src::R(system_temp_result_));
+        if (is_mad) {
+          // Release zero_plus_addend_temp.
+          PopSystemTemp();
+        }
         // Release is_zero_temp.
         PopSystemTemp();
-      }
-      if (instr.vector_opcode == AluVectorOpcode::kMad) {
-        a_.OpAdd(per_component_dest, dxbc::Src::R(system_temp_result_),
-                 operands[2]);
       }
     } break;
 

--- a/src/xenia/gpu/dxbc_shader_translator_fetch.cc
+++ b/src/xenia/gpu/dxbc_shader_translator_fetch.cc
@@ -83,14 +83,7 @@ void DxbcShaderTranslator::ProcessVertexFetchInstruction(
           a_.OpAdd(address_dest, index_operand, dxbc::Src::LF(0.5f));
           a_.OpRoundNI(address_dest, address_src);
         } else {
-          // UGLY HACK. Remove ASAP.
-          // Proper fix requires accurate RCP implementation.
-          if (cvars::ac6_ground_fix) {
-            a_.OpAdd(address_dest, index_operand, dxbc::Src::LF(0.00025f));
-            a_.OpRoundNI(address_dest, address_src);
-          } else {
-            a_.OpRoundNI(address_dest, index_operand);
-          }
+          a_.OpRoundNI(address_dest, index_operand);
         }
         if (index_operand_temp_pushed) {
           PopSystemTemp();

--- a/src/xenia/gpu/gpu_flags.cc
+++ b/src/xenia/gpu/gpu_flags.cc
@@ -108,9 +108,3 @@ DEFINE_bool(
     "artifacts while pipelines are being created. When disabled, pipelines are "
     "created synchronously which causes stutter but no visual artifacts.",
     "GPU");
-
-DEFINE_bool(
-    ac6_ground_fix, false,
-    "This fixes(hide) issues with black ground in AC6. Use only in AC6. "
-    "Might cause issues in other titles.",
-    "HACKS");

--- a/src/xenia/gpu/gpu_flags.h
+++ b/src/xenia/gpu/gpu_flags.h
@@ -42,8 +42,6 @@ DECLARE_bool(async_shader_compilation);
 
 DECLARE_bool(gpu_3d_to_2d_texture);
 
-DECLARE_bool(ac6_ground_fix);
-
 #define XE_GPU_FINE_GRAINED_DRAW_SCOPES 1
 
 #endif  // XENIA_GPU_GPU_FLAGS_H_

--- a/src/xenia/gpu/spirv_shader_translator_alu.cc
+++ b/src/xenia/gpu/spirv_shader_translator_alu.cc
@@ -285,12 +285,36 @@ spv::Id SpirvShaderTranslator::ProcessVectorAluOperation(
         }
       }
       if (instr.vector_opcode == ucode::AluVectorOpcode::kMad) {
-        // Not replacing true `0 + term` with conditional selection of the term
-        // because +0 + -0 should result in +0, not -0.
-        result = builder_->createNoContractionBinOp(
-            spv::OpFAdd, result_type, result,
+        // Fused-multiply-add instead of separate FMul+FAdd
+        // is assumed to be closer to the real hardware
+        // (fixes black ground in AC6).
+        spv::Id addend =
             GetOperandComponents(operand_storage[2], instr.vector_operands[2],
-                                 used_result_components));
+                                 used_result_components);
+        result = builder_->createTriBuiltinCall(
+            result_type, ext_inst_glsl_std_450_, GLSLstd450Fma,
+            multiplicands[0], multiplicands[1], addend);
+        // SM3 forces 0 * anything = +0, but Fma would propagate NaN through
+        // `0 * NaN + c`. Substitute `+0 + c` (not just `c`) so signed-zero
+        // semantics preserve `+0 + (-0) = +0` matching the hardware.
+        if (multiplicands_different) {
+          spv::Id abs_a =
+              GetAbsoluteOperand(multiplicands[0], instr.vector_operands[0]);
+          spv::Id abs_b =
+              GetAbsoluteOperand(multiplicands[1], instr.vector_operands[1]);
+          spv::Id any_zero = builder_->createBinOp(
+              spv::OpFOrdEqual,
+              type_bool_vectors_[used_result_component_count - 1],
+              builder_->createBinBuiltinCall(result_type,
+                                             ext_inst_glsl_std_450_,
+                                             GLSLstd450NMin, abs_a, abs_b),
+              const_float_vectors_0_[used_result_component_count - 1]);
+          spv::Id zero_plus_addend = builder_->createNoContractionBinOp(
+              spv::OpFAdd, result_type,
+              const_float_vectors_0_[used_result_component_count - 1], addend);
+          result = builder_->createTriOp(spv::OpSelect, result_type, any_zero,
+                                         zero_plus_addend, result);
+        }
       }
       return result;
     }

--- a/src/xenia/gpu/spirv_shader_translator_fetch.cc
+++ b/src/xenia/gpu/spirv_shader_translator_fetch.cc
@@ -82,12 +82,6 @@ void SpirvShaderTranslator::ProcessVertexFetchInstruction(
       if (instr.attributes.is_index_rounded) {
         index = builder_->createNoContractionBinOp(
             spv::OpFAdd, type_float_, index, builder_->makeFloatConstant(0.5f));
-      } else if (cvars::ac6_ground_fix) {
-        // UGLY HACK for AC6 copied from the DXBC translator.
-        // Proper fix requires accurate RCP implementation.
-        index = builder_->createNoContractionBinOp(
-            spv::OpFAdd, type_float_, index,
-            builder_->makeFloatConstant(0.00025f));
       }
       index = builder_->createUnaryOp(
           spv::OpConvertFToS, type_int_,


### PR DESCRIPTION
We were using FMA in the past (see feb8258a5 (Triang3l, 30 Oct 2020, "[DXBC] Multiplication signed zero handling"))
but, switched because of the `+0 + (-0) = +0` - requirement.
Go back to FMA, to get more accuracy, but also do x + 0 - to match that requirement.