### PR TITLE
[GPU] Scaled resolve readback through downscale CS

### DIFF
--- a/src/xenia/gpu/command_processor.cc
+++ b/src/xenia/gpu/command_processor.cc
@@ -78,6 +78,20 @@ DEFINE_string(
 UPDATE_from_string(readback_resolve, 2025, 12, 4, 21, "fast");
 
 DEFINE_bool(
+    readback_resolve_half_pixel_offset, false,
+    "When resolution scaling and readback resolve are enabled, resolve "
+    "downscaling keeps one supersample out of each scaled pixel block.\n"
+    "This selects the center of the block instead of the top-left corner, "
+    "which can be closer to where the GPU would have sampled the original "
+    "pixel, and can help with thin features and edge coverage.\n"
+    "Both choices give a real rendered value, but they can disagree where "
+    "geometry edges fall inside a pixel block.\n"
+    "This matters when the CPU reads the resolve as data instead of an image, "
+    "such as for gamma correction readbacks, occlusion checks, and GPU buffers "
+    "reused later in the frame.",
+    "GPU");
+
+DEFINE_bool(
     readback_memexport, false,
     "Read data written by memory export in shaders on the CPU. "
     "This may be needed in some games (but many only access exported data on "

--- a/src/xenia/gpu/d3d12/d3d12_command_processor.cc
+++ b/src/xenia/gpu/d3d12/d3d12_command_processor.cc
@@ -40,6 +40,7 @@ DEFINE_bool(d3d12_submit_on_primary_buffer_end, true,
             "D3D12");
 
 DECLARE_bool(clear_memory_page_state);
+DECLARE_bool(readback_resolve_half_pixel_offset);
 
 namespace xe {
 namespace gpu {
@@ -53,6 +54,7 @@ namespace shaders {
 #include "xenia/gpu/shaders/bytecode/d3d12_5_1/apply_gamma_table_fxaa_luma_cs.h"
 #include "xenia/gpu/shaders/bytecode/d3d12_5_1/fxaa_cs.h"
 #include "xenia/gpu/shaders/bytecode/d3d12_5_1/fxaa_extreme_cs.h"
+#include "xenia/gpu/shaders/bytecode/d3d12_5_1/resolve_downscale_cs.h"
 }  // namespace shaders
 
 D3D12CommandProcessor::D3D12CommandProcessor(
@@ -1435,6 +1437,93 @@ bool D3D12CommandProcessor::SetupContext() {
     return false;
   }
 
+  // Initialize the resolve downscale compute pipeline for scaled resolution
+  // readback.
+  {
+    D3D12_ROOT_PARAMETER resolve_downscale_root_parameters[UINT(
+        ResolveDownscaleRootParameter::kCount)];
+    {
+      D3D12_ROOT_PARAMETER& resolve_downscale_root_parameter_constants =
+          resolve_downscale_root_parameters[UINT(
+              ResolveDownscaleRootParameter::kConstants)];
+      resolve_downscale_root_parameter_constants.ParameterType =
+          D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS;
+      resolve_downscale_root_parameter_constants.Constants.ShaderRegister = 0;
+      resolve_downscale_root_parameter_constants.Constants.RegisterSpace = 0;
+      resolve_downscale_root_parameter_constants.Constants.Num32BitValues =
+          sizeof(ResolveDownscaleConstants) / sizeof(uint32_t);
+      resolve_downscale_root_parameter_constants.ShaderVisibility =
+          D3D12_SHADER_VISIBILITY_ALL;
+    }
+    D3D12_DESCRIPTOR_RANGE resolve_downscale_root_descriptor_range_source;
+    resolve_downscale_root_descriptor_range_source.RangeType =
+        D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+    resolve_downscale_root_descriptor_range_source.NumDescriptors = 1;
+    resolve_downscale_root_descriptor_range_source.BaseShaderRegister = 0;
+    resolve_downscale_root_descriptor_range_source.RegisterSpace = 0;
+    resolve_downscale_root_descriptor_range_source
+        .OffsetInDescriptorsFromTableStart = 0;
+    {
+      D3D12_ROOT_PARAMETER& resolve_downscale_root_parameter_source =
+          resolve_downscale_root_parameters[UINT(
+              ResolveDownscaleRootParameter::kSource)];
+      resolve_downscale_root_parameter_source.ParameterType =
+          D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+      resolve_downscale_root_parameter_source.DescriptorTable
+          .NumDescriptorRanges = 1;
+      resolve_downscale_root_parameter_source.DescriptorTable
+          .pDescriptorRanges = &resolve_downscale_root_descriptor_range_source;
+      resolve_downscale_root_parameter_source.ShaderVisibility =
+          D3D12_SHADER_VISIBILITY_ALL;
+    }
+    D3D12_DESCRIPTOR_RANGE resolve_downscale_root_descriptor_range_dest;
+    resolve_downscale_root_descriptor_range_dest.RangeType =
+        D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
+    resolve_downscale_root_descriptor_range_dest.NumDescriptors = 1;
+    resolve_downscale_root_descriptor_range_dest.BaseShaderRegister = 0;
+    resolve_downscale_root_descriptor_range_dest.RegisterSpace = 0;
+    resolve_downscale_root_descriptor_range_dest
+        .OffsetInDescriptorsFromTableStart = 0;
+    {
+      D3D12_ROOT_PARAMETER& resolve_downscale_root_parameter_dest =
+          resolve_downscale_root_parameters[UINT(
+              ResolveDownscaleRootParameter::kDestination)];
+      resolve_downscale_root_parameter_dest.ParameterType =
+          D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+      resolve_downscale_root_parameter_dest.DescriptorTable
+          .NumDescriptorRanges = 1;
+      resolve_downscale_root_parameter_dest.DescriptorTable.pDescriptorRanges =
+          &resolve_downscale_root_descriptor_range_dest;
+      resolve_downscale_root_parameter_dest.ShaderVisibility =
+          D3D12_SHADER_VISIBILITY_ALL;
+    }
+    D3D12_ROOT_SIGNATURE_DESC resolve_downscale_root_signature_desc;
+    resolve_downscale_root_signature_desc.NumParameters =
+        UINT(ResolveDownscaleRootParameter::kCount);
+    resolve_downscale_root_signature_desc.pParameters =
+        resolve_downscale_root_parameters;
+    resolve_downscale_root_signature_desc.NumStaticSamplers = 0;
+    resolve_downscale_root_signature_desc.pStaticSamplers = nullptr;
+    resolve_downscale_root_signature_desc.Flags =
+        D3D12_ROOT_SIGNATURE_FLAG_NONE;
+    *(resolve_downscale_root_signature_.ReleaseAndGetAddressOf()) =
+        ui::d3d12::util::CreateRootSignature(
+            provider, resolve_downscale_root_signature_desc);
+    if (!resolve_downscale_root_signature_) {
+      XELOGE("Failed to create the resolve downscale root signature");
+      return false;
+    }
+    *(resolve_downscale_pipeline_.ReleaseAndGetAddressOf()) =
+        ui::d3d12::util::CreateComputePipeline(
+            device, shaders::resolve_downscale_cs,
+            sizeof(shaders::resolve_downscale_cs),
+            resolve_downscale_root_signature_.Get());
+    if (!resolve_downscale_pipeline_) {
+      XELOGE("Failed to create the resolve downscale compute pipeline");
+      return false;
+    }
+  }
+
   if (bindless_resources_used_) {
     // Create the system bindless descriptors once all resources are
     // initialized.
@@ -1602,6 +1691,11 @@ void D3D12CommandProcessor::ShutdownContext() {
 
   fxaa_source_texture_submission_ = 0;
   fxaa_source_texture_.Reset();
+
+  resolve_downscale_buffer_.Reset();
+  resolve_downscale_buffer_size_ = 0;
+  resolve_downscale_pipeline_.Reset();
+  resolve_downscale_root_signature_.Reset();
 
   fxaa_extreme_pipeline_.Reset();
   fxaa_pipeline_.Reset();
@@ -3072,119 +3166,290 @@ bool D3D12CommandProcessor::IssueCopy() {
 XE_NOINLINE
 bool D3D12CommandProcessor::IssueCopy_ReadbackResolvePath() {
   uint32_t written_address, written_length;
-  if (render_target_cache_->Resolve(*memory_, *shared_memory_, *texture_cache_,
-                                    written_address, written_length)) {
-    if (!texture_cache_->IsDrawResolutionScaled() && written_length) {
-      // Early check: if destination memory is not accessible, skip all the
-      // expensive GPU readback work.
-      VirtualHeap* physical_heap = memory_->GetPhysicalHeap();
-      bool memory_accessible = false;
-      if (physical_heap) {
-        HeapAllocationInfo alloc_info;
-        if (physical_heap->QueryRegionInfo(written_address, &alloc_info) &&
-            (alloc_info.state & kMemoryAllocationCommit) &&
-            (alloc_info.protect & kMemoryProtectWrite)) {
-          uint32_t end_address = written_address + written_length;
-          uint32_t region_end =
-              alloc_info.base_address + alloc_info.region_size;
-          if (end_address <= region_end) {
-            memory_accessible = true;
-          }
-        }
-      }
+  reg::RB_COPY_DEST_INFO copy_dest_info;
+  if (!render_target_cache_->Resolve(*memory_, *shared_memory_, *texture_cache_,
+                                     written_address, written_length,
+                                     &copy_dest_info)) {
+    return false;
+  }
+  if (!written_length) {
+    return true;
+  }
 
-      if (!memory_accessible) {
-        // Destination memory not accessible, skip readback entirely
-        return true;
-      }
-
-      // Create a key for this specific resolve operation
-      uint64_t resolve_key =
-          MakeReadbackResolveKey(written_address, written_length);
-      ReadbackBuffer& rb = readback_buffers_[resolve_key];
-      rb.last_used_frame = frame_current_;
-
-      uint32_t write_index = rb.current_index;
-      uint32_t size = AlignReadbackBufferSize(written_length);
-
-      // Allocate/resize write buffer if needed
-      if (size > rb.sizes[write_index]) {
-        const ui::d3d12::D3D12Provider& provider = GetD3D12Provider();
-        ID3D12Device* device = provider.GetDevice();
-        D3D12_RESOURCE_DESC buffer_desc;
-        ui::d3d12::util::FillBufferResourceDesc(buffer_desc, size,
-                                                D3D12_RESOURCE_FLAG_NONE);
-        ID3D12Resource* buffer;
-        if (SUCCEEDED(device->CreateCommittedResource(
-                &ui::d3d12::util::kHeapPropertiesReadback,
-                provider.GetHeapFlagCreateNotZeroed(), &buffer_desc,
-                D3D12_RESOURCE_STATE_COPY_DEST, nullptr,
-                IID_PPV_ARGS(&buffer)))) {
-          if (rb.buffers[write_index] != nullptr) {
-            rb.buffers[write_index]->Release();
-          }
-          rb.buffers[write_index] = buffer;
-          rb.sizes[write_index] = size;
-        } else {
-          XELOGE("Failed to create a {} MB readback buffer", size >> 20);
-          return true;
-        }
-      }
-
-      // Copy resolved data to current frame's buffer
-      shared_memory_->UseAsCopySource();
-      SubmitBarriers();
-      ID3D12Resource* shared_memory_buffer = shared_memory_->GetBuffer();
-      deferred_command_list_.D3DCopyBufferRegion(
-          rb.buffers[write_index], 0, shared_memory_buffer, written_address,
-          written_length);
-
-      ReadbackResolveMode readback_mode = GetReadbackResolveMode();
-      bool use_delayed_sync = (readback_mode == ReadbackResolveMode::kFast);
-      uint32_t read_index = write_index;
-
-      if (use_delayed_sync) {
-        // Use previous frame's data (avoid stall)
-        read_index = 1 - write_index;
-      } else {
-        // Wait for GPU to finish (accurate but slow)
-        if (!AwaitAllQueueOperationsCompletion()) {
-          return true;
-        }
-      }
-
-      // Read from the appropriate buffer
-      ID3D12Resource* read_source = rb.buffers[read_index];
-
-      // If using delayed sync but previous buffer doesn't exist, use current
-      // buffer with sync as fallback
-      if (use_delayed_sync &&
-          (read_source == nullptr || written_length > rb.sizes[read_index])) {
-        read_source = rb.buffers[write_index];
-        read_index = write_index;
-        if (!AwaitAllQueueOperationsCompletion()) {
-          return true;
-        }
-      }
-
-      if (read_source != nullptr && written_length <= rb.sizes[read_index]) {
-        D3D12_RANGE readback_range;
-        readback_range.Begin = 0;
-        readback_range.End = written_length;
-        void* readback_mapping;
-        if (SUCCEEDED(
-                read_source->Map(0, &readback_range, &readback_mapping))) {
-          // Memory accessibility already checked at the start of this function
-          // chrispy: this memcpy needs to be optimized as much as possible
-          auto physaddr = memory_->TranslatePhysical(written_address);
-          memory::vastcpy(physaddr, (uint8_t*)readback_mapping, written_length);
-          D3D12_RANGE readback_write_range = {};
-          read_source->Unmap(0, &readback_write_range);
-        }
+  // Skip all the GPU readback work if the destination memory isn't writable.
+  VirtualHeap* physical_heap = memory_->GetPhysicalHeap();
+  bool memory_accessible = false;
+  if (physical_heap) {
+    HeapAllocationInfo alloc_info;
+    if (physical_heap->QueryRegionInfo(written_address, &alloc_info) &&
+        (alloc_info.state & kMemoryAllocationCommit) &&
+        (alloc_info.protect & kMemoryProtectWrite)) {
+      uint32_t end_address = written_address + written_length;
+      uint32_t region_end = alloc_info.base_address + alloc_info.region_size;
+      if (end_address <= region_end) {
+        memory_accessible = true;
       }
     }
+  }
+  if (!memory_accessible) {
+    return true;
+  }
+
+  // With resolution scaling, the resolve went to the scaled resolve buffer,
+  // and a compute downscale back to 1x is needed before readback. If any
+  // prerequisite fails, skip the readback - that was previously the behavior
+  // for every scaled resolve.
+  bool is_scaled = texture_cache_->IsDrawResolutionScaled();
+  uint32_t readback_length = written_length;
+  uint32_t downscale_pixel_size_log2 = 0;
+  uint32_t downscale_tile_count = 0;
+  uint64_t downscale_source_offset = 0;
+  ID3D12Resource* downscale_source_buffer = nullptr;
+  if (is_scaled) {
+    // The same destination format and texel size derivation that
+    // GetResolveInfo calculated the written extent with.
+    downscale_pixel_size_log2 =
+        draw_util::GetResolveDownscalePixelSizeLog2(copy_dest_info);
+    if (downscale_pixel_size_log2 > 3) {
+      // 128bpp - not supported by the tiled scaled addressing reversal in the
+      // downscale shader.
+      XELOGGPU(
+          "Skipping readback of a resolution-scaled resolve to a 128bpp "
+          "destination - not supported by the downscale shader");
+      return true;
+    }
+    // The scaled addressing is periodic per guest group - the written extent
+    // must be group-aligned for the reversal to be valid (tiled destinations
+    // are 32x32-tile-aligned, so this normally holds).
+    uint32_t group_bytes_log2 = downscale_pixel_size_log2 <= 2 ? 7 : 6;
+    if (written_address & ((UINT32_C(1) << group_bytes_log2) - 1)) {
+      XELOGGPU(
+          "Skipping readback of a resolution-scaled resolve to 0x{:08X} - the "
+          "destination is not aligned to the scaled addressing group size",
+          written_address);
+      return true;
+    }
+    uint32_t tile_bytes = (32 * 32) << downscale_pixel_size_log2;
+    downscale_tile_count = written_length / tile_bytes;
+    if (!downscale_tile_count) {
+      return true;
+    }
+    if (written_length % tile_bytes) {
+      // Only whole 32x32-texel tiles are downscaled - don't copy a garbage
+      // tail to the guest.
+      readback_length = downscale_tile_count * tile_bytes;
+      XELOGGPU(
+          "Readback of a resolution-scaled resolve to 0x{:08X}: length {} is "
+          "not a multiple of the {}-byte tile, truncating to {}",
+          written_address, written_length, tile_bytes, readback_length);
+    }
+    // The scaled resolve range made current by the render target cache during
+    // the resolve must contain the written extent.
+    uint32_t scale_area = texture_cache_->draw_resolution_scale_x() *
+                          texture_cache_->draw_resolution_scale_y();
+    uint64_t scaled_start = uint64_t(written_address) * scale_area;
+    uint64_t scaled_length = uint64_t(readback_length) * scale_area;
+    uint64_t range_start_scaled =
+        texture_cache_->GetCurrentScaledResolveRangeStartScaled();
+    uint64_t range_length_scaled =
+        texture_cache_->GetCurrentScaledResolveRangeLengthScaled();
+    if (!range_length_scaled || scaled_start < range_start_scaled ||
+        scaled_start + scaled_length >
+            range_start_scaled + range_length_scaled) {
+      XELOGGPU(
+          "Skipping readback of a resolution-scaled resolve to 0x{:08X} - the "
+          "written extent is not within the current scaled resolve range",
+          written_address);
+      return true;
+    }
+    downscale_source_buffer =
+        texture_cache_->GetCurrentScaledResolveBufferResource();
+    if (!downscale_source_buffer) {
+      return true;
+    }
+    downscale_source_offset =
+        scaled_start -
+        texture_cache_->GetCurrentScaledResolveBufferBaseOffset();
+  }
+
+  uint64_t resolve_key =
+      MakeReadbackResolveKey(written_address, written_length);
+  ReadbackBuffer& rb = readback_buffers_[resolve_key];
+  rb.last_used_frame = frame_current_;
+
+  uint32_t write_index = rb.current_index;
+  uint32_t size = AlignReadbackBufferSize(readback_length);
+
+  // Allocate/resize write buffer if needed
+  if (size > rb.sizes[write_index]) {
+    const ui::d3d12::D3D12Provider& provider = GetD3D12Provider();
+    ID3D12Device* device = provider.GetDevice();
+    D3D12_RESOURCE_DESC buffer_desc;
+    ui::d3d12::util::FillBufferResourceDesc(buffer_desc, size,
+                                            D3D12_RESOURCE_FLAG_NONE);
+    ID3D12Resource* buffer;
+    if (SUCCEEDED(device->CreateCommittedResource(
+            &ui::d3d12::util::kHeapPropertiesReadback,
+            provider.GetHeapFlagCreateNotZeroed(), &buffer_desc,
+            D3D12_RESOURCE_STATE_COPY_DEST, nullptr, IID_PPV_ARGS(&buffer)))) {
+      if (rb.buffers[write_index] != nullptr) {
+        rb.buffers[write_index]->Release();
+      }
+      rb.buffers[write_index] = buffer;
+      rb.sizes[write_index] = size;
+    } else {
+      XELOGE("Failed to create a {} MB readback buffer", size >> 20);
+      return true;
+    }
+  }
+
+  ReadbackResolveMode readback_mode = GetReadbackResolveMode();
+  uint32_t read_index = readback_mode == ReadbackResolveMode::kFast
+                            ? 1 - write_index
+                            : write_index;
+  bool read_cache_miss = readback_mode == ReadbackResolveMode::kFast &&
+                         (rb.buffers[read_index] == nullptr ||
+                          readback_length > rb.sizes[read_index]);
+
+  if (is_scaled) {
+    // Scaled path: downscale on the GPU, then copy the 1x data to the
+    // readback buffer.
+    if (size > resolve_downscale_buffer_size_) {
+      const ui::d3d12::D3D12Provider& provider = GetD3D12Provider();
+      ID3D12Device* device = provider.GetDevice();
+      D3D12_RESOURCE_DESC buffer_desc;
+      ui::d3d12::util::FillBufferResourceDesc(
+          buffer_desc, size, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+      ID3D12Resource* buffer;
+      if (SUCCEEDED(device->CreateCommittedResource(
+              &ui::d3d12::util::kHeapPropertiesDefault,
+              provider.GetHeapFlagCreateNotZeroed(), &buffer_desc,
+              D3D12_RESOURCE_STATE_UNORDERED_ACCESS, nullptr,
+              IID_PPV_ARGS(&buffer)))) {
+        // Defer the release of the old buffer - it may still be referenced
+        // by commands recorded for previous resolves.
+        if (resolve_downscale_buffer_) {
+          resources_for_deletion_.emplace_back(
+              GetCurrentSubmission(), resolve_downscale_buffer_.Detach());
+        }
+        resolve_downscale_buffer_.Attach(buffer);
+        resolve_downscale_buffer_size_ = size;
+      } else {
+        XELOGE("Failed to create a {} MB resolve downscale buffer", size >> 20);
+        return true;
+      }
+    }
+
+    ui::d3d12::util::DescriptorCpuGpuHandlePair downscale_descriptors[2];
+    if (!RequestOneUseSingleViewDescriptors(2, downscale_descriptors)) {
+      XELOGE("Failed to allocate descriptors for the resolve downscale");
+      return true;
+    }
+
+    const ui::d3d12::D3D12Provider& provider = GetD3D12Provider();
+    ID3D12Device* device = provider.GetDevice();
+    uint32_t scale_area = texture_cache_->draw_resolution_scale_x() *
+                          texture_cache_->draw_resolution_scale_y();
+    // Both offsets are group-aligned, so they also satisfy the 16-byte raw
+    // view alignment.
+    uint32_t aligned_scaled_length =
+        uint32_t(xe::align<uint64_t>(uint64_t(readback_length) * scale_area,
+                                     D3D12_RAW_UAV_SRV_BYTE_ALIGNMENT));
+    ui::d3d12::util::CreateBufferRawSRV(
+        device, downscale_descriptors[0].first, downscale_source_buffer,
+        aligned_scaled_length, downscale_source_offset);
+    uint32_t aligned_readback_length =
+        xe::align(readback_length, uint32_t(D3D12_RAW_UAV_SRV_BYTE_ALIGNMENT));
+    ui::d3d12::util::CreateBufferRawUAV(device, downscale_descriptors[1].first,
+                                        resolve_downscale_buffer_.Get(),
+                                        aligned_readback_length, 0);
+
+    // The resolve wrote to the scaled resolve buffer via a UAV - transition
+    // it to a shader resource for the downscale.
+    texture_cache_->TransitionCurrentScaledResolveRange(
+        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    SubmitBarriers();
+
+    SetExternalPipeline(resolve_downscale_pipeline_.Get());
+    deferred_command_list_.D3DSetComputeRootSignature(
+        resolve_downscale_root_signature_.Get());
+    ResolveDownscaleConstants downscale_constants;
+    downscale_constants.scale_x = texture_cache_->draw_resolution_scale_x();
+    downscale_constants.scale_y = texture_cache_->draw_resolution_scale_y();
+    downscale_constants.pixel_size_log2 = downscale_pixel_size_log2;
+    downscale_constants.tile_count = downscale_tile_count;
+    // The source SRV is created at the offset of the written extent, so the
+    // shader reads from the start of the bound range.
+    downscale_constants.source_offset_bytes = 0;
+    downscale_constants.half_pixel_offset =
+        uint32_t(cvars::readback_resolve_half_pixel_offset);
+    deferred_command_list_.D3DSetComputeRoot32BitConstants(
+        UINT(ResolveDownscaleRootParameter::kConstants),
+        sizeof(downscale_constants) / sizeof(uint32_t), &downscale_constants,
+        0);
+    deferred_command_list_.D3DSetComputeRootDescriptorTable(
+        UINT(ResolveDownscaleRootParameter::kSource),
+        downscale_descriptors[0].second);
+    deferred_command_list_.D3DSetComputeRootDescriptorTable(
+        UINT(ResolveDownscaleRootParameter::kDestination),
+        downscale_descriptors[1].second);
+    // One thread group per 32x32 tile.
+    deferred_command_list_.D3DDispatch(downscale_tile_count, 1, 1);
+
+    // Copy the downscaled data to the readback buffer.
+    PushTransitionBarrier(resolve_downscale_buffer_.Get(),
+                          D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+                          D3D12_RESOURCE_STATE_COPY_SOURCE);
+    SubmitBarriers();
+    deferred_command_list_.D3DCopyBufferRegion(rb.buffers[write_index], 0,
+                                               resolve_downscale_buffer_.Get(),
+                                               0, readback_length);
+    // Return the buffers to their steady states.
+    PushTransitionBarrier(resolve_downscale_buffer_.Get(),
+                          D3D12_RESOURCE_STATE_COPY_SOURCE,
+                          D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+    texture_cache_->TransitionCurrentScaledResolveRange(
+        D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+    SubmitBarriers();
   } else {
-    return false;
+    // Non-scaled path: copy resolved data from the shared memory to the
+    // current frame's buffer.
+    shared_memory_->UseAsCopySource();
+    SubmitBarriers();
+    ID3D12Resource* shared_memory_buffer = shared_memory_->GetBuffer();
+    deferred_command_list_.D3DCopyBufferRegion(
+        rb.buffers[write_index], 0, shared_memory_buffer, written_address,
+        readback_length);
+  }
+
+  if (readback_mode != ReadbackResolveMode::kFast) {
+    // Wait for GPU to finish (accurate but slow)
+    if (!AwaitAllQueueOperationsCompletion()) {
+      return true;
+    }
+  } else if (read_cache_miss) {
+    // Delayed sync, but the previous buffer doesn't exist - use the current
+    // buffer with a sync as a fallback.
+    read_index = write_index;
+    if (!AwaitAllQueueOperationsCompletion()) {
+      return true;
+    }
+  }
+
+  ID3D12Resource* read_source = rb.buffers[read_index];
+  if (read_source != nullptr && readback_length <= rb.sizes[read_index]) {
+    D3D12_RANGE readback_range;
+    readback_range.Begin = 0;
+    readback_range.End = readback_length;
+    void* readback_mapping;
+    if (SUCCEEDED(read_source->Map(0, &readback_range, &readback_mapping))) {
+      // Memory accessibility already checked at the start of this function
+      // chrispy: this memcpy needs to be optimized as much as possible
+      auto physaddr = memory_->TranslatePhysical(written_address);
+      memory::vastcpy(physaddr, (uint8_t*)readback_mapping, readback_length);
+      D3D12_RANGE readback_write_range = {};
+      read_source->Unmap(0, &readback_write_range);
+    }
   }
   return true;
 }

--- a/src/xenia/gpu/d3d12/d3d12_command_processor.h
+++ b/src/xenia/gpu/d3d12/d3d12_command_processor.h
@@ -755,6 +755,34 @@ class D3D12CommandProcessor final : public CommandProcessor {
   ID3D12Resource* memexport_readback_buffer_ = nullptr;
   uint32_t memexport_readback_buffer_size_ = 0;
 
+  // Resolve downscale compute shader for scaled resolution readback,
+  // reversing the scaled resolve buffer packing back to 1x on the GPU.
+  struct ResolveDownscaleConstants {
+    uint32_t scale_x;          // 1 to kMaxDrawResolutionScaleAlongAxis
+    uint32_t scale_y;          // 1 to kMaxDrawResolutionScaleAlongAxis
+    uint32_t pixel_size_log2;  // 0=8bit, 1=16bit, 2=32bit, 3=64bit
+    uint32_t tile_count;       // Number of 32x32 tiles to process
+    // Byte offset into the source buffer. Always 0 on D3D12 (the offset is
+    // baked into the source SRV). Kept for a shader shared with Vulkan.
+    uint32_t source_offset_bytes;
+    // When non-zero, sample from (scale/2, scale/2) within each scaled block
+    // instead of (0, 0).
+    uint32_t half_pixel_offset;
+  };
+  enum class ResolveDownscaleRootParameter : UINT {
+    kConstants,
+    kSource,
+    kDestination,
+
+    kCount,
+  };
+  Microsoft::WRL::ComPtr<ID3D12RootSignature> resolve_downscale_root_signature_;
+  Microsoft::WRL::ComPtr<ID3D12PipelineState> resolve_downscale_pipeline_;
+  // Intermediate buffer for downscaled output (DEFAULT heap, UAV-capable),
+  // kept in UNORDERED_ACCESS state between resolves.
+  Microsoft::WRL::ComPtr<ID3D12Resource> resolve_downscale_buffer_;
+  uint32_t resolve_downscale_buffer_size_ = 0;
+
   // The current fixed-function drawing state.
   D3D12_VIEWPORT ff_viewport_;
   D3D12_RECT ff_scissor_;

--- a/src/xenia/gpu/d3d12/d3d12_render_target_cache.cc
+++ b/src/xenia/gpu/d3d12/d3d12_render_target_cache.cc
@@ -1294,11 +1294,10 @@ void D3D12RenderTargetCache::WriteEdramUintPow2UAVDescriptor(
       D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 }
 
-bool D3D12RenderTargetCache::Resolve(const Memory& memory,
-                                     D3D12SharedMemory& shared_memory,
-                                     D3D12TextureCache& texture_cache,
-                                     uint32_t& written_address_out,
-                                     uint32_t& written_length_out) {
+bool D3D12RenderTargetCache::Resolve(
+    const Memory& memory, D3D12SharedMemory& shared_memory,
+    D3D12TextureCache& texture_cache, uint32_t& written_address_out,
+    uint32_t& written_length_out, reg::RB_COPY_DEST_INFO* copy_dest_info_out) {
   written_address_out = 0;
   written_length_out = 0;
 
@@ -1311,6 +1310,14 @@ bool D3D12RenderTargetCache::Resolve(const Memory& memory,
           draw_resolution_scale_y(), fixed_16_truncated_to_minus_1_to_1,
           fixed_16_truncated_to_minus_1_to_1, resolve_info)) {
     return false;
+  }
+
+  if (copy_dest_info_out) {
+    // The destination format in it is normalized by GetResolveInfo to the
+    // xenos::TextureFormat actually used for the copy (in particular, the
+    // depth format instead of the raw guest-specified one for depth copies) -
+    // the same value the destination extent was calculated for.
+    *copy_dest_info_out = resolve_info.copy_dest_info;
   }
 
   // Nothing to copy/clear.

--- a/src/xenia/gpu/d3d12/d3d12_render_target_cache.h
+++ b/src/xenia/gpu/d3d12/d3d12_render_target_cache.h
@@ -83,10 +83,14 @@ class D3D12RenderTargetCache final : public RenderTargetCache {
 
   // Performs the resolve to a shared memory area according to the current
   // register values, and also clears the render targets if needed. Must be in a
-  // frame for calling.
+  // frame for calling. copy_dest_info_out, if not null, receives the
+  // destination info with the format normalized to the xenos::TextureFormat
+  // the copy was actually performed with (only meaningful when a nonzero
+  // length was written).
   bool Resolve(const Memory& memory, D3D12SharedMemory& shared_memory,
                D3D12TextureCache& texture_cache, uint32_t& written_address_out,
-               uint32_t& written_length_out);
+               uint32_t& written_length_out,
+               reg::RB_COPY_DEST_INFO* copy_dest_info_out = nullptr);
 
   // Returns true if any downloads were submitted to the command processor.
   bool InitializeTraceSubmitDownloads();

--- a/src/xenia/gpu/d3d12/d3d12_texture_cache.h
+++ b/src/xenia/gpu/d3d12/d3d12_texture_cache.h
@@ -145,6 +145,27 @@ class D3D12TextureCache final : public TextureCache {
     assert_true(IsDrawResolutionScaled());
     GetCurrentScaledResolveBuffer().SetUAVBarrierPending();
   }
+  // The range specified in the last successful MakeScaledResolveRangeCurrent
+  // call, in the scaled physical memory address space.
+  uint64_t GetCurrentScaledResolveRangeStartScaled() const {
+    assert_true(IsDrawResolutionScaled());
+    return scaled_resolve_current_range_start_scaled_;
+  }
+  uint64_t GetCurrentScaledResolveRangeLengthScaled() const {
+    assert_true(IsDrawResolutionScaled());
+    return scaled_resolve_current_range_length_scaled_;
+  }
+  // The resource of the buffer containing the current scaled resolve range,
+  // and the offset of the start of the buffer within the scaled physical
+  // memory address space (the buffer index is also its gigabyte offset).
+  ID3D12Resource* GetCurrentScaledResolveBufferResource() {
+    assert_true(IsDrawResolutionScaled());
+    return GetCurrentScaledResolveBuffer().resource();
+  }
+  uint64_t GetCurrentScaledResolveBufferBaseOffset() const {
+    assert_true(IsDrawResolutionScaled());
+    return uint64_t(GetCurrentScaledResolveBufferIndex()) << 30;
+  }
 
   // Returns the ID3D12Resource of the front buffer texture (in
   // NON_PIXEL_SHADER_RESOURCE state), or nullptr in case of failure, and writes

--- a/src/xenia/gpu/draw_util.cc
+++ b/src/xenia/gpu/draw_util.cc
@@ -1442,6 +1442,16 @@ ResolveCopyShaderIndex ResolveInfo::GetCopyShader(
   return shader;
 }
 
+uint32_t GetResolveDownscalePixelSizeLog2(
+    reg::RB_COPY_DEST_INFO copy_dest_info) {
+  // copy_dest_format holds a xenos::TextureFormat normalized by
+  // GetResolveInfo, and this is the same size derivation that was used for
+  // the destination extent calculation there.
+  const FormatInfo& dest_format_info = *FormatInfo::Get(
+      xenos::TextureFormat(uint32_t(copy_dest_info.copy_dest_format)));
+  return xe::log2_floor(dest_format_info.bits_per_pixel >> 3);
+}
+
 }  // namespace draw_util
 }  // namespace gpu
 }  // namespace xe

--- a/src/xenia/gpu/draw_util.h
+++ b/src/xenia/gpu/draw_util.h
@@ -754,6 +754,13 @@ bool GetResolveInfo(const RegisterFile& regs, const Memory& memory,
                     bool fixed_rgba16_truncated_to_minus_1_to_1,
                     ResolveInfo& info_out);
 
+// Returns log2 of the resolve copy destination texel size in bytes for the
+// destination info previously returned by a render target cache Resolve (with
+// the format already normalized to the actual xenos::TextureFormat) - the same
+// derivation the destination extent was calculated with in GetResolveInfo.
+uint32_t GetResolveDownscalePixelSizeLog2(
+    reg::RB_COPY_DEST_INFO copy_dest_info);
+
 }  // namespace draw_util
 }  // namespace gpu
 }  // namespace xe

--- a/src/xenia/gpu/shaders/resolve_downscale.cs.xesl
+++ b/src/xenia/gpu/shaders/resolve_downscale.cs.xesl
@@ -1,0 +1,176 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2026 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+// Downscales scaled resolve buffer data back to 1x resolution for CPU readback.
+// One thread group processes one 32x32 tile; each thread produces output dwords.
+// Keeps the top-left texel of each scale_x * scale_y block, or its (scale/2,
+// scale/2) center when xe_downscale_half_pixel_offset is set, a pure relocation
+// so the result contains actual render target values, regardless of the
+// destination format, number format or endian.
+//
+// The source is group-packed (XeniaTextureGetResolutionScaledAddressing in
+// texture_address.xesli), not a flat scale_x*scale_y expansion, so this shader
+// reverses that layout per output block. xesl byte buffers are dword-granular
+// with no shared memory, hence the per-output-dword organization.
+
+#include "../../ui/shaders/xesl.xesli"
+
+// Scaled-buffer byte of the chosen supersample of the 1x block at tiled,
+// tile-relative offset tile_rel_bytes. Callers add the intra-block offset.
+uint XeDownscaleScaledBlockByte(uint tile_src_base, uint tile_rel_bytes,
+                                uint pixel_size_log2, uint scale_x,
+                                uint scale_y, uint sample_x, uint sample_y) {
+  // A guest group spans the low 7 tiled-address bits (6 for 64bpp).
+  uint group_size_log2 = (pixel_size_log2 <= 2u) ? 7u : 6u;
+  uint group_index = tile_rel_bytes >> group_size_log2;
+  uint in_group = tile_rel_bytes & ((1u << group_size_log2) - 1u);
+  uint block_index = in_group >> pixel_size_log2;
+
+  uint px;
+  uint py;
+  if (pixel_size_log2 == 0u) {
+    // 1bpp, group 16x8: bits X0 X1 X2 Y1 Y0 Y2 X3.
+    px = (block_index & 7u) | (((block_index >> 6u) & 1u) << 3u);
+    py = ((block_index >> 4u) & 1u) | (((block_index >> 3u) & 1u) << 1u) |
+         (((block_index >> 5u) & 1u) << 2u);
+  } else if (pixel_size_log2 == 1u) {
+    // 2bpp, group 16x4: bits X0 X1 X2 Y0 Y1 X3.
+    px = (block_index & 7u) | (((block_index >> 5u) & 1u) << 3u);
+    py = (block_index >> 3u) & 3u;
+  } else if (pixel_size_log2 == 2u) {
+    // 4bpp, group 16x2: bits X0 X1 Y0 X2 X3.
+    px = (block_index & 3u) | (((block_index >> 3u) & 3u) << 2u);
+    py = (block_index >> 2u) & 1u;
+  } else {
+    // 8bpp, group 4x2: bits X0 Y0 X1.
+    px = (block_index & 1u) | (((block_index >> 2u) & 1u) << 1u);
+    py = (block_index >> 1u) & 1u;
+  }
+
+  // Group dimensions in blocks (XeniaTextureResolutionScaledGroupBlocksLog2).
+  uint group_blocks_x_log2 =
+      (pixel_size_log2 >= 3u) ? (5u - pixel_size_log2) : 4u;
+  uint group_blocks_y_log2 = 3u - min(pixel_size_log2, 2u);
+
+  uint host_x = px * scale_x + sample_x;
+  uint host_y = py * scale_y + sample_y;
+  uint host_group_x = host_x >> group_blocks_x_log2;
+  uint host_group_y = host_y >> group_blocks_y_log2;
+  uint host_group_index = host_group_x * scale_y + host_group_y;
+  uint pos_x = host_x & ((1u << group_blocks_x_log2) - 1u);
+  uint pos_y = host_y & ((1u << group_blocks_y_log2) - 1u);
+  uint group_width_bytes_log2 = group_blocks_x_log2 + pixel_size_log2;
+
+  uint scaled_in_group =
+      (host_group_index << (group_width_bytes_log2 + group_blocks_y_log2)) |
+      (pos_y << group_width_bytes_log2) | (pos_x << pixel_size_log2);
+
+  uint group_size_scaled = (1u << group_size_log2) * (scale_x * scale_y);
+  return tile_src_base + group_index * group_size_scaled + scaled_in_group;
+}
+
+push_const_begin_xe(b0, space0)
+  uint xe_downscale_scale_x;          // 1 to kMaxDrawResolutionScaleAlongAxis
+  uint xe_downscale_scale_y;          // 1 to kMaxDrawResolutionScaleAlongAxis
+  uint xe_downscale_pixel_size_log2;  // 0=8bit, 1=16bit, 2=32bit, 3=64bit
+  uint xe_downscale_tile_count;       // Number of 32x32 tiles to process.
+  uint xe_downscale_source_offset_bytes;  // Byte offset into the source buffer.
+  // When non-zero, sample from (scale/2, scale/2) within each scaled block
+  // instead of (0, 0).
+  uint xe_downscale_half_pixel_offset;
+push_const_end_xe
+
+byte_buffer_align4_declare_xe(xe_downscale_source, set=0, binding=0, t0, space0)
+byte_buffer_align4_wo_declare_xe(xe_downscale_dest, set=1, binding=0, u0, space0)
+
+// 128 threads per group - the recommended size and the Vulkan minimum for
+// maxComputeWorkGroupInvocations. A tile has 256..2048 output dwords depending
+// on the pixel size, so each thread strides over several of them.
+#define LOCAL_SIZE_X_XE 128
+#define LOCAL_SIZE_Y_XE 1
+#define LOCAL_SIZE_Z_XE 1
+entry_bindings_begin_compute_xe
+  push_const_binding_xe(buffer(0))
+  entry_binding_next_xe
+  byte_buffer_binding_xe(xe_downscale_source, buffer(1))
+  entry_binding_next_xe
+  byte_buffer_wo_binding_xe(xe_downscale_dest, buffer(2))
+entry_bindings_end_inputs_begin_compute_xe
+  entry_in_group_id_xe
+  entry_input_next_xe
+  entry_in_local_thread_index_xe
+entry_inputs_end_code_begin_compute_xe
+{
+  uint tile_index = in_group_id_xe.x;
+  if (tile_index >= push_const_xe(xe_downscale_tile_count)) {
+    return;
+  }
+
+  uint pixel_size_log2 = push_const_xe(xe_downscale_pixel_size_log2);
+  uint scale_x = push_const_xe(xe_downscale_scale_x);
+  uint scale_y = push_const_xe(xe_downscale_scale_y);
+  uint scale_xy = scale_x * scale_y;
+  uint tile_size_1x = (32u * 32u) << pixel_size_log2;
+  uint tile_size_scaled = tile_size_1x * scale_xy;
+  // Number of output dwords in a 1x tile (256, 512, 1024 or 2048).
+  uint tile_dwords = tile_size_1x >> 2u;
+
+  // Supersample kept within each block: top-left, or center when requested.
+  uint sample_x = 0u;
+  uint sample_y = 0u;
+  if (push_const_xe(xe_downscale_half_pixel_offset) != 0u && scale_xy > 1u) {
+    sample_x = scale_x >> 1u;
+    sample_y = scale_y >> 1u;
+  }
+
+  uint tile_src_base = push_const_xe(xe_downscale_source_offset_bytes) +
+                       tile_index * tile_size_scaled;
+  uint tile_dst_base = tile_index * tile_size_1x;
+
+  // Stride over the tile's output dwords, 128 per pass.
+  for (uint dword_index = in_local_thread_index_xe; dword_index < tile_dwords;
+       dword_index += 128u) {
+    uint dst_dword_bytes = tile_dst_base + (dword_index << 2u);
+    // Tile-relative 1x byte offset this output dword maps to.
+    uint dword_rel_bytes = dword_index << 2u;
+
+    if (pixel_size_log2 >= 2u) {
+      // 32bpp: one source texel per output dword.
+      // 64bpp: one texel spans two contiguous output dwords.
+      uint dword_offset_bytes =
+          (pixel_size_log2 == 3u) ? (dword_rel_bytes & 4u) : 0u;
+      uint src_bytes = XeDownscaleScaledBlockByte(
+                           tile_src_base, dword_rel_bytes, pixel_size_log2,
+                           scale_x, scale_y, sample_x, sample_y) +
+                       dword_offset_bytes;
+      byte_buffer_align4_store4_xe(
+          xe_downscale_dest, dst_dword_bytes,
+          byte_buffer_align4_load4_xe(xe_downscale_source, src_bytes));
+    } else {
+      // 8bpp/16bpp: consecutive-X texels packed into one output dword.
+      uint texels_per_dword = 4u >> pixel_size_log2;
+      uint bytes_per_block = 1u << pixel_size_log2;
+      uint component_bits = 8u << pixel_size_log2;
+      uint component_mask = (1u << component_bits) - 1u;
+      uint packed = 0u;
+      for (uint texel_index = 0u; texel_index < texels_per_dword;
+           ++texel_index) {
+        uint src_bytes = XeDownscaleScaledBlockByte(
+            tile_src_base, dword_rel_bytes + texel_index * bytes_per_block,
+            pixel_size_log2, scale_x, scale_y, sample_x, sample_y);
+        uint src_word =
+            byte_buffer_align4_load4_xe(xe_downscale_source, src_bytes & ~3u);
+        packed |= ((src_word >> ((src_bytes & 3u) << 3u)) & component_mask)
+                  << (texel_index * component_bits);
+      }
+      byte_buffer_align4_store4_xe(xe_downscale_dest, dst_dword_bytes, packed);
+    }
+  }
+}
+entry_code_end_compute_xe

--- a/src/xenia/gpu/vulkan/vulkan_command_processor.cc
+++ b/src/xenia/gpu/vulkan/vulkan_command_processor.cc
@@ -37,6 +37,7 @@
 #include "xenia/ui/vulkan/vulkan_util.h"
 
 DECLARE_bool(clear_memory_page_state);
+DECLARE_bool(readback_resolve_half_pixel_offset);
 
 namespace xe {
 namespace gpu {
@@ -49,6 +50,7 @@ namespace shaders {
 #include "xenia/gpu/shaders/bytecode/vulkan_spirv/apply_gamma_table_fxaa_luma_ps.h"
 #include "xenia/gpu/shaders/bytecode/vulkan_spirv/apply_gamma_table_ps.h"
 #include "xenia/gpu/shaders/bytecode/vulkan_spirv/fullscreen_cw_vs.h"
+#include "xenia/gpu/shaders/bytecode/vulkan_spirv/resolve_downscale_cs.h"
 }  // namespace shaders
 
 constexpr VkDescriptorPoolSize
@@ -1126,6 +1128,50 @@ bool VulkanCommandProcessor::SetupContext() {
     return false;
   }
 
+  // Initialize the resolve downscale compute pipeline for scaled resolution
+  // readback.
+  {
+    VkDescriptorSetLayout resolve_downscale_descriptor_set_layouts[] = {
+        // Source.
+        GetSingleTransientDescriptorLayout(
+            SingleTransientDescriptorLayout::kStorageBufferCompute),
+        // Destination.
+        GetSingleTransientDescriptorLayout(
+            SingleTransientDescriptorLayout::kStorageBufferCompute),
+    };
+    VkPushConstantRange resolve_downscale_push_constant_range;
+    resolve_downscale_push_constant_range.stageFlags =
+        VK_SHADER_STAGE_COMPUTE_BIT;
+    resolve_downscale_push_constant_range.offset = 0;
+    resolve_downscale_push_constant_range.size =
+        sizeof(ResolveDownscaleConstants);
+    VkPipelineLayoutCreateInfo resolve_downscale_pipeline_layout_create_info;
+    resolve_downscale_pipeline_layout_create_info.sType =
+        VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    resolve_downscale_pipeline_layout_create_info.pNext = nullptr;
+    resolve_downscale_pipeline_layout_create_info.flags = 0;
+    resolve_downscale_pipeline_layout_create_info.setLayoutCount =
+        uint32_t(xe::countof(resolve_downscale_descriptor_set_layouts));
+    resolve_downscale_pipeline_layout_create_info.pSetLayouts =
+        resolve_downscale_descriptor_set_layouts;
+    resolve_downscale_pipeline_layout_create_info.pushConstantRangeCount = 1;
+    resolve_downscale_pipeline_layout_create_info.pPushConstantRanges =
+        &resolve_downscale_push_constant_range;
+    if (dfn.vkCreatePipelineLayout(
+            device, &resolve_downscale_pipeline_layout_create_info, nullptr,
+            &resolve_downscale_pipeline_layout_) != VK_SUCCESS) {
+      XELOGE("Failed to create the resolve downscale pipeline layout");
+      return false;
+    }
+    resolve_downscale_pipeline_ = ui::vulkan::util::CreateComputePipeline(
+        vulkan_device, resolve_downscale_pipeline_layout_,
+        shaders::resolve_downscale_cs, sizeof(shaders::resolve_downscale_cs));
+    if (resolve_downscale_pipeline_ == VK_NULL_HANDLE) {
+      XELOGE("Failed to create the resolve downscale compute pipeline");
+      return false;
+    }
+  }
+
   // Initialize the ZPD occlusion query pool and resources.
   zpd_host_query_pool_ = std::make_unique<VulkanZPDQueryPool>();
   EnsureZPDQueryResources();
@@ -1206,6 +1252,16 @@ void VulkanCommandProcessor::ShutdownContext() {
   ui::vulkan::util::DestroyAndNullHandle(dfn.vkFreeMemory, device,
                                          memexport_readback_buffer_memory_);
   memexport_readback_buffer_size_ = 0;
+
+  ui::vulkan::util::DestroyAndNullHandle(dfn.vkDestroyBuffer, device,
+                                         resolve_downscale_buffer_);
+  ui::vulkan::util::DestroyAndNullHandle(dfn.vkFreeMemory, device,
+                                         resolve_downscale_buffer_memory_);
+  resolve_downscale_buffer_size_ = 0;
+  ui::vulkan::util::DestroyAndNullHandle(dfn.vkDestroyPipeline, device,
+                                         resolve_downscale_pipeline_);
+  ui::vulkan::util::DestroyAndNullHandle(dfn.vkDestroyPipelineLayout, device,
+                                         resolve_downscale_pipeline_layout_);
 
   ui::vulkan::util::DestroyAndNullHandle(
       dfn.vkDestroyDescriptorPool, device,
@@ -2933,17 +2989,22 @@ bool VulkanCommandProcessor::IssueCopy() {
   }
 
   uint32_t written_address, written_length;
+  reg::RB_COPY_DEST_INFO copy_dest_info;
   if (!render_target_cache_->Resolve(*memory_, *shared_memory_, *texture_cache_,
-                                     written_address, written_length)) {
+                                     written_address, written_length,
+                                     &copy_dest_info)) {
     return false;
   }
 
   // CPU readback resolve path (if not disabled).
   ReadbackResolveMode readback_mode = GetReadbackResolveMode();
-  if (readback_mode != ReadbackResolveMode::kDisabled &&
-      !texture_cache_->IsDrawResolutionScaled() && written_length > 0) {
-    // Early check: if destination memory is not accessible, skip all the
-    // expensive GPU readback work.
+  if (readback_mode == ReadbackResolveMode::kDisabled || !written_length) {
+    return true;
+  }
+
+  {
+    // Skip all the GPU readback work if the destination memory isn't
+    // writable.
     VirtualHeap* physical_heap = memory_->GetPhysicalHeap();
     bool memory_accessible = false;
     if (physical_heap) {
@@ -2960,26 +3021,115 @@ bool VulkanCommandProcessor::IssueCopy() {
     }
 
     if (!memory_accessible) {
-      // Destination memory not accessible, skip readback entirely
       return true;
     }
-
-    // Create a key for this specific resolve operation
-    uint64_t resolve_key =
-        MakeReadbackResolveKey(written_address, written_length);
-    ReadbackBuffer& rb = readback_buffers_[resolve_key];
-    rb.last_used_frame = frame_current_;
 
     const ui::vulkan::VulkanDevice* const vulkan_device = GetVulkanDevice();
     const ui::vulkan::VulkanDevice::Functions& dfn = vulkan_device->functions();
     const VkDevice device = vulkan_device->device();
 
+    // With resolution scaling, the resolve went to the scaled resolve buffer,
+    // and a compute downscale back to 1x is needed before readback. If any
+    // prerequisite fails, skip the readback - that was previously the
+    // behavior for every scaled resolve.
+    bool is_scaled = texture_cache_->IsDrawResolutionScaled();
+    uint32_t readback_length = written_length;
+    uint32_t downscale_pixel_size_log2 = 0;
+    uint32_t downscale_tile_count = 0;
+    uint32_t downscale_tile_size_1x = 0;
+    VkDeviceSize downscale_tile_size_scaled = 0;
+    VkBuffer downscale_source_buffer = VK_NULL_HANDLE;
+    VkDeviceSize downscale_source_bind_offset = 0;
+    uint32_t downscale_source_offset_remainder = 0;
+    if (is_scaled) {
+      // The same destination format and texel size derivation that
+      // GetResolveInfo calculated the written extent with.
+      downscale_pixel_size_log2 =
+          draw_util::GetResolveDownscalePixelSizeLog2(copy_dest_info);
+      if (downscale_pixel_size_log2 > 3) {
+        // 128bpp - not supported by the tiled scaled addressing reversal in
+        // the downscale shader.
+        XELOGGPU(
+            "Skipping readback of a resolution-scaled resolve to a 128bpp "
+            "destination - not supported by the downscale shader");
+        return true;
+      }
+      // The scaled addressing is periodic per guest group - the written
+      // extent must be group-aligned for the reversal to be valid (tiled
+      // destinations are 32x32-tile-aligned, so this normally holds).
+      uint32_t group_bytes_log2 = downscale_pixel_size_log2 <= 2 ? 7 : 6;
+      if (written_address & ((UINT32_C(1) << group_bytes_log2) - 1)) {
+        XELOGGPU(
+            "Skipping readback of a resolution-scaled resolve to 0x{:08X} - "
+            "the destination is not aligned to the scaled addressing group "
+            "size",
+            written_address);
+        return true;
+      }
+      downscale_tile_size_1x = (32 * 32) << downscale_pixel_size_log2;
+      downscale_tile_count = written_length / downscale_tile_size_1x;
+      if (!downscale_tile_count) {
+        return true;
+      }
+      if (written_length % downscale_tile_size_1x) {
+        // Only whole 32x32-texel tiles are downscaled - don't copy a garbage
+        // tail to the guest.
+        readback_length = downscale_tile_count * downscale_tile_size_1x;
+        XELOGGPU(
+            "Readback of a resolution-scaled resolve to 0x{:08X}: length {} "
+            "is not a multiple of the {}-byte tile, truncating to {}",
+            written_address, written_length, downscale_tile_size_1x,
+            readback_length);
+      }
+      // The scaled resolve range made current by the render target cache
+      // during the resolve must contain the written extent.
+      uint32_t scale_area = texture_cache_->draw_resolution_scale_x() *
+                            texture_cache_->draw_resolution_scale_y();
+      uint64_t scaled_start = uint64_t(written_address) * scale_area;
+      uint64_t scaled_length = uint64_t(readback_length) * scale_area;
+      downscale_tile_size_scaled =
+          VkDeviceSize(downscale_tile_size_1x) * scale_area;
+      uint64_t range_start_scaled =
+          texture_cache_->GetCurrentScaledResolveRangeStartScaled();
+      uint64_t range_length_scaled =
+          texture_cache_->GetCurrentScaledResolveRangeLengthScaled();
+      if (!range_length_scaled || scaled_start < range_start_scaled ||
+          scaled_start + scaled_length >
+              range_start_scaled + range_length_scaled) {
+        XELOGGPU(
+            "Skipping readback of a resolution-scaled resolve to 0x{:08X} - "
+            "the written extent is not within the current scaled resolve "
+            "range",
+            written_address);
+        return true;
+      }
+      downscale_source_buffer = texture_cache_->GetCurrentScaledResolveBuffer();
+      if (downscale_source_buffer == VK_NULL_HANDLE) {
+        return true;
+      }
+      uint64_t source_offset =
+          scaled_start -
+          texture_cache_->GetCurrentScaledResolveBufferBaseOffset();
+      // Storage buffer descriptor offsets must be aligned - pass the
+      // remainder to the shader.
+      VkDeviceSize storage_buffer_offset_alignment =
+          vulkan_device->properties().minStorageBufferOffsetAlignment;
+      downscale_source_bind_offset =
+          source_offset & ~uint64_t(storage_buffer_offset_alignment - 1);
+      downscale_source_offset_remainder =
+          uint32_t(source_offset - downscale_source_bind_offset);
+    }
+
+    uint64_t resolve_key =
+        MakeReadbackResolveKey(written_address, written_length);
+    ReadbackBuffer& rb = readback_buffers_[resolve_key];
+    rb.last_used_frame = frame_current_;
+
     uint32_t write_index = rb.current_index;
-    uint32_t size = AlignReadbackBufferSize(written_length);
+    uint32_t size = AlignReadbackBufferSize(readback_length);
 
     // Allocate/resize write buffer if needed
     if (size > rb.sizes[write_index]) {
-      // Create buffer with TRANSFER_DST usage for copying from GPU.
       VkBufferCreateInfo buffer_info = {};
       buffer_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
       buffer_info.size = size;
@@ -2995,13 +3145,10 @@ bool VulkanCommandProcessor::IssueCopy() {
         return true;
       }
 
-      // Get memory requirements.
       VkMemoryRequirements memory_requirements;
       dfn.vkGetBufferMemoryRequirements(device, new_buffer,
                                         &memory_requirements);
 
-      // Allocate HOST_VISIBLE | HOST_CACHED | HOST_COHERENT memory for
-      // readback.
       const uint32_t memory_type_index = ui::vulkan::util::ChooseMemoryType(
           vulkan_device->memory_types(), memory_requirements.memoryTypeBits,
           ui::vulkan::util::MemoryPurpose::kReadback);
@@ -3029,7 +3176,6 @@ bool VulkanCommandProcessor::IssueCopy() {
         return true;
       }
 
-      // Bind memory to buffer.
       if (dfn.vkBindBufferMemory(device, new_buffer, new_memory, 0) !=
           VK_SUCCESS) {
         XELOGE("VulkanCommandProcessor: Failed to bind readback buffer memory");
@@ -3038,7 +3184,6 @@ bool VulkanCommandProcessor::IssueCopy() {
         return true;
       }
 
-      // Clean up old buffer if exists
       if (rb.buffers[write_index] != VK_NULL_HANDLE) {
         dfn.vkDestroyBuffer(device, rb.buffers[write_index], nullptr);
       }
@@ -3051,27 +3196,208 @@ bool VulkanCommandProcessor::IssueCopy() {
       rb.sizes[write_index] = size;
     }
 
-    VkBuffer shared_memory_buffer = shared_memory_->buffer();
+    uint32_t read_index = readback_mode == ReadbackResolveMode::kFast
+                              ? 1 - write_index
+                              : write_index;
+    bool read_cache_miss = readback_mode == ReadbackResolveMode::kFast &&
+                           (rb.buffers[read_index] == VK_NULL_HANDLE ||
+                            readback_length > rb.sizes[read_index]);
 
-    // Ensure shared memory is ready for transfer.
-    shared_memory_->Use(VulkanSharedMemory::Usage::kRead);
+    if (is_scaled) {
+      // Scaled path: downscale on the GPU, then copy the 1x data to the
+      // readback buffer.
+      if (size > resolve_downscale_buffer_size_) {
+        if (resolve_downscale_buffer_ != VK_NULL_HANDLE) {
+          // The old buffer may still be referenced by commands recorded for
+          // previous resolves - growth is rare, so just await completion.
+          AwaitAllQueueOperationsCompletion();
+          dfn.vkDestroyBuffer(device, resolve_downscale_buffer_, nullptr);
+          dfn.vkFreeMemory(device, resolve_downscale_buffer_memory_, nullptr);
+          resolve_downscale_buffer_ = VK_NULL_HANDLE;
+          resolve_downscale_buffer_memory_ = VK_NULL_HANDLE;
+          resolve_downscale_buffer_size_ = 0;
+        }
+        VkBufferCreateInfo downscale_buffer_info = {};
+        downscale_buffer_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+        downscale_buffer_info.size = size;
+        downscale_buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT |
+                                      VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+        downscale_buffer_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        VkBuffer downscale_buffer;
+        if (dfn.vkCreateBuffer(device, &downscale_buffer_info, nullptr,
+                               &downscale_buffer) != VK_SUCCESS) {
+          XELOGE("Failed to create a {} MB resolve downscale buffer",
+                 size >> 20);
+          return true;
+        }
+        VkMemoryRequirements downscale_memory_requirements;
+        dfn.vkGetBufferMemoryRequirements(device, downscale_buffer,
+                                          &downscale_memory_requirements);
+        const uint32_t downscale_memory_type_index =
+            ui::vulkan::util::ChooseMemoryType(
+                vulkan_device->memory_types(),
+                downscale_memory_requirements.memoryTypeBits,
+                ui::vulkan::util::MemoryPurpose::kDeviceLocal);
+        if (downscale_memory_type_index == UINT32_MAX) {
+          XELOGE("Failed to find memory type for the resolve downscale buffer");
+          dfn.vkDestroyBuffer(device, downscale_buffer, nullptr);
+          return true;
+        }
+        VkMemoryAllocateInfo downscale_memory_info = {};
+        downscale_memory_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+        downscale_memory_info.allocationSize =
+            downscale_memory_requirements.size;
+        downscale_memory_info.memoryTypeIndex = downscale_memory_type_index;
+        VkDeviceMemory downscale_memory;
+        if (dfn.vkAllocateMemory(device, &downscale_memory_info, nullptr,
+                                 &downscale_memory) != VK_SUCCESS) {
+          XELOGE("Failed to allocate resolve downscale buffer memory");
+          dfn.vkDestroyBuffer(device, downscale_buffer, nullptr);
+          return true;
+        }
+        if (dfn.vkBindBufferMemory(device, downscale_buffer, downscale_memory,
+                                   0) != VK_SUCCESS) {
+          XELOGE("Failed to bind resolve downscale buffer memory");
+          dfn.vkFreeMemory(device, downscale_memory, nullptr);
+          dfn.vkDestroyBuffer(device, downscale_buffer, nullptr);
+          return true;
+        }
+        resolve_downscale_buffer_ = downscale_buffer;
+        resolve_downscale_buffer_memory_ = downscale_memory;
+        resolve_downscale_buffer_size_ = size;
+      }
 
-    // Copy GPU buffer → staging buffer.
-    VkBufferCopy copy_region = {};
-    copy_region.srcOffset = written_address;
-    copy_region.dstOffset = 0;
-    copy_region.size = written_length;
+      // The resolve wrote the scaled resolve buffer from a compute shader,
+      // the downscale reads it in a compute shader. The downscale buffer was
+      // last read by a transfer to the readback buffer.
+      PushBufferMemoryBarrier(downscale_source_buffer, 0, VK_WHOLE_SIZE,
+                              VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                              VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                              VK_ACCESS_SHADER_WRITE_BIT,
+                              VK_ACCESS_SHADER_READ_BIT);
+      PushBufferMemoryBarrier(
+          resolve_downscale_buffer_, 0, VK_WHOLE_SIZE,
+          VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+          VK_ACCESS_TRANSFER_READ_BIT, VK_ACCESS_SHADER_WRITE_BIT);
+      SubmitBarriers(true);
 
-    deferred_command_buffer_.CmdVkCopyBuffer(
-        shared_memory_buffer, rb.buffers[write_index], 1, &copy_region);
+      BindExternalComputePipeline(resolve_downscale_pipeline_);
+      ResolveDownscaleConstants downscale_constants;
+      downscale_constants.scale_x = texture_cache_->draw_resolution_scale_x();
+      downscale_constants.scale_y = texture_cache_->draw_resolution_scale_y();
+      downscale_constants.pixel_size_log2 = downscale_pixel_size_log2;
+      downscale_constants.source_offset_bytes =
+          downscale_source_offset_remainder;
+      downscale_constants.half_pixel_offset =
+          uint32_t(cvars::readback_resolve_half_pixel_offset);
+      // Dispatch in chunks of tiles so one bound source range never exceeds
+      // maxStorageBufferRange (at least 128 MB, always far above the offset
+      // alignment remainder).
+      VkDeviceSize max_chunk_source_size =
+          vulkan_device->properties().maxStorageBufferRange -
+          downscale_source_offset_remainder;
+      uint32_t done_tiles = 0;
+      while (done_tiles < downscale_tile_count) {
+        uint32_t chunk_tiles = uint32_t(std::min<uint64_t>(
+            downscale_tile_count - done_tiles,
+            max_chunk_source_size / downscale_tile_size_scaled));
+        if (!chunk_tiles) {
+          XELOGGPU(
+              "Skipping readback of a resolution-scaled resolve to 0x{:08X} - "
+              "one 32x32 tile exceeds maxStorageBufferRange",
+              written_address);
+          return true;
+        }
 
-    bool use_delayed_sync = (readback_mode == ReadbackResolveMode::kFast);
-    uint32_t read_index = write_index;
+        VkDescriptorSet downscale_descriptor_source =
+            AllocateSingleTransientDescriptor(
+                SingleTransientDescriptorLayout::kStorageBufferCompute);
+        VkDescriptorSet downscale_descriptor_dest =
+            AllocateSingleTransientDescriptor(
+                SingleTransientDescriptorLayout::kStorageBufferCompute);
+        if (downscale_descriptor_source == VK_NULL_HANDLE ||
+            downscale_descriptor_dest == VK_NULL_HANDLE) {
+          XELOGE("Failed to allocate descriptors for the resolve downscale");
+          return true;
+        }
+        VkDescriptorBufferInfo downscale_descriptor_buffer_info[2];
+        downscale_descriptor_buffer_info[0].buffer = downscale_source_buffer;
+        downscale_descriptor_buffer_info[0].offset =
+            downscale_source_bind_offset +
+            VkDeviceSize(done_tiles) * downscale_tile_size_scaled;
+        downscale_descriptor_buffer_info[0].range =
+            VkDeviceSize(chunk_tiles) * downscale_tile_size_scaled +
+            downscale_source_offset_remainder;
+        downscale_descriptor_buffer_info[1].buffer = resolve_downscale_buffer_;
+        downscale_descriptor_buffer_info[1].offset =
+            VkDeviceSize(done_tiles) * downscale_tile_size_1x;
+        downscale_descriptor_buffer_info[1].range =
+            VkDeviceSize(chunk_tiles) * downscale_tile_size_1x;
+        VkWriteDescriptorSet downscale_descriptor_writes[2];
+        for (uint32_t i = 0; i < 2; ++i) {
+          VkWriteDescriptorSet& downscale_descriptor_write =
+              downscale_descriptor_writes[i];
+          downscale_descriptor_write.sType =
+              VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+          downscale_descriptor_write.pNext = nullptr;
+          downscale_descriptor_write.dstSet =
+              i ? downscale_descriptor_dest : downscale_descriptor_source;
+          downscale_descriptor_write.dstBinding = 0;
+          downscale_descriptor_write.dstArrayElement = 0;
+          downscale_descriptor_write.descriptorCount = 1;
+          downscale_descriptor_write.descriptorType =
+              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+          downscale_descriptor_write.pImageInfo = nullptr;
+          downscale_descriptor_write.pBufferInfo =
+              &downscale_descriptor_buffer_info[i];
+          downscale_descriptor_write.pTexelBufferView = nullptr;
+        }
+        dfn.vkUpdateDescriptorSets(device, 2, downscale_descriptor_writes, 0,
+                                   nullptr);
 
-    if (use_delayed_sync) {
-      // Use previous frame's data (avoid stall)
-      read_index = 1 - write_index;
+        VkDescriptorSet downscale_descriptor_sets[] = {
+            downscale_descriptor_source,
+            downscale_descriptor_dest,
+        };
+        deferred_command_buffer_.CmdVkBindDescriptorSets(
+            VK_PIPELINE_BIND_POINT_COMPUTE, resolve_downscale_pipeline_layout_,
+            0, uint32_t(xe::countof(downscale_descriptor_sets)),
+            downscale_descriptor_sets, 0, nullptr);
+        downscale_constants.tile_count = chunk_tiles;
+        deferred_command_buffer_.CmdVkPushConstants(
+            resolve_downscale_pipeline_layout_, VK_SHADER_STAGE_COMPUTE_BIT, 0,
+            sizeof(downscale_constants), &downscale_constants);
+        // One thread group per 32x32 tile.
+        deferred_command_buffer_.CmdVkDispatch(chunk_tiles, 1, 1);
+
+        done_tiles += chunk_tiles;
+      }
+
+      // Copy the downscaled data to the readback buffer.
+      PushBufferMemoryBarrier(
+          resolve_downscale_buffer_, 0, VK_WHOLE_SIZE,
+          VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+          VK_ACCESS_SHADER_WRITE_BIT, VK_ACCESS_TRANSFER_READ_BIT);
+      SubmitBarriers(true);
+      VkBufferCopy downscale_copy_region = {};
+      downscale_copy_region.srcOffset = 0;
+      downscale_copy_region.dstOffset = 0;
+      downscale_copy_region.size = readback_length;
+      deferred_command_buffer_.CmdVkCopyBuffer(resolve_downscale_buffer_,
+                                               rb.buffers[write_index], 1,
+                                               &downscale_copy_region);
     } else {
+      shared_memory_->Use(VulkanSharedMemory::Usage::kRead);
+
+      VkBufferCopy copy_region = {};
+      copy_region.srcOffset = written_address;
+      copy_region.dstOffset = 0;
+      copy_region.size = readback_length;
+      deferred_command_buffer_.CmdVkCopyBuffer(
+          shared_memory_->buffer(), rb.buffers[write_index], 1, &copy_region);
+    }
+
+    if (readback_mode != ReadbackResolveMode::kFast) {
       // Wait for GPU to finish (accurate but slow)
       if (!AwaitAllQueueOperationsCompletion()) {
         XELOGE(
@@ -3079,13 +3405,9 @@ bool VulkanCommandProcessor::IssueCopy() {
             "resolve readback");
         return true;
       }
-    }
-
-    // Read from the appropriate buffer
-    // If using delayed sync but previous buffer doesn't exist, use current
-    // buffer with sync as fallback
-    if (use_delayed_sync && (rb.buffers[read_index] == VK_NULL_HANDLE ||
-                             written_length > rb.sizes[read_index])) {
+    } else if (read_cache_miss) {
+      // Delayed sync, but the previous buffer doesn't exist - use the current
+      // buffer with a sync as a fallback.
       read_index = write_index;
       if (!AwaitAllQueueOperationsCompletion()) {
         XELOGE(
@@ -3096,20 +3418,13 @@ bool VulkanCommandProcessor::IssueCopy() {
     }
 
     if (rb.buffers[read_index] != VK_NULL_HANDLE &&
-        written_length <= rb.sizes[read_index]) {
+        readback_length <= rb.sizes[read_index]) {
       void* mapped_data;
-      if (dfn.vkMapMemory(device, rb.memories[read_index], 0, written_length, 0,
-                          &mapped_data) == VK_SUCCESS) {
-        if (mapped_data) {
-          // Memory accessibility already checked at the start of this function
-          uint8_t* dest_ptr = memory_->TranslatePhysical(written_address);
-          memory::vastcpy(dest_ptr, static_cast<uint8_t*>(mapped_data),
-                          written_length);
-        } else {
-          XELOGE(
-              "VulkanCommandProcessor: Failed to map readback buffer "
-              "(mapped_data is null)");
-        }
+      if (dfn.vkMapMemory(device, rb.memories[read_index], 0, readback_length,
+                          0, &mapped_data) == VK_SUCCESS) {
+        // Memory accessibility already checked at the start of this function.
+        memory::vastcpy(memory_->TranslatePhysical(written_address),
+                        static_cast<uint8_t*>(mapped_data), readback_length);
         dfn.vkUnmapMemory(device, rb.memories[read_index]);
       } else {
         XELOGE(

--- a/src/xenia/gpu/vulkan/vulkan_command_processor.h
+++ b/src/xenia/gpu/vulkan/vulkan_command_processor.h
@@ -835,6 +835,29 @@ class VulkanCommandProcessor final : public CommandProcessor {
   VkBuffer memexport_readback_buffer_ = VK_NULL_HANDLE;
   VkDeviceMemory memexport_readback_buffer_memory_ = VK_NULL_HANDLE;
   uint32_t memexport_readback_buffer_size_ = 0;
+
+  // Resolve downscale compute pipeline for scaled resolution readback,
+  // reversing the scaled resolve buffer packing back to 1x on the GPU.
+  // Set 0 - source storage buffer, set 1 - destination storage buffer, both
+  // with the kStorageBufferCompute transient layout.
+  struct ResolveDownscaleConstants {
+    uint32_t scale_x;          // 1 to kMaxDrawResolutionScaleAlongAxis
+    uint32_t scale_y;          // 1 to kMaxDrawResolutionScaleAlongAxis
+    uint32_t pixel_size_log2;  // 0=8bit, 1=16bit, 2=32bit, 3=64bit
+    uint32_t tile_count;       // Number of 32x32 tiles to process
+    // Byte offset of the first tile within the bound source range (the
+    // storage buffer offset alignment remainder).
+    uint32_t source_offset_bytes;
+    // When non-zero, sample from (scale/2, scale/2) within each scaled block
+    // instead of (0, 0).
+    uint32_t half_pixel_offset;
+  };
+  VkPipelineLayout resolve_downscale_pipeline_layout_ = VK_NULL_HANDLE;
+  VkPipeline resolve_downscale_pipeline_ = VK_NULL_HANDLE;
+  // Intermediate device-local buffer for the downscaled output.
+  VkBuffer resolve_downscale_buffer_ = VK_NULL_HANDLE;
+  VkDeviceMemory resolve_downscale_buffer_memory_ = VK_NULL_HANDLE;
+  uint32_t resolve_downscale_buffer_size_ = 0;
 };
 
 }  // namespace vulkan

--- a/src/xenia/gpu/vulkan/vulkan_render_target_cache.cc
+++ b/src/xenia/gpu/vulkan/vulkan_render_target_cache.cc
@@ -1025,11 +1025,10 @@ void VulkanRenderTargetCache::EndSubmission() {
   }
 }
 
-bool VulkanRenderTargetCache::Resolve(const Memory& memory,
-                                      VulkanSharedMemory& shared_memory,
-                                      VulkanTextureCache& texture_cache,
-                                      uint32_t& written_address_out,
-                                      uint32_t& written_length_out) {
+bool VulkanRenderTargetCache::Resolve(
+    const Memory& memory, VulkanSharedMemory& shared_memory,
+    VulkanTextureCache& texture_cache, uint32_t& written_address_out,
+    uint32_t& written_length_out, reg::RB_COPY_DEST_INFO* copy_dest_info_out) {
   written_address_out = 0;
   written_length_out = 0;
 
@@ -1041,6 +1040,14 @@ bool VulkanRenderTargetCache::Resolve(const Memory& memory,
           draw_resolution_scale_y(), IsFixedRG16TruncatedToMinus1To1(),
           IsFixedRGBA16TruncatedToMinus1To1(), resolve_info)) {
     return false;
+  }
+
+  if (copy_dest_info_out) {
+    // The destination format in it is normalized by GetResolveInfo to the
+    // xenos::TextureFormat actually used for the copy (in particular, the
+    // depth format instead of the raw guest-specified one for depth copies) -
+    // the same value the destination extent was calculated for.
+    *copy_dest_info_out = resolve_info.copy_dest_info;
   }
 
   // Nothing to copy/clear.

--- a/src/xenia/gpu/vulkan/vulkan_render_target_cache.h
+++ b/src/xenia/gpu/vulkan/vulkan_render_target_cache.h
@@ -116,10 +116,14 @@ class VulkanRenderTargetCache final : public RenderTargetCache {
 
   // Performs the resolve to a shared memory area according to the current
   // register values, and also clears the render targets if needed. Must be in a
-  // frame for calling.
+  // frame for calling. copy_dest_info_out, if not null, receives the
+  // destination info with the format normalized to the xenos::TextureFormat
+  // the copy was actually performed with (only meaningful when a nonzero
+  // length was written).
   bool Resolve(const Memory& memory, VulkanSharedMemory& shared_memory,
                VulkanTextureCache& texture_cache, uint32_t& written_address_out,
-               uint32_t& written_length_out);
+               uint32_t& written_length_out,
+               reg::RB_COPY_DEST_INFO* copy_dest_info_out = nullptr);
 
   bool Update(bool is_rasterization_done,
               reg::RB_DEPTHCONTROL normalized_depth_control,

--- a/src/xenia/gpu/vulkan/vulkan_texture_cache.h
+++ b/src/xenia/gpu/vulkan/vulkan_texture_cache.h
@@ -181,6 +181,15 @@ class VulkanTextureCache final : public TextureCache {
     return scaled_resolve_current_buffer_index_;
   }
 
+  // The range specified in the last successful MakeScaledResolveRangeCurrent
+  // call, in the scaled physical memory address space.
+  uint64_t GetCurrentScaledResolveRangeStartScaled() const {
+    return scaled_resolve_current_range_start_scaled_;
+  }
+  uint64_t GetCurrentScaledResolveRangeLengthScaled() const {
+    return scaled_resolve_current_range_length_scaled_;
+  }
+
   const ScaledResolveBuffer* GetScaledResolveBufferInfo(size_t index) const {
     if (index < scaled_resolve_buffers_.size()) {
       return &scaled_resolve_buffers_[index];


### PR DESCRIPTION
Implements readback for scaled resolves for both backends, _mostly_ mirroring Edge's approach, with a few small adjustments.

The scaled resolve buffer stores each texel as a group-aligned scale_x by scale_y block. A small CS now reverses that packing per 32x32 tile and writes 1x. So far, this is Edge's approach verbatim.

This slightly diverges from Edge since the source window is now bound at the written extent, not the texture base, and the tail after the last whole tile is no longer copied. Dest format and texel size are from the same ResolveInfo the written extent was calculated with rather than rereading RB_COPY_DEST_INFO. That only matters for depth resolves where the register holds 8_8_8_8-likes. 128bpp dests, extents that aren't group-aligned, and extents outside the scaled range all skip readback.

Was AI used for this PR: No.