### PR TITLE
[XAM] Fixed returning error in XamLoaderGetLaunchData

### DIFF
--- a/src/xenia/kernel/xam/xam_info.cc
+++ b/src/xenia/kernel/xam/xam_info.cc
@@ -275,7 +275,7 @@ dword_result_t XamLoaderGetLaunchData_entry(lpvoid_t buffer_ptr,
                                             dword_t buffer_size) {
   auto xam = kernel_state()->GetKernelModule<XamModule>("xam.xex");
   auto& loader_data = xam->loader_data();
-  if (!loader_data.launch_data_present) {
+  if (!buffer_size) {
     return X_ERROR_NOT_FOUND;
   }
 


### PR DESCRIPTION
This issue was introduced in https://github.com/xenia-canary/xenia-canary/commit/d0f547020ae56ecb61722b4584882f21169bf00a 10 years ago.

These titles should now xex switch without issues.

- [Assassin's Creed III](https://github.com/xenia-canary/game-compatibility/issues/965)
- [Assassin's Creed IV: Black Flag](https://github.com/xenia-canary/game-compatibility/issues/966)
- [Assassin's Creed Rogue](https://github.com/xenia-canary/game-compatibility/issues/964)