### PR TITLE
[XAM] Added global variable storage with automatic management

### DIFF
--- a/src/xenia/kernel/util/guest_arena.cc
+++ b/src/xenia/kernel/util/guest_arena.cc
@@ -1,0 +1,69 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2026 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/kernel/util/guest_arena.h"
+
+#include "xenia/kernel/kernel_state.h"
+
+namespace xe {
+namespace kernel {
+namespace util {
+
+GuestArena::GuestArena(KernelState* kernel_state, uint32_t guest_address,
+                       uint32_t size)
+    : kernel_state_(kernel_state) {
+  if (!kernel_state_->memory()
+           ->LookupHeap(guest_address)
+           ->AllocFixed(guest_address, size, 0x1000, kMemoryAllocationCommit,
+                        kMemoryProtectRead | kMemoryProtectWrite)) {
+    return;
+  }
+
+  allocation_.emplace(
+      kernel_state_->memory()->TranslateVirtual<void*>(guest_address), size,
+      std::pmr::null_memory_resource());
+}
+
+GuestArena::~GuestArena() {
+  if (allocation_) {
+    allocation_->release();
+  }
+}
+
+uint32_t GuestArena::Allocate(uint32_t byte_count) {
+  if (!allocation_) {
+    return 0;
+  }
+
+  return kernel_state_->memory()->HostToGuestVirtual(
+      allocation_->allocate(byte_count));
+}
+
+uint32_t GuestArena::Write(std::string_view s) { return WriteChars(s); }
+uint32_t GuestArena::Write(std::u16string_view s) { return WriteChars(s); }
+
+template <CharType CharT>
+uint32_t GuestArena::WriteChars(std::basic_string_view<CharT> s) {
+  const size_t count = s.size() + 1;
+  auto* dst = static_cast<CharT*>(
+      allocation_->allocate(count * sizeof(CharT), alignof(CharT)));
+
+  if constexpr (sizeof(CharT) == sizeof(char)) {
+    std::memcpy(dst, s.data(), s.size());
+    dst[s.size()] = CharT{};
+  } else {
+    string_util::copy_and_swap_truncating(dst, s, s.size() + 1);
+  }
+
+  return kernel_state_->memory()->HostToGuestVirtual(dst);
+}
+
+}  // namespace util
+}  // namespace kernel
+}  // namespace xe

--- a/src/xenia/kernel/util/guest_arena.h
+++ b/src/xenia/kernel/util/guest_arena.h
@@ -1,0 +1,56 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2026 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_KERNEL_UTIL_GUEST_ARENA_H_
+#define XENIA_KERNEL_UTIL_GUEST_ARENA_H_
+
+#include <concepts>
+#include <memory_resource>
+#include <optional>
+#include <string_view>
+
+namespace xe {
+namespace kernel {
+class KernelState;
+}
+}  // namespace xe
+
+namespace xe {
+namespace kernel {
+namespace util {
+
+template <typename T>
+concept CharType = std::same_as<T, char> || std::same_as<T, char8_t> ||
+                   std::same_as<T, char16_t>;
+
+class GuestArena {
+ public:
+  GuestArena(KernelState* kernel_state, uint32_t guest_address, uint32_t size);
+  ~GuestArena();
+
+  uint32_t Allocate(uint32_t byte_count);
+  // Add scalar types when needed!
+  uint32_t Write(std::string_view s);
+  uint32_t Write(std::u16string_view s);
+
+  bool is_valid() const { return allocation_.has_value(); }
+
+ private:
+  template <CharType CharT>
+  uint32_t WriteChars(std::basic_string_view<CharT> s);
+
+  KernelState* kernel_state_;
+  std::optional<std::pmr::monotonic_buffer_resource> allocation_;
+};
+
+}  // namespace util
+}  // namespace kernel
+}  // namespace xe
+
+#endif  // XENIA_KERNEL_UTIL_GUEST_ARENA_H_

--- a/src/xenia/kernel/xam/xam_info.cc
+++ b/src/xenia/kernel/xam/xam_info.cc
@@ -926,6 +926,10 @@ DECLARE_XAM_EXPORT1(XamIsIptvEnabled, kNone, kImplemented);
 
 dword_result_t XamIptvGetServiceName_entry(lpdword_t service_name_ptr) {
   auto address = kernel_state()->xam_state()->GetIptvNameAddress();
+  if (!address) {
+    return X_ERROR_SUCCESS;
+  }
+
   auto buffer = kernel_state()->memory()->TranslateVirtual(address);
   char16_t* data_ptr = reinterpret_cast<char16_t*>(buffer);
   kernel_state()->xconfig()->ReadSetting(

--- a/src/xenia/kernel/xam/xam_state.cc
+++ b/src/xenia/kernel/xam/xam_state.cc
@@ -15,7 +15,8 @@ namespace kernel {
 namespace xam {
 
 XamState::XamState(Emulator* emulator, KernelState* kernel_state)
-    : kernel_state_(kernel_state) {
+    : kernel_state_(kernel_state),
+      global_allocator_(kernel_state, 0x80D00000, 0x100000) {
   app_manager_ = std::make_unique<AppManager>();
 
   auto content_root = emulator->content_root();
@@ -38,32 +39,26 @@ XamState::XamState(Emulator* emulator, KernelState* kernel_state)
 }
 
 void XamState::LoadLanguageLocaleFallback() {
-  const std::array<std::u16string, 18> locale_data = {
+  if (!global_allocator_.is_valid()) {
+    return;
+  }
+
+  const std::array<std::u16string_view, 18> locale_data = {
       u"",      u"",      u"ja-JP", u"de-DE", u"fr-FR",  u"es-ES",
       u"it-IT", u"ko-KR", u"zh-TW", u"pt-BR", u"zh-CHS", u"pl-PL",
       u"ru-RU", u"sv-SE", u"tr-TR", u"nb-NO", u"nl-NL",  u"zh-CHS"};
 
-  constexpr uint32_t array_start = 0x80D00000;
-
-  if (kernel_state_->memory()
-          ->LookupHeap(0x80000000)
-          ->AllocFixed(array_start, 0xC8, 0x1000, kMemoryAllocationCommit,
-                       kMemoryProtectRead | kMemoryProtectWrite)) {
-    char16_t* ptr =
-        kernel_state_->memory()->TranslateVirtual<char16_t*>(array_start);
-
-    for (size_t i = 1; i < locale_data.size(); i++) {
-      language_fallback_address_[i] =
-          kernel_state_->memory()->HostToGuestVirtual(ptr);
-      ptr += xe::string_util::copy_and_swap_truncating(
-                 ptr, locale_data.at(i), locale_data.at(i).size() + 1) +
-             1;
-    }
+  for (size_t i = 1; i < locale_data.size(); i++) {
+    language_fallback_address_[i] = global_allocator_.Write(locale_data.at(i));
   }
 }
 
 void XamState::LoadLanguageTypefacePatch() {
-  const std::array<std::u16string, 7> patch_data = {
+  if (!global_allocator_.is_valid()) {
+    return;
+  }
+
+  const std::array<std::u16string_view, 7> patch_data = {
       u"",
       u"file://media:/XenonSCLatin.xttp2",
       u"file://media:/XenonCLatin.xttp2",
@@ -72,22 +67,8 @@ void XamState::LoadLanguageTypefacePatch() {
       u"file://media:/XenonCLatin.xttp1",
       u"file://media:/XenonJKLatin.xttp1"};
 
-  constexpr uint32_t array_start = 0x80D10000;
-
-  if (kernel_state_->memory()
-          ->LookupHeap(0x80000000)
-          ->AllocFixed(array_start, 0x168, 0x1000, kMemoryAllocationCommit,
-                       kMemoryProtectRead | kMemoryProtectWrite)) {
-    char16_t* ptr =
-        kernel_state_->memory()->TranslateVirtual<char16_t*>(array_start);
-
-    for (size_t i = 1; i < patch_data.size(); i++) {
-      language_type_face_patch_[i] =
-          kernel_state_->memory()->HostToGuestVirtual(ptr);
-      ptr += xe::string_util::copy_and_swap_truncating(
-                 ptr, patch_data.at(i), patch_data.at(i).size() + 1) +
-             1;
-    }
+  for (size_t i = 0; i < patch_data.size(); i++) {
+    language_type_face_patch_[i] = global_allocator_.Write(patch_data.at(i));
   }
 }
 
@@ -108,14 +89,11 @@ uint32_t XamState::GetLanguageTypefacePatch(uint32_t language) const {
 }
 
 void XamState::LoadIptvServiceName() {
-  constexpr uint32_t address = 0x80D20000;
-
-  if (kernel_state_->memory()
-          ->LookupHeap(0x80000000)
-          ->AllocFixed(address, 0x78, 0x1000, kMemoryAllocationCommit,
-                       kMemoryProtectRead | kMemoryProtectWrite)) {
-    iptv_name_address_ = address;
+  if (!global_allocator_.is_valid()) {
+    return;
   }
+  constexpr size_t iptv_service_buffer_size = 0x78;
+  iptv_name_address_ = global_allocator_.Allocate(iptv_service_buffer_size);
 }
 
 UserProfile* XamState::GetUserProfile(uint32_t user_index) const {

--- a/src/xenia/kernel/xam/xam_state.h
+++ b/src/xenia/kernel/xam/xam_state.h
@@ -12,6 +12,7 @@
 
 #include <memory>
 
+#include "xenia/kernel/util/guest_arena.h"
 #include "xenia/kernel/xam/achievement_manager.h"
 #include "xenia/kernel/xam/app_manager.h"
 #include "xenia/kernel/xam/content_manager.h"
@@ -89,6 +90,8 @@ class XamState {
   std::unique_ptr<ProfileManager> profile_manager_;
 
   std::unique_ptr<SpaInfo> spa_info_;
+
+  util::GuestArena global_allocator_;
 
   // Custom XAM stuff
   std::array<uint32_t, 0x12> language_fallback_address_{};


### PR DESCRIPTION
This adds convenient way to add global variables in executable range, mostly used by XAM, so currently it is embedded directly into XAM.

In the future if needed in other places it might be moved to common and maybe redesigned to some custom allocator to precisely point what should be where.