### PR TITLE
fix(cpu/x64): correct partial vector stores

### DIFF
--- a/src/xenia/cpu/backend/x64/x64_seq_memory.cc
+++ b/src/xenia/cpu/backend/x64/x64_seq_memory.cc
@@ -356,29 +356,32 @@ EMITTER_OPCODE_TABLE(OPCODE_LVR, LVR_V128);
 
 struct STVL_V128 : Sequence<STVL_V128, I<OPCODE_STVL, VoidOp, I64Op, V128Op>> {
   static void Emit(X64Emitter& e, const EmitArgType& i) {
-    e.mov(e.ecx, 15);
-    e.mov(e.edx, e.ecx);
+    Xmm src2 = GetInputRegOrConstant(e, i.src2, e.xmm0);
+    e.StashXmm(0, src2);
+
+    // Store bytes offset..15 from the source vector. Xenia's host vector byte
+    // layout is word-swapped from guest byte order, so convert source byte
+    // indexes with ^ 3 before reading the stashed XMM value.
     e.lea(e.rax, e.ptr[ComputeMemoryAddress(e, i.src1)]);
+    e.mov(e.ecx, 15);
     e.and_(e.ecx, e.eax);
-    e.vmovd(e.xmm0, e.ecx);
+    e.mov(e.edx, 15);
     e.not_(e.rdx);
     e.and_(e.rax, e.rdx);
-    e.vmovdqa(e.xmm1, e.GetXmmConstPtr(XMMSTVLShuffle));
-    if (e.IsFeatureEnabled(kX64EmitAVX2)) {
-      e.vpbroadcastb(e.xmm3, e.xmm0);
-    } else {
-      e.vpshufb(e.xmm3, e.xmm0, e.GetXmmConstPtr(XMMZero));
-    }
-    e.vpsubb(e.xmm0, e.xmm1, e.xmm3);
-    e.vpxor(e.xmm1, e.xmm0,
-            e.GetXmmConstPtr(XMMSwapWordMask));  // xmm1 from now on will be our
-                                                 // selector for blend/shuffle
 
-    Xmm src2 = GetInputRegOrConstant(e, i.src2, e.xmm0);
-
-    e.vpshufb(e.xmm2, src2, e.xmm1);
-    e.vpblendvb(e.xmm3, e.xmm2, e.ptr[e.rax], e.xmm1);
-    e.vmovdqa(e.ptr[e.rax], e.xmm3);
+    Xbyak::Label loop, done;
+    e.mov(e.edx, e.ecx);
+    e.L(loop);
+    e.cmp(e.edx, 16);
+    e.jge(done);
+    e.mov(e.r8d, e.edx);
+    e.sub(e.r8d, e.ecx);
+    e.xor_(e.r8d, 3);
+    e.movzx(e.r9d, e.byte[e.rsp + X64Emitter::kStashOffset + e.r8]);
+    e.mov(e.byte[e.rax + e.rdx], e.r9b);
+    e.inc(e.edx);
+    e.jmp(loop);
+    e.L(done);
   }
 };
 EMITTER_OPCODE_TABLE(OPCODE_STVL, STVL_V128);
@@ -391,28 +394,26 @@ struct STVR_V128 : Sequence<STVR_V128, I<OPCODE_STVR, VoidOp, I64Op, V128Op>> {
     e.lea(e.rax, e.ptr[ComputeMemoryAddress(e, i.src1)]);
     e.and_(e.ecx, e.eax);
     e.jz(skipper);
-    e.vmovd(e.xmm0, e.ecx);
     e.not_(e.rdx);
     e.and_(e.rax, e.rdx);
-    e.vmovdqa(e.xmm1, e.GetXmmConstPtr(XMMSTVLShuffle));
-    // todo: maybe a table lookup might be a better idea for getting the
-    // shuffle/blend
-
-    if (e.IsFeatureEnabled(kX64EmitAVX2)) {
-      e.vpbroadcastb(e.xmm3, e.xmm0);
-    } else {
-      e.vpshufb(e.xmm3, e.xmm0, e.GetXmmConstPtr(XMMZero));
-    }
-    e.vpsubb(e.xmm0, e.xmm1, e.xmm3);
-    e.vpxor(e.xmm1, e.xmm0,
-            e.GetXmmConstPtr(XMMSTVRSwapMask));  // xmm1 from now on will be our
-                                                 // selector for blend/shuffle
 
     Xmm src2 = GetInputRegOrConstant(e, i.src2, e.xmm0);
+    e.StashXmm(0, src2);
 
-    e.vpshufb(e.xmm2, src2, e.xmm1);
-    e.vpblendvb(e.xmm3, e.xmm2, e.ptr[e.rax], e.xmm1);
-    e.vmovdqa(e.ptr[e.rax], e.xmm3);
+    // Store bytes 0..offset-1 from the tail of the source vector.
+    Xbyak::Label loop;
+    e.xor_(e.edx, e.edx);
+    e.L(loop);
+    e.cmp(e.edx, e.ecx);
+    e.jge(skipper);
+    e.mov(e.r8d, 16);
+    e.sub(e.r8d, e.ecx);
+    e.add(e.r8d, e.edx);
+    e.xor_(e.r8d, 3);
+    e.movzx(e.r9d, e.byte[e.rsp + X64Emitter::kStashOffset + e.r8]);
+    e.mov(e.byte[e.rax + e.rdx], e.r9b);
+    e.inc(e.edx);
+    e.jmp(loop);
     e.L(skipper);
   }
 };

--- a/src/xenia/cpu/testing/misc_opcode_test.cc
+++ b/src/xenia/cpu/testing/misc_opcode_test.cc
@@ -13,6 +13,7 @@
 
 #include "xenia/cpu/testing/util.h"
 
+#include <array>
 #include <atomic>
 #include <cmath>
 #include <cstdlib>
@@ -628,4 +629,141 @@ TEST_CASE("LOAD_VECTOR_RIGHT", "[memory]") {
            });
 
   test.memory->SystemHeapFree(guest_addr);
+}
+
+// ============================================================================
+// STVL / STVR - partial vector store left/right
+// These are used by optimized memcpy implementations for unaligned heads/tails.
+// ============================================================================
+constexpr std::array<uint8_t, 16> kStoreVectorSource = {
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+constexpr uint32_t kPartialStoreOffsets[] = {0, 1, 4, 8, 12, 15};
+
+TEST_CASE("STORE_VECTOR_LEFT", "[memory]") {
+  TestFunction test([](HIRBuilder& b) {
+    b.StoreVectorLeft(LoadGPR(b, 4), LoadVR(b, 5));
+    b.Return();
+  });
+
+  for (const uint32_t offset : kPartialStoreOffsets) {
+    uint32_t guest_addr = test.memory->SystemHeapAlloc(64, 16);
+    REQUIRE(guest_addr != 0);
+    const uint32_t aligned_addr = (guest_addr + 15) & ~15u;
+    auto* host_ptr =
+        reinterpret_cast<uint8_t*>(test.memory->TranslateVirtual(aligned_addr));
+
+    std::array<uint8_t, 16> expected;
+    for (uint32_t i = 0; i < 16; ++i) {
+      host_ptr[i] = static_cast<uint8_t>(0xA0 + i);
+      expected[i] = host_ptr[i];
+    }
+
+    for (uint32_t i = offset; i < 16; ++i) {
+      expected[i] = kStoreVectorSource[(i - offset) ^ 3];
+    }
+
+    test.Run(
+        [&](PPCContext* ctx) {
+          ctx->r[4] = aligned_addr + offset;
+          ctx->v[5] =
+              vec128b(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+        },
+        [&](PPCContext* ctx) {
+          REQUIRE(std::memcmp(host_ptr, expected.data(), expected.size()) == 0);
+        });
+
+    test.memory->SystemHeapFree(guest_addr);
+  }
+}
+
+TEST_CASE("STORE_VECTOR_RIGHT", "[memory]") {
+  TestFunction test([](HIRBuilder& b) {
+    b.StoreVectorRight(LoadGPR(b, 4), LoadVR(b, 5));
+    b.Return();
+  });
+
+  for (const uint32_t offset : kPartialStoreOffsets) {
+    uint32_t guest_addr = test.memory->SystemHeapAlloc(64, 16);
+    REQUIRE(guest_addr != 0);
+    const uint32_t aligned_addr = (guest_addr + 15) & ~15u;
+    auto* host_ptr =
+        reinterpret_cast<uint8_t*>(test.memory->TranslateVirtual(aligned_addr));
+
+    std::array<uint8_t, 16> expected;
+    for (uint32_t i = 0; i < 16; ++i) {
+      host_ptr[i] = static_cast<uint8_t>(0xA0 + i);
+      expected[i] = host_ptr[i];
+    }
+
+    for (uint32_t i = 0; i < offset; ++i) {
+      expected[i] = kStoreVectorSource[(16 - offset + i) ^ 3];
+    }
+
+    test.Run(
+        [&](PPCContext* ctx) {
+          ctx->r[4] = aligned_addr + offset;
+          ctx->v[5] =
+              vec128b(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+        },
+        [&](PPCContext* ctx) {
+          REQUIRE(std::memcmp(host_ptr, expected.data(), expected.size()) == 0);
+        });
+
+    test.memory->SystemHeapFree(guest_addr);
+  }
+}
+
+TEST_CASE("STORE_VECTOR_LEFT_MEMCPY_HEAD", "[memory]") {
+  TestFunction test([](HIRBuilder& b) {
+    auto src_addr = LoadGPR(b, 4);
+    auto dest_addr = LoadGPR(b, 5);
+    auto aligned_src =
+        b.And(src_addr, b.LoadConstantInt64(static_cast<int64_t>(~0xFULL)));
+    auto next_src = b.And(b.Add(src_addr, b.LoadConstantInt64(15)),
+                          b.LoadConstantInt64(static_cast<int64_t>(~0xFULL)));
+    auto source_a = b.ByteSwap(b.Load(aligned_src, VEC128_TYPE));
+    auto source_b = b.ByteSwap(b.Load(next_src, VEC128_TYPE));
+    auto control = b.LoadVectorShl(
+        b.Truncate(b.And(src_addr, b.LoadConstantInt64(0xF)), INT8_TYPE));
+    auto head = b.Permute(control, source_a, source_b, INT8_TYPE);
+    b.StoreVectorLeft(dest_addr, head);
+    b.Return();
+  });
+
+  for (const uint32_t source_offset : {0u, 1u, 4u, 12u}) {
+    uint32_t guest_addr = test.memory->SystemHeapAlloc(128, 16);
+    REQUIRE(guest_addr != 0);
+    const uint32_t aligned_addr = (guest_addr + 15) & ~15u;
+    auto* host_ptr =
+        reinterpret_cast<uint8_t*>(test.memory->TranslateVirtual(aligned_addr));
+    auto* src_ptr = host_ptr;
+    auto* dest_block = host_ptr + 64;
+    const uint32_t src_addr = aligned_addr + source_offset;
+    const uint32_t dest_addr = aligned_addr + 64 + 12;
+
+    for (uint32_t i = 0; i < 64; ++i) {
+      src_ptr[i] = static_cast<uint8_t>(i);
+    }
+    for (uint32_t i = 0; i < 16; ++i) {
+      dest_block[i] = static_cast<uint8_t>(0xC0 + i);
+    }
+
+    std::array<uint8_t, 16> expected;
+    std::memcpy(expected.data(), dest_block, expected.size());
+    for (uint32_t i = 0; i < 4; ++i) {
+      expected[12 + i] = src_ptr[source_offset + i];
+    }
+
+    test.Run(
+        [&](PPCContext* ctx) {
+          ctx->r[4] = src_addr;
+          ctx->r[5] = dest_addr;
+        },
+        [&](PPCContext* ctx) {
+          REQUIRE(std::memcmp(dest_block, expected.data(), expected.size()) ==
+                  0);
+        });
+
+    test.memory->SystemHeapFree(guest_addr);
+  }
 }


### PR DESCRIPTION
## Summary

This changes the x64 lowering for `STVL` / `STVR` to use explicit byte stores that preserve the guest-visible vector byte order.

The previous shuffle/blend implementation could produce incorrect bytes for partial vector stores. This matters for optimized guest memcpy implementations that use `stvlx` / `stvrx` for unaligned heads and tails.

## Why

This was observed in `4156081C` / Call of Duty: World at War TU7. The game uses an optimized VMX memcpy path containing:

- `lvx128`
- `lvsl`
- `vperm128`
- `stvlx128`
- `stvrx128`

<details>
<summary>
See sub_8238FB78

</summary>

```c++
void *__cdecl sub_8238FB78(void *Dst, const void *Src, size_t Size)
{
  size_t v5; // r29
  size_t v8; // r28
  int v9; // r11
  int v11; // r10
  unsigned int v12; // r8
  size_t v13; // r9
  unsigned int v16; // r28
  unsigned int v17; // r10
  unsigned int i; // r11
  unsigned int v20; // r11
  unsigned int v31; // r11
  _BYTE v34[80]; // [sp+60h] [-50h] BYREF

  _R26 = Dst;
  v5 = Size;
  _R30 = Dst;
  _R31 = (int)Src;
  if ( Size >= 0x10 )
  {
    v11 = -(int)Dst & 0xF;
    v12 = (-(int)Dst >> 4) & 7;
    v13 = Size;
    if ( Size >= 0x400 )
      v13 = 1024;
    for ( _R11 = 0; _R11 < v13; _R11 += 128 )
      __asm { dcbt      r11, r4 }
    _R27 = 15;
    if ( v11 )
    {
      __asm { lvx128    v63, r0, r4 }
      _R31 = (int)Src + v11;
      __asm { lvx128    v62, r4, r27 }
      v5 = Size - v11;
      __asm { lvsl      v0, 0, r4 }
      _R30 = (char *)Dst + v11;
      __asm
      {
        vperm128  v63, v95, v62, v0
        stvlx128  v63, r0, r26
      }
    }
    if ( v5 >> 4 < v12 )
      v12 = v5 >> 4;
    v16 = (v5 - 16 * v12) & 0xFFFFFF80;
    v17 = v16;
    if ( v16 >= 0x80 )
      v17 = 128;
    for ( i = 0; i < v17; i += 128 )
      __asm { dcbz128   r11, r9 }
    _R11 = v34;
    __asm { lvsl      v0, 0, r31 }
    __asm { stvx128   v0, r0, r11 }
    if ( v12 )
    {
      v20 = v12;
      do
      {
        __asm { lvx128    v63, r0, r31 }
        --v20;
        __asm { lvx128    v62, r31, r27 }
        _R31 += 16;
        __asm
        {
          vperm128  v62, v95, v62, v0
          stvx128   v62, r0, r30
        }
        _R30 += 16;
      }
      while ( v20 );
    }
    _R29 = v5 - 16 * v12;
    if ( (_R31 & 0xF) != 0 )
    {
      sub_8239A4D0((int)_R30, _R31, v16);
      _R11 = v34;
      _R30 += v16;
      _R31 += v16;
      _R29 -= v16;
      __asm { lvx128    v0, r0, r11 }
    }
    else if ( _R29 >= 0x80 )
    {
      _R5 = 16;
      _R6 = 32;
      _R7 = 48;
      _R8 = 64;
      _R9 = 80;
      _R10 = 96;
      _R11 = 112;
      do
      {
        if ( _R29 > 0x400 )
        {
          _R4 = 1024;
          __asm { dcbt      r4, r31 }
        }
        if ( _R29 > 0x100 )
          __asm { dcbz128   r4, r30 }
        _R29 -= 128;
        __asm
        {
          lvx128    v61, r0, r31
          lvx128    v60, r31, r5
          lvx128    v59, r31, r6
        }
        __asm
        {
          lvx128    v58, r31, r7
          lvx128    v57, r31, r8
          lvx128    v56, r31, r9
          lvx128    v55, r31, r10
          lvx128    v54, r31, r11
        }
        _R31 += 128;
        __asm
        {
          stvx128   v61, r0, r30
          stvx128   v60, r30, r5
          stvx128   v59, r30, r6
          stvx128   v58, r30, r7
          stvx128   v57, r30, r8
          stvx128   v56, r30, r9
          stvx128   v55, r30, r10
          stvx128   v54, r30, r11
        }
        _R30 += 128;
      }
      while ( _R29 >= 0x80 );
    }
    if ( _R29 >= 0x10 )
    {
      v31 = _R29 >> 4;
      do
      {
        __asm { lvx128    v63, r0, r31 }
        --v31;
        __asm { lvx128    v62, r31, r27 }
        _R29 -= 16;
        __asm { vperm128  v53, v95, v62, v0 }
        _R31 += 16;
        __asm { stvx128   v53, r0, r30 }
        _R30 += 16;
      }
      while ( v31 );
    }
    if ( _R29 )
    {
      _R11 = _R31 + _R29;
      __asm { lvx128    v52, r0, r31 }
      _R10 = -1;
      __asm
      {
        lvsl      v0, r31, r29
        lvx128    v51, r11, r10
        vperm128  v50, v84, v51, v0
        stvrx128  v50, r30, r29
      }
    }
    return _R26;
  }
  if ( Size >= 8 && ((unsigned __int8)Src & 7) == 0 )
  {
    _R30 = (char *)Dst + 8;
    _R31 = (int)Src + 8;
    v5 = Size - 8;
    *(_QWORD *)Dst = *(_QWORD *)Src;
  }
  if ( (_R31 & 3) == 0 && v5 >= 4 )
  {
    v8 = v5 >> 2;
    sub_8243F018(_R30, (char *)_R31, v5 & 0xFFFFFFFC);
    _R30 += v5 & 0xFFFFFFFC;
    _R31 += v5 & 0xFFFFFFFC;
    do
    {
      --v8;
      v5 -= 4;
    }
    while ( v8 );
  }
  if ( !v5 )
    return _R26;
  v9 = dword_824A3F8C;
  do
  {
    v5 -= v9;
    *_R30++ = *(_BYTE *)_R31++;
  }
  while ( v5 );
  return _R26;
}
```

</details>


With the old x64 lowering, that memcpy sometimes left corrupted bytes in skinned model render command data. The corruption later surfaced as render-thread crashes in functions consuming that data. See

This appears to fix the crash observed here:
https://github.com/xenia-canary/game-compatibility/issues/132#issuecomment-2062085815

## Changes

- Replaces x64 `STVL` / `STVR` lowering with correctness-first byte stores.
- Preserves Xenia's guest-visible vector byte order by applying the existing word-swapped byte index behaviour.
- Adds regression coverage for:
  - `StoreVectorLeft`
  - `StoreVectorRight`
  - a memcpy-head style pattern matching the affected guest instruction sequence

## Testing

I tested several multiplayer matches in Call of Duty: World at War TU7 with no crashes after this change. Before this, the game would eventually crash during rendering, and instrumentation showed corrupted memcpy output before the crash. I have also tested the first and second mission "Semper Fi" and "Little Resistance" both of which would crash during the opening cutscene with the latest build as of today.

## Caveat

I am not deeply knowledgeable in PowerPC VMX/x64 emitter assembly, so this should get careful review and broader testing. The implementation is intentionally conservative and correctness-first; if there is a preferred vectorized lowering, this may be better treated as a validated behavioural baseline.