### PR TITLE
[Emulator] Auto disc swapping using path prediction

### DIFF
--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -1250,6 +1250,24 @@ bool Emulator::RestoreFromFile(const std::filesystem::path& path) {
   return true;
 }
 
+const std::filesystem::path Emulator::GetNewDiscPathPrediction(
+    std::string disc_number) {
+  std::filesystem::path path = "";
+
+  auto xam = kernel_state()->GetKernelModule<kernel::xam::XamModule>("xam.xex");
+  if (!xam->loader_data().host_path.empty()) {
+    std::string host_path = xam->loader_data().host_path;
+    std::regex pattern(R"((\(Disc )(\d+)(\)))", std::regex_constants::icase);
+    std::string replacement = "$01" + disc_number + "$03";
+    std::filesystem::path path_prediction = std::filesystem::path(
+        std::regex_replace(host_path, pattern, replacement));
+    if (std::filesystem::exists(path_prediction)) {
+      path = path_prediction;
+    }
+  }
+  return path;
+}
+
 const std::filesystem::path Emulator::GetNewDiscPath(
     std::string window_message) {
   std::filesystem::path path = "";

--- a/src/xenia/emulator.h
+++ b/src/xenia/emulator.h
@@ -302,6 +302,8 @@ class Emulator {
   bool RestoreFromFile(const std::filesystem::path& path);
 
   // The game can request another title to be loaded.
+  const std::filesystem::path GetNewDiscPathPrediction(
+      std::string disc_number = "");
   const std::filesystem::path GetNewDiscPath(std::string window_message = "");
 
   void WaitUntilExit();

--- a/src/xenia/kernel/xam/xam_content.cc
+++ b/src/xenia/kernel/xam/xam_content.cc
@@ -721,6 +721,19 @@ dword_result_t XamSwapDisc_entry(
   std::u16string text_message = xe::load_and_swap<std::u16string>(
       kernel_state()->memory()->TranslateVirtual(error_message->stringTextPtr));
 
+  const std::filesystem::path new_predict_disc_path =
+      kernel_state()->emulator()->GetNewDiscPathPrediction(
+          std::to_string(disc_number));
+  XELOGI("GetNewDiscPathPrediction returned path {}.",
+         new_predict_disc_path.string().c_str());
+
+  if (new_predict_disc_path != "") {
+    kernel_state()->emulator()->MountPath(new_predict_disc_path, mount_path);
+    completion_event();
+
+    return X_ERROR_SUCCESS;
+  }
+
   const std::filesystem::path new_disc_path =
       kernel_state()->emulator()->GetNewDiscPath(xe::to_utf8(text_message));
   XELOGI("GetNewDiscPath returned path {}.", new_disc_path.string().c_str());

--- a/src/xenia/kernel/xam/xam_content.cc
+++ b/src/xenia/kernel/xam/xam_content.cc
@@ -691,7 +691,7 @@ dword_result_t XamSwapDisc_entry(
   kernel_state()->GetExecutableModule()->GetOptHeader(XEX_HEADER_EXECUTION_INFO,
                                                       &info);
 
-  if (info->disc_number > info->disc_count) {
+  if (disc_number > info->disc_count) {
     return X_ERROR_INVALID_PARAMETER;
   }
 
@@ -706,10 +706,10 @@ dword_result_t XamSwapDisc_entry(
     }
   };
 
-  if (info->disc_number == disc_number) {
-    completion_event();
-    return X_ERROR_SUCCESS;
-  }
+  // if (info->disc_number == disc_number) {
+  // completion_event();
+  // return X_ERROR_SUCCESS;
+  // }
 
   auto filesystem = kernel_state()->file_system();
   auto mount_path = "\\Device\\LauncherData";


### PR DESCRIPTION
This will take the loaded file name and substitute the disc number if a (Disc <num>)  tag is found. It then checks if the file exists, if so it loads it. If it cannot find the predicted file it continues with prompting as usual.