### PR TITLE
[XAM] Limit XContentQueryVolumeDeviceType to XContent packages

### DIFF
--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -545,7 +545,7 @@ X_STATUS Emulator::LaunchPath(const std::filesystem::path& path) {
     case FileSignatureType::LIVE:
     case FileSignatureType::CON:
     case FileSignatureType::PIRS: {
-      mount_result = MountPath(path, "\\Device\\Cdrom0");
+      mount_result = MountPath(path, "\\Device\\Package_0");
       return mount_result ? mount_result : LaunchStfsContainer(path);
     } break;
     case FileSignatureType::XISO: {

--- a/src/xenia/kernel/xam/apps/xam_app.cc
+++ b/src/xenia/kernel/xam/apps/xam_app.cc
@@ -111,6 +111,17 @@ X_HRESULT XamApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
       }* data = reinterpret_cast<XContentQueryVolumeDeviceType*>(buffer);
       assert_true(buffer_length == sizeof(XContentQueryVolumeDeviceType));
 
+      std::string target;
+      if (!kernel_state_->file_system()->FindSymbolicLink(
+              std::string(data->root_name) + ':', target)) {
+        return X_E_INVALIDARG;
+      }
+
+      // Only apply this check to XContent packages
+      if (!target.starts_with("\\Device\\Package_")) {
+        return X_E_INVALIDARG;
+      }
+
       xe::be<DeviceType>* device_type_ptr =
           memory_->TranslateVirtual<xe::be<DeviceType>*>(
               static_cast<uint32_t>(data->device_type_ptr.get()));


### PR DESCRIPTION
- Changed mount path for XContent packages from Cdrom to Package_0 Normally it should generate specific value instead of 0, but for now 0 is enough