### PR TITLE
[XAM/XMP] - Add missing returns

### DIFF
--- a/src/xenia/kernel/xam/apps/xmp_app.cc
+++ b/src/xenia/kernel/xam/apps/xmp_app.cc
@@ -103,6 +103,9 @@ X_HRESULT XmpApp::XMPDeleteTitlePlaylist(uint32_t playlist_handle) {
 X_HRESULT XmpApp::XMPPlayTitlePlaylist(uint32_t playlist_handle,
                                        uint32_t song_handle) {
   XELOGD("XMPPlayTitlePlaylist({:08X}, {:08X})", playlist_handle, song_handle);
+  if (!playlist_handle) {
+    return X_E_INVALIDARG;
+  }
   kernel_state_->emulator()->audio_media_player()->Play(playlist_handle,
                                                         song_handle, false);
   kernel_state_->BroadcastNotification(kXNotificationXmpPlaybackBehaviorChanged,
@@ -297,6 +300,7 @@ X_HRESULT XmpApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
                                     args->storage_ptr);
     }
     case 0x0007000E: {
+      // XMPGetCurrentSong
       assert_true(!buffer_length ||
                   buffer_length == sizeof(XMP_GET_CURRENT_SONG));
       XMP_GET_CURRENT_SONG* args =
@@ -432,9 +436,15 @@ X_HRESULT XmpApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
       XMP_CREATE_USER_PLAYLIST_ENUMERATOR* args =
           reinterpret_cast<XMP_CREATE_USER_PLAYLIST_ENUMERATOR*>(buffer);
 
+      assert_true(args->xmp_client == apu::XMP_CLIENT::Game);
+
       XELOGD("XMPCreateUserPlaylistEnumerator({:08X}, {:08X}, {:08X})",
              uint32_t(args->xmp_client.get()), uint32_t(args->flags),
-             uint32_t(args->object_ptr));
+             uint32_t(args->private_enum_structure_ptr));
+      if (!args->private_enum_structure_ptr ||
+          args->xmp_client != apu::XMP_CLIENT::Game) {
+        return X_E_INVALIDARG;
+      }
       return X_E_SUCCESS;
     }
     case 0x00070029: {
@@ -539,14 +549,18 @@ X_HRESULT XmpApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
       assert_true(!buffer_length || buffer_length == sizeof(XMP_DASH_INIT));
       XMP_DASH_INIT* args = reinterpret_cast<XMP_DASH_INIT*>(buffer);
 
-      assert_true(args->xmp_client == apu::XMP_CLIENT::Game ||
-                  args->xmp_client == apu::XMP_CLIENT::Dash);
+      assert_true(args->xmp_client == apu::XMP_CLIENT::Dash);
       XELOGD(
           "XMPDashInit({:08X}, {:08X}, {:08X}, {:08X}, {:08X}, {:08X}), "
           "unimplemented",
           uint32_t(args->xmp_client.get()), args->buffer_ptr.get(),
           args->buffer_length.get(), args->unk1.get(), args->unk2.get(),
           args->storage_ptr.get());
+
+      if (args->xmp_client != apu::XMP_CLIENT::Dash || !args->storage_ptr ||
+          !args->buffer_ptr) {
+        return X_E_INVALIDARG;
+      }
 
       kernel_state_->BroadcastNotification(kXNotificationXmpDashInitChanged, 1);
       return X_E_SUCCESS;
@@ -604,6 +618,11 @@ X_HRESULT XmpApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
           "unimplemented",
           uint32_t(args->xmp_client.get()), args->workspace_type.get(),
           args->storage_ptr.get(), args->storage_length.get());
+
+      if (args->xmp_client > apu::XMP_CLIENT::Game ||
+          !args->storage_ptr && args->workspace_type != 3) {
+        return X_E_INVALIDARG;
+      }
       return X_E_SUCCESS;
     }
     case 0x00070053: {

--- a/src/xenia/kernel/xam/apps/xmp_app.h
+++ b/src/xenia/kernel/xam/apps/xmp_app.h
@@ -56,6 +56,14 @@ struct XMP_SONGDESCRIPTOR {
 };
 static_assert_size(XMP_SONGDESCRIPTOR, 36);
 
+struct XMP_UNK_SONG_STRUCT {
+  xe::be<uint32_t> unk1;  // 0x0 - 1
+  uint8_t data1[0x2C];    // 0x4
+  xe::be<uint32_t> unk2;  // 0x30 - 3
+  uint8_t unknown[0x460];
+};
+static_assert_size(XMP_UNK_SONG_STRUCT, 0x494);
+
 constexpr uint32_t kMaxXmpMetadataStringLength = 40;
 
 struct XMP_SONGINFO {
@@ -73,6 +81,15 @@ struct XMP_SONGINFO {
   xe::be<uint32_t> unknown_1;
 };
 static_assert_size(XMP_SONGINFO, 0x3E0);
+
+struct MSAL_MEDIASOURCEINFO {
+  uint8_t data1[0x28];     // 0x0
+  xe::be<uint32_t> unkn1;  // 0x28 - 1, 6, 7
+  xe::be<uint32_t> unkn2;  // 0x2C - 2, flag?
+  xe::be<uint32_t> unkn3;  // 0x30 - 1, 5
+  uint8_t unknown[0x80];   // 0x34
+};
+static_assert_size(MSAL_MEDIASOURCEINFO, 0xB4);
 
 struct XMP_PLAY_TITLE_PLAYLIST {
   xe::be<apu::XMP_CLIENT> xmp_client;
@@ -128,8 +145,8 @@ static_assert_size(XMP_CREATE_TITLE_PLAYLIST, 0x24);
 
 struct XMP_GET_CURRENT_SONG {
   xe::be<apu::XMP_CLIENT> xmp_client;
-  xe::be<uint32_t> unk_ptr;
-  xe::be<uint32_t> info_ptr;
+  xe::be<uint32_t> unk_ptr;   // XMP_UNK_SONG_STRUCT
+  xe::be<uint32_t> info_ptr;  // XMP_SONGINFO
 };
 static_assert_size(XMP_GET_CURRENT_SONG, 0xC);
 
@@ -156,7 +173,7 @@ static_assert_size(XMP_GET_PLAYBACK_CONTROLLER, 0xC);
 struct XMP_CREATE_USER_PLAYLIST_ENUMERATOR {
   xe::be<apu::XMP_CLIENT> xmp_client;
   xe::be<uint32_t> flags;
-  xe::be<uint32_t> object_ptr;
+  xe::be<uint32_t> private_enum_structure_ptr;
 };
 static_assert_size(XMP_CREATE_USER_PLAYLIST_ENUMERATOR, 0xC);
 


### PR DESCRIPTION
- Add missing returns for XMPPlayTitlePlaylist, XMPCreateUserPlaylistEnumerator, XMPDashInit, & XMPSetMediaSourceWorkspace
- Add MSAL_MEDIASOURCEINFO struct