### PR TITLE
[GPU] Rolls back ZPD cache erasure on guest BEGIN. Only affects kFast.

### DIFF
--- a/src/xenia/gpu/command_processor.cc
+++ b/src/xenia/gpu/command_processor.cc
@@ -1014,7 +1014,11 @@ bool CommandProcessor::BeginZPDReport(uint32_t report_address) {
   // something from a prior lifetime. The alternate fast path keeps it around
   // long enough for an async zero to help the next unresolved write.
   if (GetZPDMode() != ZPDMode::kFastAlt) {
-    fast_zpd_report_cached_values_.erase(end_record);
+    auto cache_it = fast_zpd_report_cached_values_.find(end_record);
+    if (cache_it != fast_zpd_report_cached_values_.end() &&
+        cache_it->second == 0) {
+      fast_zpd_report_cached_values_.erase(cache_it);
+    }
   }
 
   ReportHandle report_handle = zpd_next_report_handle_++;


### PR DESCRIPTION
Reverses `fast` ZPD regression, introduced by PR 1037, with 545407EE, 465307E4, and probably a few other titles.