### PR TITLE
gpu: initialize GPU registers to hardware reset defaults

### DIFF
--- a/src/xenia/gpu/register_file.cc
+++ b/src/xenia/gpu/register_file.cc
@@ -15,7 +15,38 @@
 namespace xe {
 namespace gpu {
 
-RegisterFile::RegisterFile() { std::memset(values, 0, sizeof(values)); }
+RegisterFile::RegisterFile() {
+  std::memset(values, 0, sizeof(values));
+
+  // Several context registers power up with non-zero values on real Xenos
+  // hardware, so a title that reads one of them before writing it would
+  // otherwise observe 0. These are the hardware reset defaults, corroborated by
+  // the AMD R6xx/R7xx 3D register reference and the Mesa r600g driver, which
+  // programs the same registers to the same values at context init.
+  values[XE_GPU_REG_VGT_MAX_VTX_INDX] = 0x0000FFFF;
+  values[XE_GPU_REG_VGT_MULTI_PRIM_IB_RESET_INDX] = 0x0000FFFF;
+  values[XE_GPU_REG_PA_SC_SCREEN_SCISSOR_BR] = 0x20002000;  // 8192 x 8192
+  values[XE_GPU_REG_RB_STENCILREFMASK_BF] = 0x00FFFF00;
+  values[XE_GPU_REG_PA_SU_POINT_SIZE] = 0x00080008;
+  values[XE_GPU_REG_PA_SU_POINT_MINMAX] = 0x04000010;
+  values[XE_GPU_REG_PA_SU_LINE_CNTL] = 0x00000008;
+  values[XE_GPU_REG_PA_SC_LINE_CNTL] = 0x00000400;
+  values[XE_GPU_REG_VGT_HOS_REUSE_DEPTH] = 0x0000000E;
+  values[XE_GPU_REG_VGT_VERTEX_REUSE_BLOCK_CNTL] = 0x0000000E;
+  values[XE_GPU_REG_VGT_OUT_DEALLOC_CNTL] = 0x00000010;
+  // Guard-band clip/discard adjust (2.0 clip, 1.0 discard); hardwired on
+  // hardware.
+  values[XE_GPU_REG_PA_CL_GB_VERT_CLIP_ADJ] = 0x40000000;  // 2.0f
+  values[XE_GPU_REG_PA_CL_GB_VERT_DISC_ADJ] = 0x3F800000;  // 1.0f
+  values[XE_GPU_REG_PA_CL_GB_HORZ_CLIP_ADJ] = 0x40000000;  // 2.0f
+  values[XE_GPU_REG_PA_CL_GB_HORZ_DISC_ADJ] = 0x3F800000;  // 1.0f
+  values[XE_GPU_REG_PA_SC_AA_MASK] = 0x0000FFFF;
+  // Tessellation levels also reset to 1.0f on hardware, but the backends apply
+  // the effective factor as (register + 1.0f), so initializing them here would
+  // change the effective reset factor; left out for separate review.
+  // values[XE_GPU_REG_VGT_HOS_MAX_TESS_LEVEL] = 0x3F800000;  // 1.0f
+  // values[XE_GPU_REG_VGT_HOS_MIN_TESS_LEVEL] = 0x3F800000;  // 1.0f
+}
 constexpr unsigned int GetHighestRegisterNumber() {
   uint32_t highest = 0;
 #define XE_GPU_REGISTER(index, type, name) \


### PR DESCRIPTION

`RegisterFile` zeroes every GPU register when it's constructed. On real Xenos hardware a handful of
the context registers come up non-zero, so if a title reads one of them before writing it, it sees
0 under emulation but the real value on console. This sets those registers to their hardware reset
defaults in the constructor.

## Values

| Register | Value | Notes |
|----------|-------|-------|
| `VGT_MAX_VTX_INDX` | `0x0000FFFF` | max vertex index (24-bit field) |
| `VGT_MULTI_PRIM_IB_RESET_INDX` | `0x0000FFFF` | primitive-restart index |
| `PA_SC_SCREEN_SCISSOR_BR` | `0x20002000` | screen scissor bottom-right (8192 x 8192) |
| `RB_STENCILREFMASK_BF` | `0x00FFFF00` | back-face stencil mask/writemask |
| `PA_SU_POINT_SIZE` | `0x00080008` | default point size |
| `PA_SU_POINT_MINMAX` | `0x04000010` | point size min/max |
| `PA_SU_LINE_CNTL` | `0x00000008` | line width (1.0 in 1/8 subpixels) |
| `PA_SC_LINE_CNTL` | `0x00000400` | last-pixel / line control |
| `VGT_HOS_REUSE_DEPTH` | `0x0000000E` | HOS reuse depth |
| `VGT_VERTEX_REUSE_BLOCK_CNTL` | `0x0000000E` | vertex reuse block |
| `VGT_OUT_DEALLOC_CNTL` | `0x00000010` | output dealloc distance |
| `PA_CL_GB_VERT_CLIP_ADJ` | `0x40000000` | vertical guard-band clip adjust (2.0) |
| `PA_CL_GB_VERT_DISC_ADJ` | `0x3F800000` | vertical guard-band discard adjust (1.0) |
| `PA_CL_GB_HORZ_CLIP_ADJ` | `0x40000000` | horizontal guard-band clip adjust (2.0) |
| `PA_CL_GB_HORZ_DISC_ADJ` | `0x3F800000` | horizontal guard-band discard adjust (1.0) |
| `PA_SC_AA_MASK` | `0x0000FFFF` | sample mask (all samples enabled) |

## Where these came from

I read them off the GPU register aperture on a retail console (read-only), then checked each one
against the AMD R6xx/R7xx 3D register reference and the r600g driver in Mesa. r600g programs the same
registers to the same values at context init (guard-band 2.0/1.0, `VGT_MAX_VTX_INDX = 0xFFFF`,
screen scissor to max, stencil masks, point/line defaults, sample mask `0xFFFF`). Where the hardware
read and the driver default line up, it's a real power-on default and not leftover runtime state.

The four guard-band adjust registers are also write-locked on the console (writing `0xFFFFFFFF` or
`0` still reads back `2.0`/`1.0`), which is extra confirmation they're hardwired.

## Left out: tessellation levels

`VGT_HOS_MAX_TESS_LEVEL` and `VGT_HOS_MIN_TESS_LEVEL` reset to `1.0f` too and are writable, but I
left them out. The backends compute the effective factor as `register + 1.0f`, so seeding them with
`1.0f` would shift the effective reset factor. That one's worth a separate change.

## Notes

This only changes the starting value of registers a title reads before writing, so anything that
writes them first is unaffected. It's a data-only change in the constructor and the register names
already exist in `register_table.inc`.
