### PR TITLE
[VFS] Fixed opening files with incompatible access flags on posix

### DIFF
--- a/src/xenia/base/filesystem_posix.cc
+++ b/src/xenia/base/filesystem_posix.cc
@@ -191,16 +191,24 @@ std::unique_ptr<FileHandle> FileHandle::OpenExisting(
     open_access |= O_WRONLY;
   }
   if (desired_access & FileAccess::kGenericExecute) {
-    open_access |= O_RDONLY;
-  }
-  if (desired_access & FileAccess::kGenericAll) {
-    open_access |= O_RDWR;
+    // Unsupported
   }
   if (desired_access & FileAccess::kFileReadData) {
     open_access |= O_RDONLY;
   }
   if (desired_access & FileAccess::kFileWriteData) {
     open_access |= O_WRONLY;
+  }
+  if (desired_access & FileAccess::kGenericRead &&
+      desired_access & FileAccess::kGenericWrite) {
+    open_access = O_RDWR;
+  }
+  if (desired_access & FileAccess::kFileReadData &&
+      desired_access & FileAccess::kFileWriteData) {
+    open_access = O_RDWR;
+  }
+  if (desired_access & FileAccess::kGenericAll) {
+    open_access = O_RDWR;
   }
   if (desired_access & FileAccess::kFileAppendData) {
     open_access |= O_APPEND;

--- a/src/xenia/kernel/xam/user_profile.cc
+++ b/src/xenia/kernel/xam/user_profile.cc
@@ -104,7 +104,7 @@ void UserProfile::WriteProfileIcon(XTileType tile_type,
 
   const X_STATUS result = kernel_state()->file_system()->OpenFile(
       nullptr, path, vfs::FileDisposition::kOverwriteIf,
-      vfs::FileAccess::kGenericAll, false, true, &file, &action);
+      vfs::FileAccess::kGenericWrite, false, true, &file, &action);
 
   if (result != X_STATUS_SUCCESS) {
     return;


### PR DESCRIPTION
Fixed writing gamerpic icon in profile editor on posix.

https://man7.org/linux/man-pages/man2/open.2.html
> In other words, the combination O_RDONLY | O_WRONLY is a logical error, and certainly does not have the same meaning as O_RDWR.