### PR TITLE
Add opt-in UI localization system + Italian translation

### DIFF
--- a/assets/locale/it.toml
+++ b/assets/locale/it.toml
@@ -1,0 +1,242 @@
+# Traduzione italiana dell'interfaccia di Xenia Canary (bozza/proposta).
+#
+# Formato: "testo inglese originale" = "traduzione italiana"
+# - La chiave a sinistra DEVE corrispondere esattamente alla stringa inglese
+#   usata nel codice (compresi eventuali segnaposto {}/{:08X}/%s, che vanno
+#   riportati identici anche nella traduzione, senza tradurli).
+# - Il carattere & indica la lettera dell'acceleratore da tastiera
+#   (es. Alt+F apre il menu "&File"); nella traduzione va messo prima della
+#   lettera italiana scelta come scorciatoia.
+# - Le voci NON presenti in questo file restano automaticamente in inglese.
+
+# --- Menu principale --------------------------------------------------------
+"&File" = "&File"
+"&Open Recent" = "Apri &recenti"
+"&Zar Package" = "Pacchetto &Zar"
+"&Open..." = "&Apri..."
+"Install Content..." = "Installa contenuto..."
+"Create" = "Crea"
+"Extract" = "Estrai"
+"Close" = "Chiudi"
+"Show content directory..." = "Mostra cartella dei contenuti..."
+"E&xit" = "&Esci"
+
+"&Profile" = "&Profilo"
+"&Show Profile Menu" = "&Mostra menu profilo"
+
+"&CPU" = "&CPU"
+"&Reset Time Scalar" = "&Ripristina scala temporale"
+"Time Scalar /= 2" = "Scala temporale /= 2"
+"Time Scalar *= 2" = "Scala temporale *= 2"
+"Toggle Profiler &Display" = "Mostra/nascondi &display profiler"
+"&Pause/Resume Profiler" = "&Pausa/Riprendi profiler"
+"&Break and Show Guest Debugger" = "&Interrompi e mostra debugger guest"
+"&Break into Host Debugger" = "Interrompi nel de&bugger host"
+
+"&GPU" = "&GPU"
+"&Trace Frame" = "&Traccia fotogramma"
+"&Clear Runtime Caches" = "&Svuota cache di runtime"
+
+"&Display" = "&Schermo"
+"&Post-processing settings" = "Impostazioni &post-elaborazione"
+"&Fullscreen" = "&Schermo intero"
+"&Take Screenshot" = "&Cattura schermata"
+
+"&HID" = "&HID"
+"&Toggle controller vibration" = "&Attiva/disattiva vibrazione controller"
+"&Display controller hotkeys" = "Mostra &scorciatoie controller"
+
+"&XMP" = "&XMP"
+"&Show XMP Menu" = "&Mostra menu XMP"
+
+"&Console" = "&Console"
+"&Open console settings" = "&Apri impostazioni console"
+
+"&Help" = "&Aiuto"
+"FA&Q..." = "Domande fre&quenti..."
+"Game &compatibility..." = "&Compatibilità dei giochi..."
+"Build commit on GitHub..." = "Commit di build su GitHub..."
+"Recent changes on GitHub..." = "Modifiche recenti su GitHub..."
+"&About..." = "&Informazioni su..."
+
+# --- Notifiche e finestre di dialogo generiche ------------------------------
+"Screenshot Created!" = "Schermata creata!"
+"Screenshot saved: {}" = "Schermata salvata: {}"
+"Xenia Debugger" = "Debugger di Xenia"
+"Xenia must be launched with the --debug flag in order to enable debugging." = "Xenia deve essere avviato con il flag --debug per abilitare il debug."
+"Title Launch Failed!" = "Avvio del titolo non riuscito!"
+"Failed to launch title path is {}." = "Avvio del titolo non riuscito: il percorso è {}."
+"empty" = "vuoto"
+"invalid" = "non valido"
+"\nProvided Path: {}" = "\nPercorso fornito: {}"
+"Unsupported format!\nXenia does not support running software in an archived format." = "Formato non supportato!\nXenia non supporta l'esecuzione di software in formato archiviato."
+"Failed to launch title.\n\nCheck xenia.log for technical details." = "Avvio del titolo non riuscito.\n\nConsulta xenia.log per i dettagli tecnici."
+
+# --- Impostazioni console ----------------------------------------------------
+"Console settings" = "Impostazioni console"
+"User" = "Utente"
+"Time" = "Ora"
+"Disable Daylight-Saving Time" = "Disattiva ora legale"
+"24H Time" = "Formato 24 ore"
+"Locale" = "Lingua e paese"
+"Language" = "Lingua"
+"Country" = "Paese"
+"Profile" = "Profilo"
+"Default Profile" = "Profilo predefinito"
+"Parental Control" = "Controllo genitori"
+"Retail Options" = "Opzioni retail"
+"Dashboard Initialized" = "Dashboard inizializzata"
+"IPTV Initialized" = "IPTV inizializzato"
+"DVR Initialized" = "DVR inizializzato"
+"Kinect Initialized" = "Kinect inizializzato"
+"System" = "Sistema"
+"Video Options" = "Opzioni video"
+"AV Region" = "Regione AV"
+"Widescreen" = "Widescreen"
+"Audio Options" = "Opzioni audio"
+"Mono" = "Mono"
+"Dolby Pro Logic" = "Dolby Pro Logic"
+"Dolby Digital" = "Dolby Digital"
+"Dolby Digital WMA PRO" = "Dolby Digital WMA PRO"
+"Low Latency (unsupported)" = "Bassa latenza (non supportata)"
+"Audio player volume" = "Volume lettore musicale"
+"Network" = "Rete"
+"MAC Address: " = "Indirizzo MAC: "
+"Network ID: " = "ID di rete: "
+"Resolution" = "Risoluzione"
+"Timezone" = "Fuso orario"
+"Save" = "Salva"
+"Settings Saved!" = "Impostazioni salvate!"
+"Reset" = "Ripristina"
+
+# --- Profili -----------------------------------------------------------------
+"No Profiles Found" = "Nessun profilo trovato"
+"There is no profile available! You will not be able to save without one.\n\nWould you like to create one?" = "Non è disponibile alcun profilo! Non potrai salvare senza uno.\n\nVuoi crearne uno?"
+"Create Profile" = "Crea profilo"
+"Create profile & migrate data" = "Crea profilo e migra i dati"
+"Open profile menu" = "Apri menu profili"
+
+"Profiles Menu" = "Menu profili"
+"No profiles found!" = "Nessun profilo trovato!"
+"Profile Menu" = "Menu profilo"
+"Login" = "Accedi"
+"Login to slot:" = "Accedi allo slot:"
+"slot {}" = "slot {}"
+"Logout" = "Esci"
+"Modify" = "Modifica"
+"Show Played Titles" = "Mostra titoli giocati"
+"Show Content Directory" = "Mostra cartella contenuti"
+"Delete Profile" = "Elimina profilo"
+"You're about to delete profile: {} (XUID: {:016X}). This will remove all data assigned to this profile including savefiles. Are you sure?" = "Stai per eliminare il profilo: {} (XUID: {:016X}). Verranno rimossi tutti i dati assegnati a questo profilo, compresi i salvataggi. Sei sicuro?"
+"Yes, delete it!" = "Sì, eliminalo!"
+
+"Gamertag:" = "Gamertag:"
+"Cancel" = "Annulla"
+
+# --- Accesso (SigninUI) -------------------------------------------------------
+"Sign In" = "Accedi"
+"OK" = "OK"
+
+# --- Codice di accesso (PasscodeUI) ------------------------------------------
+"Enter Pass Code" = "Inserisci codice di accesso"
+"Enter your Xbox LIVE pass code." = "Inserisci il tuo codice di accesso Xbox LIVE."
+
+# --- Elenco titoli / achievement ---------------------------------------------
+"{}'s Games List###{}" = "Giochi di {}###{}"
+"Search: " = "Cerca: "
+"There are no titles, so far." = "Non ci sono ancora titoli."
+"Last played: {:%Y-%m-%d %H:%M}" = "Ultima sessione: {:%Y-%m-%d %H:%M}"
+"Last played: Unknown" = "Ultima sessione: sconosciuta"
+"Title Menu {:08X}" = "Menu titolo {:08X}"
+"Open savefile directory" = "Apri cartella salvataggi"
+"Open DLC directory" = "Apri cartella DLC"
+"Open Title Update directory" = "Apri cartella aggiornamenti titolo"
+"Refresh title stats" = "Aggiorna statistiche titolo"
+"Delete title" = "Elimina titolo"
+
+"{} Achievements###{}" = "Obiettivi di {}###{}"
+"Show locked achievements information" = "Mostra informazioni sugli obiettivi bloccati"
+"No achievements data!" = "Nessun dato sugli obiettivi!"
+"Secret trophy" = "Trofeo segreto"
+"Hidden description" = "Descrizione nascosta"
+"Unlocked: Online {:%Y-%m-%d %H:%M}" = "Sbloccato: online {:%Y-%m-%d %H:%M}"
+"Unlocked: Offline ({:%Y-%m-%d %H:%M})" = "Sbloccato: offline ({:%Y-%m-%d %H:%M})"
+"Unlocked: Offline" = "Sbloccato: offline"
+
+# --- Finestra "Post-processing" (impostazioni grafiche) ----------------------
+"Post-processing" = "Post-elaborazione"
+"All effects can be used on GPUs of any brand." = "Tutti gli effetti possono essere usati su GPU di qualsiasi marca."
+"None" = "Nessuno"
+"NVIDIA Fast Approximate Anti-Aliasing (FXAA) [Normal Quality]" = "NVIDIA Fast Approximate Anti-Aliasing (FXAA) [Qualità normale]"
+"NVIDIA Fast Approximate Anti-Aliasing (FXAA) [Extreme Quality]" = "NVIDIA Fast Approximate Anti-Aliasing (FXAA) [Qualità estrema]"
+"Resampling and sharpening" = "Ricampionamento e nitidezza"
+"None / Bilinear" = "Nessuno / Bilineare"
+"Simple bilinear filtering is done if resampling is needed.\nOtherwise, only anti-aliasing is done if enabled, or displaying as is." = "Se serve ricampionare, viene applicato un semplice filtro bilineare.\nAltrimenti viene eseguito solo l'anti-aliasing, se attivo, oppure l'immagine è mostrata così com'è."
+"Sharpening and resampling to up to 2x2 to improve the fidelity of details.\nFor scaling by more than 2x2, bilinear stretching is done afterwards." = "Nitidezza e ricampionamento fino a 2x2 per migliorare la fedeltà dei dettagli.\nPer ingrandimenti superiori a 2x2, viene applicato successivamente uno stiramento bilineare."
+"High-quality edge-preserving upscaling to arbitrary target resolutions.\nFor scaling by more than 2x2, multiple upsampling passes are done.\nIf not upscaling, Contrast Adaptive Sharpening (CAS) is used instead." = "Upscaling di alta qualità che preserva i bordi, verso qualsiasi risoluzione di destinazione.\nPer ingrandimenti superiori a 2x2 vengono eseguiti più passaggi di upsampling.\nSe non si esegue upscaling, viene usato invece il Contrast Adaptive Sharpening (CAS)."
+"FXAA is highly recommended when using CAS or FSR." = "FXAA è vivamente consigliato quando si usa CAS o FSR."
+"FSR sharpness reduction when upscaling (lower is sharper):" = "Riduzione della nitidezza FSR durante l'upscaling (più basso = più nitido):"
+"CAS additional sharpness when not upscaling (higher is sharper):" = "Nitidezza aggiuntiva CAS quando non si esegue upscaling (più alto = più nitido):"
+"CAS additional sharpness (higher is sharper):" = "Nitidezza aggiuntiva CAS (più alto = più nitido):"
+"Dithering" = "Dithering"
+"Dither the final output to 8bpc to make gradients smoother" = "Applica il dithering all'immagine finale a 8bpc per sfumature più morbide"
+
+# --- Nuova scheda "Interface" nelle impostazioni console --------------------
+"Interface" = "Interfaccia"
+"Xenia Interface Language" = "Lingua dell'interfaccia di Xenia"
+"Dialogs update immediately. The menu bar at the top of the window is only rebuilt on the next launch of Xenia." = "Le finestre di dialogo si aggiornano subito. La barra dei menu in alto viene invece ricostruita solo al prossimo avvio di Xenia."
+"Community-contributed translations may be incomplete: any text without a translation yet is simply shown in English." = "Le traduzioni realizzate dalla community potrebbero essere incomplete: il testo non ancora tradotto viene semplicemente mostrato in inglese."
+"Restart Now" = "Riavvia ora"
+"Couldn't restart Xenia automatically. Please close and reopen it manually to finish applying the new language." = "Non è stato possibile riavviare automaticamente Xenia. Chiudi e riapri il programma manualmente per completare l'applicazione della nuova lingua."
+"Restarts Xenia now so the menu bar picks up the new language too." = "Riavvia subito Xenia in modo che anche la barra dei menu passi alla nuova lingua."
+
+# --- Menu XMP (lettore audio) -------------------------------------------------
+"Audio Player Menu" = "Menu lettore audio"
+"Audio player status:" = "Stato del lettore audio:"
+"Idle" = "Inattivo"
+"Paused" = "In pausa"
+"Playing" = "In riproduzione"
+"Pause" = "Pausa"
+"Resume" = "Riprendi"
+
+# --- Finestra "Controller Hotkeys" -------------------------------------------
+"Controller Hotkeys" = "Scorciatoie controller"
+"Gameplay Hotkeys" = "Scorciatoie di gioco"
+"Readback Resolve: " = "Readback Resolve: "
+"Clear Memory Page State: " = "Azzera stato pagine di memoria: "
+"Controller Hotkeys: " = "Scorciatoie controller: "
+" (Disabled)" = " (Disattivata)"
+"A + Guide = Toggle Readback Resolve" = "A + Guide = Attiva/disattiva Readback Resolve"
+"A + Back = Toggle Readback Resolve" = "A + Back = Attiva/disattiva Readback Resolve"
+"B + Guide = Toggle between loglevel set in config and the 'Disabled' loglevel." = "B + Guide = Passa dal livello di log impostato in configurazione al livello 'Disabled'."
+"B + Back = Toggle between loglevel set in config and the 'Disabled' loglevel." = "B + Back = Passa dal livello di log impostato in configurazione al livello 'Disabled'."
+"Y + Guide = Toggle Fullscreen" = "Y + Guide = Attiva/disattiva schermo intero"
+"Y + Back = Toggle Fullscreen" = "Y + Back = Attiva/disattiva schermo intero"
+"X + Guide = Toggle Clear Memory Page State" = "X + Guide = Attiva/disattiva azzeramento pagine di memoria"
+"X + Back = Toggle Clear Memory Page State" = "X + Back = Attiva/disattiva azzeramento pagine di memoria"
+"Right Shoulder + Guide = Clear GPU Cache" = "Dorsale destro + Guide = Svuota cache GPU"
+"Right Shoulder + Back = Clear GPU Cache" = "Dorsale destro + Back = Svuota cache GPU"
+"Left Shoulder + Guide = Toggle Controller Vibration" = "Dorsale sinistro + Guide = Attiva/disattiva vibrazione controller"
+"Left Shoulder + Back = Toggle Controller Vibration" = "Dorsale sinistro + Back = Attiva/disattiva vibrazione controller"
+"D-PAD Down + Guide = Half CPU Scalar" = "Croce direzionale giù + Guide = Dimezza scala CPU"
+"D-PAD Down + Back = Half CPU Scalar" = "Croce direzionale giù + Back = Dimezza scala CPU"
+"D-PAD Up + Guide = Double CPU Scalar" = "Croce direzionale su + Guide = Raddoppia scala CPU"
+"D-PAD Up + Back = Double CPU Scalar" = "Croce direzionale su + Back = Raddoppia scala CPU"
+"D-PAD Right + Guide = Reset CPU Scalar" = "Croce direzionale destra + Guide = Ripristina scala CPU"
+"D-PAD Right + Back = Reset CPU Scalar" = "Croce direzionale destra + Back = Ripristina scala CPU"
+"Y = Toggle Fullscreen" = "Y = Attiva/disattiva schermo intero"
+"Start = Run Selected Title" = "Start = Avvia il titolo selezionato"
+"Back + Start = Toggle between loglevel set in config and the 'Disabled' loglevel." = "Back + Start = Passa dal livello di log impostato in configurazione al livello 'Disabled'."
+"D-PAD Down = Title Selection +1" = "Croce direzionale giù = Selezione titolo +1"
+"D-PAD Up = Title Selection -1" = "Croce direzionale su = Selezione titolo -1"
+
+# --- Menu profili (xam_ui.cc) -------------------------------------------------
+"Paste" = "Incolla"
+"Profile is not signed in" = "Il profilo non ha effettuato l'accesso"
+"User: {}\n" = "Utente: {}\n"
+"XUID: {:016X}  \n" = "XUID: {:016X}  \n"
+"Assigned to slot: {}\n" = "Assegnato allo slot: {}\n"
+
+
+
+

--- a/src/xenia/app/console_settings_dialog.cc
+++ b/src/xenia/app/console_settings_dialog.cc
@@ -8,8 +8,10 @@
  */
 #include "xenia/app/emulator_window.h"
 #include "xenia/app/profile_dialogs.h"
+#include "xenia/base/locale.h"
 #include "xenia/base/png_utils.h"
 #include "xenia/base/system.h"
+#include "xenia/config.h"
 #include "xenia/kernel/util/shim_utils.h"
 #include "xenia/kernel/xam/xam_ui.h"
 #include "xenia/ui/file_picker.h"
@@ -99,7 +101,7 @@ void DrawResolutionCombobox(ImGuiIO& io,
     }
   }
 
-  if (ImGui::BeginCombo("Resolution", preview)) {
+  if (ImGui::BeginCombo(XE_LOCALIZE("Resolution").c_str(), preview)) {
     for (const auto& opt : options) {
       const bool selected = (opt.to_host() == resolution.get());
       if (ImGui::Selectable(opt.name_.c_str(), selected)) {
@@ -137,7 +139,8 @@ void DrawTimezoneCombobox(ImGuiIO& io, kernel::XConfigData* xdata) {
     index = std::distance(kernel::kTimezones.cbegin(), it);
   }
 
-  if (ImGui::BeginCombo("Timezone", kernel::kTimezones[index].name.c_str())) {
+  if (ImGui::BeginCombo(XE_LOCALIZE("Timezone").c_str(),
+                        kernel::kTimezones[index].name.c_str())) {
     for (size_t i = 0; i < kernel::kTimezones.size(); ++i) {
       const bool is_selected =
           (kernel::kTimezones[i] == kernel::kTimezones[index]);
@@ -248,7 +251,7 @@ void ConsoleSettingsDialog::OnDraw(ImGuiIO& io) {
   ImGui::SetNextWindowSize(ImVec2(20, 20), ImGuiCond_FirstUseEver);
   ImGui::SetNextWindowBgAlpha(0.90f);
   bool dialog_open = true;
-  if (!ImGui::Begin("Console settings", &dialog_open,
+  if (!ImGui::Begin(XE_LOCALIZE("Console settings").c_str(), &dialog_open,
                     ImGuiWindowFlags_NoCollapse |
                         ImGuiWindowFlags_AlwaysAutoResize |
                         ImGuiWindowFlags_NoMove)) {
@@ -264,62 +267,147 @@ void ConsoleSettingsDialog::OnDraw(ImGuiIO& io) {
   }
 
   if (ImGui::BeginTabBar("##Categories")) {
-    if (ImGui::BeginTabItem("User")) {
+    if (ImGui::BeginTabItem(XE_LOCALIZE("Interface").c_str())) {
+      ImGui::Dummy(ImVec2(2.f, 2.f));
+
+      GroupBox(XE_LOCALIZE("Language").c_str(), [&]() {
+        const std::string current_language = xe::locale::current_language();
+        const std::string preview = xe::locale::DisplayName(current_language);
+
+        if (ImGui::BeginCombo(XE_LOCALIZE("Xenia Interface Language").c_str(),
+                              preview.c_str())) {
+          for (const auto& code : xe::locale::AvailableLanguages()) {
+            const bool selected = (code == current_language);
+            const std::string label = xe::locale::DisplayName(code);
+            if (ImGui::Selectable(label.c_str(), selected)) {
+              xe::locale::SwitchLanguage(code);
+            }
+            if (selected) {
+              ImGui::SetItemDefaultFocus();
+            }
+          }
+          ImGui::EndCombo();
+        }
+
+        ImGui::TextWrapped(
+            "%s",
+            XE_LOCALIZE(
+                "Dialogs update immediately. The menu bar at the top of the "
+                "window is only rebuilt on the next launch of Xenia.")
+                .c_str());
+        ImGui::Spacing();
+        ImGui::TextWrapped(
+            "%s",
+            XE_LOCALIZE(
+                "Community-contributed translations may be incomplete: any "
+                "text without a translation yet is simply shown in English.")
+                .c_str());
+
+        ImGui::Spacing();
+
+        const bool restart_required = xe::locale::RestartRequired();
+        ImGui::BeginDisabled(!restart_required);
+        if (ImGui::Button(XE_LOCALIZE("Restart Now").c_str())) {
+          // The language choice only lives in memory until the general
+          // Xenia config is written to disk - unrelated to (and not
+          // covered by) the "Save"/"Reset" buttons at the bottom of this
+          // dialog, which only apply to the emulated console's own
+          // settings. Without this, the new instance launched below would
+          // start up and read the *old* language back from
+          // xenia-canary.config.toml.
+          config::SaveConfig();
+          if (xe::RestartApplication()) {
+            emulator_window_.window()->RequestClose();
+          } else {
+            xe::ShowSimpleMessageBox(
+                xe::SimpleMessageBoxType::Warning,
+                XE_LOCALIZE(
+                    "Couldn't restart Xenia automatically. Please close and "
+                    "reopen it manually to finish applying the new "
+                    "language."));
+          }
+        }
+        ImGui::EndDisabled();
+        if (restart_required) {
+          ImGui::SameLine();
+          ImGui::TextUnformatted(
+              XE_LOCALIZE("Restarts Xenia now so the menu bar picks up the new "
+                          "language too.")
+                  .c_str());
+        }
+      });
+
+      ImGui::EndTabItem();
+    }
+
+    if (ImGui::BeginTabItem(XE_LOCALIZE("User").c_str())) {
       ImGui::BeginDisabled(emulator_window_.emulator()->is_title_open());
       ImGui::Dummy(ImVec2(2.f, 2.f));
 
-      GroupBox("Time", [&]() {
+      GroupBox(XE_LOCALIZE("Time").c_str(), [&]() {
         DrawTimezoneCombobox(io, &xconfig_data_);
 
-        FlagCheckbox("Disable Daylight-Saving Time",
+        FlagCheckbox(XE_LOCALIZE("Disable Daylight-Saving Time").c_str(),
                      xconfig_data_.user.retail_flags,
                      static_cast<uint32_t>(kernel::X_RETAIL_FLAGS::DSTOff));
 
         FlagCheckbox(
-            "24H Time", xconfig_data_.user.retail_flags,
+            XE_LOCALIZE("24H Time").c_str(), xconfig_data_.user.retail_flags,
             static_cast<uint32_t>(kernel::X_RETAIL_FLAGS::TwentyFourHourClock));
       });
 
-      GroupBox("Locale", [&]() {
-        DrawCombobox(io, "Language", kLanguageMap, xconfig_data_.user.language);
-        DrawCombobox(io, "Country", kCountryMap, xconfig_data_.user.country);
+      GroupBox(XE_LOCALIZE("Locale").c_str(), [&]() {
+        // NOTE: the language/country VALUE LISTS below (kLanguageMap,
+        // kCountryMap) are deliberately NOT translated - they represent the
+        // fixed set of languages/countries the emulated Xbox 360 dashboard
+        // itself understands, not Xenia's own UI text.
+        DrawCombobox(io, XE_LOCALIZE("Language"), kLanguageMap,
+                     xconfig_data_.user.language);
+        DrawCombobox(io, XE_LOCALIZE("Country"), kCountryMap,
+                     xconfig_data_.user.country);
       });
 
-      GroupBox("Profile", [&]() {
-        DrawCombobox(io, "Default Profile", profiles_,
+      GroupBox(XE_LOCALIZE("Profile").c_str(), [&]() {
+        DrawCombobox(io, XE_LOCALIZE("Default Profile"), profiles_,
                      xconfig_data_.user.default_profile);
 
-        FlagCheckbox("Parental Control",
+        FlagCheckbox(XE_LOCALIZE("Parental Control").c_str(),
                      xconfig_data_.user.parental_control_flags,
                      static_cast<uint8_t>(kernel::X_PC_FLAGS::PCEnabled));
       });
 
       ImGui::Dummy(ImVec2(2.f, 2.f));
 
-      GroupBox("Retail Options", [&]() {
-        FlagCheckbox("Dashboard Initialized", xconfig_data_.user.retail_flags,
+      GroupBox(XE_LOCALIZE("Retail Options").c_str(), [&]() {
+        FlagCheckbox(XE_LOCALIZE("Dashboard Initialized").c_str(),
+                     xconfig_data_.user.retail_flags,
                      static_cast<uint32_t>(
                          kernel::X_RETAIL_FLAGS::DashboardInitialized));
         FlagCheckbox(
-            "IPTV Initialized", xconfig_data_.user.retail_flags,
+            XE_LOCALIZE("IPTV Initialized").c_str(),
+            xconfig_data_.user.retail_flags,
             static_cast<uint32_t>(kernel::X_RETAIL_FLAGS::IPTVEnabled));
         FlagCheckbox(
-            "DVR Initialized", xconfig_data_.user.retail_flags,
+            XE_LOCALIZE("DVR Initialized").c_str(),
+            xconfig_data_.user.retail_flags,
             static_cast<uint32_t>(kernel::X_RETAIL_FLAGS::IPTVDVREnabled));
         FlagCheckbox(
-            "Kinect Initialized", xconfig_data_.user.retail_flags,
+            XE_LOCALIZE("Kinect Initialized").c_str(),
+            xconfig_data_.user.retail_flags,
             static_cast<uint32_t>(kernel::X_RETAIL_FLAGS::KinectInitialized));
       });
       ImGui::EndDisabled();
       ImGui::EndTabItem();
     }
 
-    if (ImGui::BeginTabItem("System")) {
+    if (ImGui::BeginTabItem(XE_LOCALIZE("System").c_str())) {
       ImGui::BeginDisabled(emulator_window_.emulator()->is_title_open());
       ImGui::Dummy(ImVec2(2.f, 2.f));
 
-      GroupBox("Video Options", [&]() {
-        DrawCombobox(io, "AV Region", kAVRegion,
+      GroupBox(XE_LOCALIZE("Video Options").c_str(), [&]() {
+        // kAVRegion values intentionally left untranslated (NTSC/PAL/...
+        // are the standard, universally-recognized region codes).
+        DrawCombobox(io, XE_LOCALIZE("AV Region"), kAVRegion,
                      xconfig_data_.secured.av_region);
 
         DrawResolutionCombobox(
@@ -330,44 +418,49 @@ void ConsoleSettingsDialog::OnDraw(ImGuiIO& io) {
             kernel::Resolution(xconfig_data_.user.av_pack_hdmi_sz.get());
 
         ImGui::BeginDisabled(res.is_widescreen());
-        FlagCheckbox("Widescreen", xconfig_data_.user.video_flags,
+        FlagCheckbox(XE_LOCALIZE("Widescreen").c_str(),
+                     xconfig_data_.user.video_flags,
                      static_cast<uint32_t>(kernel::X_VIDEO_FLAGS::Widescreen));
         ImGui::EndDisabled();
       });
 
-      GroupBox("Audio Options", [&]() {
-        FlagCheckbox("Mono", xconfig_data_.user.audio_flags,
+      GroupBox(XE_LOCALIZE("Audio Options").c_str(), [&]() {
+        FlagCheckbox(XE_LOCALIZE("Mono").c_str(),
+                     xconfig_data_.user.audio_flags,
                      static_cast<uint32_t>(kernel::X_AUDIO_FLAGS::AnalogMono));
 
         FlagCheckbox(
-            "Dolby Pro Logic", xconfig_data_.user.audio_flags,
+            XE_LOCALIZE("Dolby Pro Logic").c_str(),
+            xconfig_data_.user.audio_flags,
             static_cast<uint32_t>(kernel::X_AUDIO_FLAGS::DolbyProLogic));
 
         FlagCheckbox(
-            "Dolby Digital", xconfig_data_.user.audio_flags,
+            XE_LOCALIZE("Dolby Digital").c_str(),
+            xconfig_data_.user.audio_flags,
             static_cast<uint32_t>(kernel::X_AUDIO_FLAGS::DolbyDigital));
 
-        FlagCheckbox("Dolby Digital WMA PRO", xconfig_data_.user.audio_flags,
+        FlagCheckbox(XE_LOCALIZE("Dolby Digital WMA PRO").c_str(),
+                     xconfig_data_.user.audio_flags,
                      static_cast<uint32_t>(
                          kernel::X_AUDIO_FLAGS::DolbyDigitalWithWMAPRO));
 
-        FlagCheckbox("Low Latency (unsupported)",
+        FlagCheckbox(XE_LOCALIZE("Low Latency (unsupported)").c_str(),
                      xconfig_data_.user.audio_flags,
                      static_cast<uint32_t>(kernel::X_AUDIO_FLAGS::LowLatency));
 
         float volume = xconfig_data_.user.music_volume.get();
-        if (ImGui::SliderFloat("Audio player volume", &volume, 0.0f, 1.0f,
-                               "%.2f")) {
+        if (ImGui::SliderFloat(XE_LOCALIZE("Audio player volume").c_str(),
+                               &volume, 0.0f, 1.0f, "%.2f")) {
           xconfig_data_.user.music_volume = volume;
         }
       });
 
-      GroupBox("Network", [&]() {
+      GroupBox(XE_LOCALIZE("Network").c_str(), [&]() {
         if (ImGui::BeginTable("##NetworkTable", 2)) {
           ImGui::TableNextRow();
           ImGui::TableNextColumn();
 
-          ImGui::Text("MAC Address: ");
+          ImGui::Text("%s", XE_LOCALIZE("MAC Address: ").c_str());
           ImGui::TableNextColumn();
 
           ByteArray("mac", xconfig_data_.secured.mac_address.data(),
@@ -376,7 +469,7 @@ void ConsoleSettingsDialog::OnDraw(ImGuiIO& io) {
           ImGui::TableNextRow();
           ImGui::TableNextColumn();
 
-          ImGui::Text("Network ID: ");
+          ImGui::Text("%s", XE_LOCALIZE("Network ID: ").c_str());
           ImGui::TableNextColumn();
 
           ByteArray("netid", xconfig_data_.secured.online_network_id.data(),
@@ -397,21 +490,21 @@ void ConsoleSettingsDialog::OnDraw(ImGuiIO& io) {
   ImGui::Separator();
 
   ImGui::BeginDisabled(emulator_window_.emulator()->is_title_open());
-  if (ImGui::Button("Save")) {
+  if (ImGui::Button(XE_LOCALIZE("Save").c_str())) {
     SaveConfig();
     save_confirmation_disappearance_ = ImGui::GetTime() + 3.0;
   }
 
   if (save_confirmation_disappearance_ > ImGui::GetTime()) {
     ImGui::SameLine();
-    ImGui::Text("Settings Saved!");
+    ImGui::Text("%s", XE_LOCALIZE("Settings Saved!").c_str());
   }
 
   ImGui::SameLine();
   ImGui::SetCursorPosX(ImGui::GetCursorPosX() +
                        ImGui::GetContentRegionAvail().x - 55.f);
 
-  if (ImGui::Button("Reset", ImVec2(55.f, 0.0f))) {
+  if (ImGui::Button(XE_LOCALIZE("Reset").c_str(), ImVec2(55.f, 0.0f))) {
     xconfig_->SetDefaults();
     xconfig_data_ = *xconfig_->GetXConfig();
     save_confirmation_disappearance_ = ImGui::GetTime() + 3.0;

--- a/src/xenia/app/emulator_window.cc
+++ b/src/xenia/app/emulator_window.cc
@@ -25,6 +25,7 @@
 #include "xenia/base/clock.h"
 #include "xenia/base/cvar.h"
 #include "xenia/base/debugging.h"
+#include "xenia/base/locale.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/platform.h"
 #include "xenia/base/profiling.h"
@@ -349,7 +350,7 @@ void EmulatorWindow::DisplayConfigDialog::OnDraw(ImGuiIO& io) {
   // through it.
   ImGui::SetNextWindowBgAlpha(0.6f);
   bool dialog_open = true;
-  if (!ImGui::Begin("Post-processing", &dialog_open,
+  if (!ImGui::Begin(XE_LOCALIZE("Post-processing").c_str(), &dialog_open,
                     ImGuiWindowFlags_NoCollapse |
                         ImGuiWindowFlags_AlwaysAutoResize |
                         ImGuiWindowFlags_HorizontalScrollbar)) {
@@ -362,26 +363,32 @@ void EmulatorWindow::DisplayConfigDialog::OnDraw(ImGuiIO& io) {
   // have one frame with an empty window.
 
   // Prevent user confusion which has been reported multiple times.
-  ImGui::TextUnformatted("All effects can be used on GPUs of any brand.");
+  ImGui::TextUnformatted(
+      XE_LOCALIZE("All effects can be used on GPUs of any brand.").c_str());
   ImGui::Spacing();
 
   gpu::CommandProcessor* command_processor =
       graphics_system->command_processor();
   if (command_processor) {
     if (ImGui::TreeNodeEx(
-            "Anti-aliasing",
+            XE_LOCALIZE("Anti-aliasing").c_str(),
             ImGuiTreeNodeFlags_Framed | ImGuiTreeNodeFlags_DefaultOpen)) {
       gpu::CommandProcessor::SwapPostEffect current_swap_post_effect =
           command_processor->GetDesiredSwapPostEffect();
       int new_swap_post_effect_index = int(current_swap_post_effect);
-      ImGui::RadioButton("None", &new_swap_post_effect_index,
+      ImGui::RadioButton(XE_LOCALIZE("None").c_str(),
+                         &new_swap_post_effect_index,
                          int(gpu::CommandProcessor::SwapPostEffect::kNone));
       ImGui::RadioButton(
-          "NVIDIA Fast Approximate Anti-Aliasing (FXAA) [Normal Quality]",
+          XE_LOCALIZE(
+              "NVIDIA Fast Approximate Anti-Aliasing (FXAA) [Normal Quality]")
+              .c_str(),
           &new_swap_post_effect_index,
           int(gpu::CommandProcessor::SwapPostEffect::kFxaa));
       ImGui::RadioButton(
-          "NVIDIA Fast Approximate Anti-Aliasing (FXAA) [Extreme Quality]",
+          XE_LOCALIZE("NVIDIA Fast Approximate Anti-Aliasing (FXAA) [Extreme "
+                      "Quality]")
+              .c_str(),
           &new_swap_post_effect_index,
           int(gpu::CommandProcessor::SwapPostEffect::kFxaaExtreme));
       gpu::CommandProcessor::SwapPostEffect new_swap_post_effect =
@@ -410,12 +417,12 @@ void EmulatorWindow::DisplayConfigDialog::OnDraw(ImGuiIO& io) {
         current_presenter_config;
 
     if (ImGui::TreeNodeEx(
-            "Resampling and sharpening",
+            XE_LOCALIZE("Resampling and sharpening").c_str(),
             ImGuiTreeNodeFlags_Framed | ImGuiTreeNodeFlags_DefaultOpen)) {
       // Filtering effect.
       int new_effect_index = int(new_presenter_config.GetEffect());
       ImGui::RadioButton(
-          "None / Bilinear", &new_effect_index,
+          XE_LOCALIZE("None / Bilinear").c_str(), &new_effect_index,
           int(ui::Presenter::GuestOutputPaintConfig::Effect::kBilinear));
       ImGui::RadioButton(
           "AMD FidelityFX Contrast Adaptive Sharpening (CAS)",
@@ -431,45 +438,47 @@ void EmulatorWindow::DisplayConfigDialog::OnDraw(ImGuiIO& io) {
       // line, as TextWrapped doesn't work correctly in auto-resizing windows
       // (in the initial frames, the window becomes extremely tall, and widgets
       // added after the wrapped text have no effect on the width of the text).
-      const char* effect_description = nullptr;
-      switch (new_presenter_config.GetEffect()) {
-        case ui::Presenter::GuestOutputPaintConfig::Effect::kBilinear:
-          effect_description =
-              "Simple bilinear filtering is done if resampling is needed.\n"
-              "Otherwise, only anti-aliasing is done if enabled, or displaying "
-              "as is.";
-          break;
-        case ui::Presenter::GuestOutputPaintConfig::Effect::kCas:
-          effect_description =
-              "Sharpening and resampling to up to 2x2 to improve the fidelity "
-              "of details.\n"
-              "For scaling by more than 2x2, bilinear stretching is done "
-              "afterwards.";
-          break;
-        case ui::Presenter::GuestOutputPaintConfig::Effect::kFsr:
-          effect_description =
-              "High-quality edge-preserving upscaling to arbitrary target "
-              "resolutions.\n"
-              "For scaling by more than 2x2, multiple upsampling passes are "
-              "done.\n"
-              "If not upscaling, Contrast Adaptive Sharpening (CAS) is used "
-              "instead.";
-          break;
-      }
-      if (effect_description) {
-        ImGui::TextUnformatted(effect_description);
+      const std::string effect_description = [&]() -> std::string {
+        switch (new_presenter_config.GetEffect()) {
+          case ui::Presenter::GuestOutputPaintConfig::Effect::kBilinear:
+            return XE_LOCALIZE(
+                "Simple bilinear filtering is done if resampling is "
+                "needed.\n"
+                "Otherwise, only anti-aliasing is done if enabled, or "
+                "displaying as is.");
+          case ui::Presenter::GuestOutputPaintConfig::Effect::kCas:
+            return XE_LOCALIZE(
+                "Sharpening and resampling to up to 2x2 to improve the "
+                "fidelity of details.\n"
+                "For scaling by more than 2x2, bilinear stretching is done "
+                "afterwards.");
+          case ui::Presenter::GuestOutputPaintConfig::Effect::kFsr:
+            return XE_LOCALIZE(
+                "High-quality edge-preserving upscaling to arbitrary target "
+                "resolutions.\n"
+                "For scaling by more than 2x2, multiple upsampling passes "
+                "are done.\n"
+                "If not upscaling, Contrast Adaptive Sharpening (CAS) is "
+                "used instead.");
+          default:
+            return std::string();
+        }
+      }();
+      if (!effect_description.empty()) {
+        ImGui::TextUnformatted(effect_description.c_str());
       }
 
       if (new_presenter_config.GetEffect() ==
               ui::Presenter::GuestOutputPaintConfig::Effect::kCas ||
           new_presenter_config.GetEffect() ==
               ui::Presenter::GuestOutputPaintConfig::Effect::kFsr) {
-        if (effect_description) {
+        if (!effect_description.empty()) {
           ImGui::Spacing();
         }
 
         ImGui::TextUnformatted(
-            "FXAA is highly recommended when using CAS or FSR.");
+            XE_LOCALIZE("FXAA is highly recommended when using CAS or FSR.")
+                .c_str());
 
         ImGui::Spacing();
 
@@ -488,7 +497,9 @@ void EmulatorWindow::DisplayConfigDialog::OnDraw(ImGuiIO& io) {
           float fsr_sharpness_reduction =
               new_presenter_config.GetFsrSharpnessReduction();
           ImGui::TextUnformatted(
-              "FSR sharpness reduction when upscaling (lower is sharper):");
+              XE_LOCALIZE("FSR sharpness reduction when upscaling (lower is "
+                          "sharper):")
+                  .c_str());
           const auto label = fmt::format(
               "{} %%", static_cast<int>(fsr_sharpness_reduction * 100));
           // Power 2.0 scaling as the reduction is in stops, used in exp2.
@@ -501,7 +512,9 @@ void EmulatorWindow::DisplayConfigDialog::OnDraw(ImGuiIO& io) {
           fsr_sharpness_reduction =
               .5f * fsr_sharpness_reduction * fsr_sharpness_reduction;
           ImGui::SameLine();
-          if (ImGui::Button("Reset##ResetFSRSharpnessReduction")) {
+          const std::string reset_fsr_label =
+              XE_LOCALIZE("Reset") + "##ResetFSRSharpnessReduction";
+          if (ImGui::Button(reset_fsr_label.c_str())) {
             fsr_sharpness_reduction = ui::Presenter::GuestOutputPaintConfig ::
                 kFsrSharpnessReductionDefault;
           }
@@ -512,11 +525,14 @@ void EmulatorWindow::DisplayConfigDialog::OnDraw(ImGuiIO& io) {
         float cas_additional_sharpness =
             new_presenter_config.GetCasAdditionalSharpness();
         ImGui::TextUnformatted(
-            new_presenter_config.GetEffect() ==
-                    ui::Presenter::GuestOutputPaintConfig::Effect::kFsr
-                ? "CAS additional sharpness when not upscaling (higher is "
-                  "sharper):"
-                : "CAS additional sharpness (higher is sharper):");
+            (new_presenter_config.GetEffect() ==
+                     ui::Presenter::GuestOutputPaintConfig::Effect::kFsr
+                 ? XE_LOCALIZE(
+                       "CAS additional sharpness when not upscaling (higher "
+                       "is sharper):")
+                 : XE_LOCALIZE("CAS additional sharpness (higher is "
+                               "sharper):"))
+                .c_str());
         const auto label = fmt::format(
             "{} %%", static_cast<int>(cas_additional_sharpness * 100));
         ImGui::SliderFloat(
@@ -525,7 +541,9 @@ void EmulatorWindow::DisplayConfigDialog::OnDraw(ImGuiIO& io) {
             ui::Presenter::GuestOutputPaintConfig::kCasAdditionalSharpnessMax,
             label.c_str(), ImGuiSliderFlags_NoInput);
         ImGui::SameLine();
-        if (ImGui::Button("Reset##ResetCASAdditionalSharpness")) {
+        const std::string reset_cas_label =
+            XE_LOCALIZE("Reset") + "##ResetCASAdditionalSharpness";
+        if (ImGui::Button(reset_cas_label.c_str())) {
           cas_additional_sharpness = ui::Presenter::GuestOutputPaintConfig ::
               kCasAdditionalSharpnessDefault;
         }
@@ -543,11 +561,14 @@ void EmulatorWindow::DisplayConfigDialog::OnDraw(ImGuiIO& io) {
       ImGui::TreePop();
     }
 
-    if (ImGui::TreeNodeEx("Dithering", ImGuiTreeNodeFlags_Framed |
-                                           ImGuiTreeNodeFlags_DefaultOpen)) {
+    if (ImGui::TreeNodeEx(
+            XE_LOCALIZE("Dithering").c_str(),
+            ImGuiTreeNodeFlags_Framed | ImGuiTreeNodeFlags_DefaultOpen)) {
       bool dither = current_presenter_config.GetDither();
       ImGui::Checkbox(
-          "Dither the final output to 8bpc to make gradients smoother",
+          XE_LOCALIZE(
+              "Dither the final output to 8bpc to make gradients smoother")
+              .c_str(),
           &dither);
       new_presenter_config.SetDither(dither);
 
@@ -687,7 +708,7 @@ void EmulatorWindow::XMPConfigDialog::OnDraw(ImGuiIO& io) {
   ImGui::SetNextWindowSize(ImVec2(20, 20), ImGuiCond_FirstUseEver);
 
   bool dialog_open = true;
-  if (!ImGui::Begin("Audio Player Menu", &dialog_open,
+  if (!ImGui::Begin(XE_LOCALIZE("Audio Player Menu").c_str(), &dialog_open,
                     ImGuiWindowFlags_NoCollapse |
                         ImGuiWindowFlags_AlwaysAutoResize |
                         ImGuiWindowFlags_HorizontalScrollbar)) {
@@ -699,28 +720,28 @@ void EmulatorWindow::XMPConfigDialog::OnDraw(ImGuiIO& io) {
   auto audio_player = emulator_window_.emulator_->audio_media_player();
   using xmp_state = kernel::xam::apps::XmpApp::State;
   if (audio_player) {
-    ImGui::Text("Audio player status:");
+    ImGui::Text("%s", XE_LOCALIZE("Audio player status:").c_str());
     ImGui::SameLine();
     switch (audio_player->GetState()) {
       case xmp_state::kIdle:
-        ImGui::Text("Idle");
+        ImGui::Text("%s", XE_LOCALIZE("Idle").c_str());
         break;
       case xmp_state::kPaused:
-        ImGui::Text("Paused");
+        ImGui::Text("%s", XE_LOCALIZE("Paused").c_str());
         break;
       case xmp_state::kPlaying:
-        ImGui::Text("Playing");
+        ImGui::Text("%s", XE_LOCALIZE("Playing").c_str());
         break;
       default:
         break;
     }
 
     if (audio_player->IsPlaying()) {
-      if (ImGui::Button("Pause")) {
+      if (ImGui::Button(XE_LOCALIZE("Pause").c_str())) {
         audio_player->Pause();
       }
     } else if (audio_player->IsPaused()) {
-      if (ImGui::Button("Resume")) {
+      if (ImGui::Button(XE_LOCALIZE("Resume").c_str())) {
         audio_player->Continue();
       }
     }
@@ -728,8 +749,8 @@ void EmulatorWindow::XMPConfigDialog::OnDraw(ImGuiIO& io) {
     volume_ =
         emulator_window_.emulator_->audio_media_player()->GetVolume()->load();
 
-    if (ImGui::SliderFloat("Audio player volume", &volume_, 0.0f, 1.0f,
-                           "%.2f")) {
+    if (ImGui::SliderFloat(XE_LOCALIZE("Audio player volume").c_str(), &volume_,
+                           0.0f, 1.0f, "%.2f")) {
       audio_player->SetVolume(volume_);
     }
   }
@@ -750,174 +771,182 @@ bool EmulatorWindow::Initialize() {
   // Main menu.
   // FIXME: This code is really messy.
   auto main_menu = MenuItem::Create(MenuItem::Type::kNormal);
-  auto file_menu = MenuItem::Create(MenuItem::Type::kPopup, "&File");
-  auto recent_menu = MenuItem::Create(MenuItem::Type::kPopup, "&Open Recent");
-  auto zar_menu = MenuItem::Create(MenuItem::Type::kPopup, "&Zar Package");
+  auto file_menu =
+      MenuItem::Create(MenuItem::Type::kPopup, XE_LOCALIZE("&File"));
+  auto recent_menu =
+      MenuItem::Create(MenuItem::Type::kPopup, XE_LOCALIZE("&Open Recent"));
+  auto zar_menu =
+      MenuItem::Create(MenuItem::Type::kPopup, XE_LOCALIZE("&Zar Package"));
   FillRecentlyLaunchedTitlesMenu(recent_menu.get());
   {
     file_menu->AddChild(
-        MenuItem::Create(MenuItem::Type::kString, "&Open...", "Ctrl+O",
-                         std::bind(&EmulatorWindow::FileOpen, this)));
+        MenuItem::Create(MenuItem::Type::kString, XE_LOCALIZE("&Open..."),
+                         "Ctrl+O", std::bind(&EmulatorWindow::FileOpen, this)));
     file_menu->AddChild(std::move(recent_menu));
     file_menu->AddChild(MenuItem::Create(MenuItem::Type::kSeparator));
-    file_menu->AddChild(
-        MenuItem::Create(MenuItem::Type::kString, "Install Content...",
-                         std::bind(&EmulatorWindow::InstallContent, this)));
+    file_menu->AddChild(MenuItem::Create(
+        MenuItem::Type::kString, XE_LOCALIZE("Install Content..."),
+        std::bind(&EmulatorWindow::InstallContent, this)));
     zar_menu->AddChild(
-        MenuItem::Create(MenuItem::Type::kString, "Create",
+        MenuItem::Create(MenuItem::Type::kString, XE_LOCALIZE("Create"),
                          std::bind(&EmulatorWindow::CreateZarchive, this)));
     zar_menu->AddChild(
-        MenuItem::Create(MenuItem::Type::kString, "Extract",
+        MenuItem::Create(MenuItem::Type::kString, XE_LOCALIZE("Extract"),
                          std::bind(&EmulatorWindow::ExtractZarchive, this)));
     file_menu->AddChild(std::move(zar_menu));
 #ifdef DEBUG
     file_menu->AddChild(MenuItem::Create(MenuItem::Type::kSeparator));
     file_menu->AddChild(
-        MenuItem::Create(MenuItem::Type::kString, "Close",
+        MenuItem::Create(MenuItem::Type::kString, XE_LOCALIZE("Close"),
                          std::bind(&EmulatorWindow::FileClose, this)));
 #endif  // #ifdef DEBUG
     file_menu->AddChild(MenuItem::Create(MenuItem::Type::kSeparator));
     file_menu->AddChild(MenuItem::Create(
-        MenuItem::Type::kString, "Show content directory...",
+        MenuItem::Type::kString, XE_LOCALIZE("Show content directory..."),
         std::bind(&EmulatorWindow::ShowContentDirectory, this)));
     file_menu->AddChild(MenuItem::Create(MenuItem::Type::kSeparator));
     file_menu->AddChild(
-        MenuItem::Create(MenuItem::Type::kString, "E&xit", "Alt+F4",
-                         [this]() { window_->RequestClose(); }));
+        MenuItem::Create(MenuItem::Type::kString, XE_LOCALIZE("E&xit"),
+                         "Alt+F4", [this]() { window_->RequestClose(); }));
   }
   main_menu->AddChild(std::move(file_menu));
 
   // Profile Menu
-  auto profile_menu = MenuItem::Create(MenuItem::Type::kPopup, "&Profile");
+  auto profile_menu =
+      MenuItem::Create(MenuItem::Type::kPopup, XE_LOCALIZE("&Profile"));
   {
     profile_menu->AddChild(MenuItem::Create(
-        MenuItem::Type::kString, "&Show Profile Menu", "",
+        MenuItem::Type::kString, XE_LOCALIZE("&Show Profile Menu"), "",
         std::bind(&EmulatorWindow::ToggleProfilesConfigDialog, this)));
   }
   main_menu->AddChild(std::move(profile_menu));
 
   // CPU menu.
-  auto cpu_menu = MenuItem::Create(MenuItem::Type::kPopup, "&CPU");
+  auto cpu_menu = MenuItem::Create(MenuItem::Type::kPopup, XE_LOCALIZE("&CPU"));
   {
     cpu_menu->AddChild(MenuItem::Create(
-        MenuItem::Type::kString, "&Reset Time Scalar", "Numpad *",
+        MenuItem::Type::kString, XE_LOCALIZE("&Reset Time Scalar"), "Numpad *",
         std::bind(&EmulatorWindow::CpuTimeScalarReset, this)));
     cpu_menu->AddChild(MenuItem::Create(
-        MenuItem::Type::kString, "Time Scalar /= 2", "Numpad -",
+        MenuItem::Type::kString, XE_LOCALIZE("Time Scalar /= 2"), "Numpad -",
         std::bind(&EmulatorWindow::CpuTimeScalarSetHalf, this)));
     cpu_menu->AddChild(MenuItem::Create(
-        MenuItem::Type::kString, "Time Scalar *= 2", "Numpad +",
+        MenuItem::Type::kString, XE_LOCALIZE("Time Scalar *= 2"), "Numpad +",
         std::bind(&EmulatorWindow::CpuTimeScalarSetDouble, this)));
   }
 #if XE_OPTION_PROFILING
   cpu_menu->AddChild(MenuItem::Create(MenuItem::Type::kSeparator));
   {
-    cpu_menu->AddChild(MenuItem::Create(MenuItem::Type::kString,
-                                        "Toggle Profiler &Display", "F3",
-                                        []() { Profiler::ToggleDisplay(); }));
-    cpu_menu->AddChild(MenuItem::Create(MenuItem::Type::kString,
-                                        "&Pause/Resume Profiler", "`",
-                                        []() { Profiler::TogglePause(); }));
+    cpu_menu->AddChild(MenuItem::Create(
+        MenuItem::Type::kString, XE_LOCALIZE("Toggle Profiler &Display"), "F3",
+        []() { Profiler::ToggleDisplay(); }));
+    cpu_menu->AddChild(MenuItem::Create(
+        MenuItem::Type::kString, XE_LOCALIZE("&Pause/Resume Profiler"), "`",
+        []() { Profiler::TogglePause(); }));
   }
 #endif
   cpu_menu->AddChild(MenuItem::Create(MenuItem::Type::kSeparator));
   {
     cpu_menu->AddChild(MenuItem::Create(
-        MenuItem::Type::kString, "&Break and Show Guest Debugger",
+        MenuItem::Type::kString, XE_LOCALIZE("&Break and Show Guest Debugger"),
         "Pause/Break", std::bind(&EmulatorWindow::CpuBreakIntoDebugger, this)));
     cpu_menu->AddChild(MenuItem::Create(
-        MenuItem::Type::kString, "&Break into Host Debugger",
+        MenuItem::Type::kString, XE_LOCALIZE("&Break into Host Debugger"),
         "Ctrl+Pause/Break",
         std::bind(&EmulatorWindow::CpuBreakIntoHostDebugger, this)));
   }
   main_menu->AddChild(std::move(cpu_menu));
 
   // GPU menu.
-  auto gpu_menu = MenuItem::Create(MenuItem::Type::kPopup, "&GPU");
+  auto gpu_menu = MenuItem::Create(MenuItem::Type::kPopup, XE_LOCALIZE("&GPU"));
   {
-    gpu_menu->AddChild(
-        MenuItem::Create(MenuItem::Type::kString, "&Trace Frame", "F4",
-                         std::bind(&EmulatorWindow::GpuTraceFrame, this)));
+    gpu_menu->AddChild(MenuItem::Create(
+        MenuItem::Type::kString, XE_LOCALIZE("&Trace Frame"), "F4",
+        std::bind(&EmulatorWindow::GpuTraceFrame, this)));
   }
   gpu_menu->AddChild(MenuItem::Create(MenuItem::Type::kSeparator));
   {
-    gpu_menu->AddChild(
-        MenuItem::Create(MenuItem::Type::kString, "&Clear Runtime Caches", "F5",
-                         std::bind(&EmulatorWindow::GpuClearCaches, this)));
+    gpu_menu->AddChild(MenuItem::Create(
+        MenuItem::Type::kString, XE_LOCALIZE("&Clear Runtime Caches"), "F5",
+        std::bind(&EmulatorWindow::GpuClearCaches, this)));
   }
   main_menu->AddChild(std::move(gpu_menu));
 
   // Display menu.
-  auto display_menu = MenuItem::Create(MenuItem::Type::kPopup, "&Display");
+  auto display_menu =
+      MenuItem::Create(MenuItem::Type::kPopup, XE_LOCALIZE("&Display"));
   {
     display_menu->AddChild(MenuItem::Create(
-        MenuItem::Type::kString, "&Post-processing settings", "F6",
+        MenuItem::Type::kString, XE_LOCALIZE("&Post-processing settings"), "F6",
         std::bind(&EmulatorWindow::ToggleDisplayConfigDialog, this)));
   }
   display_menu->AddChild(MenuItem::Create(MenuItem::Type::kSeparator));
   {
-    display_menu->AddChild(
-        MenuItem::Create(MenuItem::Type::kString, "&Fullscreen", "F11",
-                         std::bind(&EmulatorWindow::ToggleFullscreen, this)));
-    display_menu->AddChild(
-        MenuItem::Create(MenuItem::Type::kString, "&Take Screenshot", "F12",
-                         std::bind(&EmulatorWindow::TakeScreenshot, this)));
+    display_menu->AddChild(MenuItem::Create(
+        MenuItem::Type::kString, XE_LOCALIZE("&Fullscreen"), "F11",
+        std::bind(&EmulatorWindow::ToggleFullscreen, this)));
+    display_menu->AddChild(MenuItem::Create(
+        MenuItem::Type::kString, XE_LOCALIZE("&Take Screenshot"), "F12",
+        std::bind(&EmulatorWindow::TakeScreenshot, this)));
   }
   main_menu->AddChild(std::move(display_menu));
 
   // HID menu.
-  auto hid_menu = MenuItem::Create(MenuItem::Type::kPopup, "&HID");
+  auto hid_menu = MenuItem::Create(MenuItem::Type::kPopup, XE_LOCALIZE("&HID"));
   {
     hid_menu->AddChild(MenuItem::Create(
-        MenuItem::Type::kString, "&Toggle controller vibration", "",
-        std::bind(&EmulatorWindow::ToggleControllerVibration, this)));
+        MenuItem::Type::kString, XE_LOCALIZE("&Toggle controller vibration"),
+        "", std::bind(&EmulatorWindow::ToggleControllerVibration, this)));
     hid_menu->AddChild(MenuItem::Create(
-        MenuItem::Type::kString, "&Display controller hotkeys", "",
+        MenuItem::Type::kString, XE_LOCALIZE("&Display controller hotkeys"), "",
         std::bind(&EmulatorWindow::DisplayHotKeysConfig, this)));
   }
   main_menu->AddChild(std::move(hid_menu));
 
   // XMP menu
-  auto xmp_menu = MenuItem::Create(MenuItem::Type::kPopup, "&XMP");
+  auto xmp_menu = MenuItem::Create(MenuItem::Type::kPopup, XE_LOCALIZE("&XMP"));
   {
     xmp_menu->AddChild(MenuItem::Create(
-        MenuItem::Type::kString, "&Show XMP Menu", "",
+        MenuItem::Type::kString, XE_LOCALIZE("&Show XMP Menu"), "",
         std::bind(&EmulatorWindow::ToggleXMPConfigDialog, this)));
   }
   main_menu->AddChild(std::move(xmp_menu));
 
   // Console menu
-  auto console_menu = MenuItem::Create(MenuItem::Type::kPopup, "&Console");
+  auto console_menu =
+      MenuItem::Create(MenuItem::Type::kPopup, XE_LOCALIZE("&Console"));
   {
     console_menu->AddChild(MenuItem::Create(
-        MenuItem::Type::kString, "&Open console settings", "",
+        MenuItem::Type::kString, XE_LOCALIZE("&Open console settings"), "",
         std::bind(&EmulatorWindow::ToggleConsoleSettingsDialog, this)));
   }
   main_menu->AddChild(std::move(console_menu));
 
   // Help menu.
-  auto help_menu = MenuItem::Create(MenuItem::Type::kPopup, "&Help");
+  auto help_menu =
+      MenuItem::Create(MenuItem::Type::kPopup, XE_LOCALIZE("&Help"));
   {
     help_menu->AddChild(
-        MenuItem::Create(MenuItem::Type::kString, "FA&Q...", "F1",
+        MenuItem::Create(MenuItem::Type::kString, XE_LOCALIZE("FA&Q..."), "F1",
                          std::bind(&EmulatorWindow::ShowFAQ, this)));
     help_menu->AddChild(MenuItem::Create(MenuItem::Type::kSeparator));
-    help_menu->AddChild(
-        MenuItem::Create(MenuItem::Type::kString, "Game &compatibility...",
-                         std::bind(&EmulatorWindow::ShowCompatibility, this)));
+    help_menu->AddChild(MenuItem::Create(
+        MenuItem::Type::kString, XE_LOCALIZE("Game &compatibility..."),
+        std::bind(&EmulatorWindow::ShowCompatibility, this)));
     help_menu->AddChild(MenuItem::Create(MenuItem::Type::kSeparator));
     help_menu->AddChild(MenuItem::Create(
-        MenuItem::Type::kString, "Build commit on GitHub...", "F2",
+        MenuItem::Type::kString, XE_LOCALIZE("Build commit on GitHub..."), "F2",
         std::bind(&EmulatorWindow::ShowBuildCommit, this)));
     help_menu->AddChild(MenuItem::Create(
-        MenuItem::Type::kString, "Recent changes on GitHub...", []() {
+        MenuItem::Type::kString, XE_LOCALIZE("Recent changes on GitHub..."),
+        []() {
           LaunchWebBrowser(
               "https://github.com/xenia-canary/xenia-canary/"
               "compare/" XE_BUILD_COMMIT "..." XE_BUILD_BRANCH);
         }));
     help_menu->AddChild(MenuItem::Create(MenuItem::Type::kSeparator));
     help_menu->AddChild(MenuItem::Create(
-        MenuItem::Type::kString, "&About...",
+        MenuItem::Type::kString, XE_LOCALIZE("&About..."),
         []() { LaunchWebBrowser("https://xenia.jp/about/"); }));
   }
   main_menu->AddChild(std::move(help_menu));
@@ -1176,10 +1205,11 @@ void EmulatorWindow::ExportScreenshot(const xe::ui::RawImage& image) {
   SaveImage(screenshot_path / filename, image);
 
   const std::string notification_text =
-      fmt::format("Screenshot saved: {}", filename);
+      fmt::format(fmt::runtime(XE_LOCALIZE("Screenshot saved: {}")), filename);
 
   app_context_.CallInUIThread([&, notification_text]() {
-    new xe::ui::HostNotificationWindow(imgui_drawer(), "Screenshot Created!",
+    new xe::ui::HostNotificationWindow(imgui_drawer(),
+                                       XE_LOCALIZE("Screenshot Created!"),
                                        notification_text, 0);
   });
 }
@@ -1528,10 +1558,11 @@ void EmulatorWindow::CpuTimeScalarSetDouble() {
 
 void EmulatorWindow::CpuBreakIntoDebugger() {
   if (!cvars::debug) {
-    xe::ui::ImGuiDialog::ShowMessageBox(imgui_drawer_.get(), "Xenia Debugger",
-                                        "Xenia must be launched with the "
-                                        "--debug flag in order to enable "
-                                        "debugging.");
+    xe::ui::ImGuiDialog::ShowMessageBox(
+        imgui_drawer_.get(), XE_LOCALIZE("Xenia Debugger"),
+        XE_LOCALIZE("Xenia must be launched with the "
+                    "--debug flag in order to enable "
+                    "debugging."));
     return;
   }
   auto processor = emulator()->processor();
@@ -2123,12 +2154,19 @@ void EmulatorWindow::DisplayHotKeysConfig() {
           "Back");
     }
 
+    // Translated here, after the Guide/Back substitution above: the
+    // hotkey descriptions live in a table built at static-initialization
+    // time (before locale::Initialize() has run), and the substitution
+    // relies on matching the literal English word "Guide" - both would
+    // break if done on already-translated text.
+    pretty_text = XE_LOCALIZE(pretty_text);
+
     if (emulator_->is_title_open() && !val.title_passthru) {
-      pretty_text += " (Disabled)";
+      pretty_text += XE_LOCALIZE(" (Disabled)");
     }
 
     if (val.title_passthru && !cvars::controller_hotkeys) {
-      pretty_text += " (Disabled)";
+      pretty_text += XE_LOCALIZE(" (Disabled)");
     }
 
     if (val.title_passthru) {
@@ -2139,26 +2177,26 @@ void EmulatorWindow::DisplayHotKeysConfig() {
   }
 
   // Add Title
-  msg.insert(0, "Gameplay Hotkeys\n");
+  msg.insert(0, XE_LOCALIZE("Gameplay Hotkeys") + "\n");
 
   // Prepend non-passthru hotkeys
   msg_passthru += "\n";
   msg.insert(0, msg_passthru);
   msg += "\n";
 
-  msg += "Readback Resolve: " + cvars::readback_resolve;
+  msg += XE_LOCALIZE("Readback Resolve: ") + cvars::readback_resolve;
   msg += "\n";
 
-  msg += "Clear Memory Page State: " +
+  msg += XE_LOCALIZE("Clear Memory Page State: ") +
          xe::string_util::BoolToString(cvars::clear_memory_page_state);
   msg += "\n";
 
-  msg += "Controller Hotkeys: " +
+  msg += XE_LOCALIZE("Controller Hotkeys: ") +
          xe::string_util::BoolToString(cvars::controller_hotkeys);
 
   ClearDialogs();
-  xe::ui::ImGuiDialog::ShowMessageBox(imgui_drawer_.get(), "Controller Hotkeys",
-                                      msg);
+  xe::ui::ImGuiDialog::ShowMessageBox(imgui_drawer_.get(),
+                                      XE_LOCALIZE("Controller Hotkeys"), msg);
 }
 
 std::string EmulatorWindow::CanonicalizeFileExtension(
@@ -2172,6 +2210,9 @@ xe::X_STATUS EmulatorWindow::RunTitle(
   bool titleExists = std::filesystem::exists(path_to_file, ec);
 
   if (path_to_file.empty() || !titleExists) {
+    // Kept in English regardless of UI language: this also gets written to
+    // xenia.log, and log files should stay in a language the developers
+    // reading bug reports can always understand.
     std::string log_msg =
         fmt::format("Failed to launch title path is {}.",
                     path_to_file.empty() ? "empty" : "invalid");
@@ -2189,8 +2230,18 @@ xe::X_STATUS EmulatorWindow::RunTitle(
 
     ClearDialogs();
 
-    xe::ui::ImGuiDialog::ShowMessageBox(imgui_drawer_.get(),
-                                        "Title Launch Failed!", log_msg);
+    // The dialog shown to the user is translated separately from the log
+    // message above, since the two have different audiences.
+    std::string display_msg = fmt::format(
+        fmt::runtime(XE_LOCALIZE("Failed to launch title path is {}.")),
+        XE_LOCALIZE(path_to_file.empty() ? "empty" : "invalid"));
+    if (!path_to_file.empty() && !titleExists) {
+      display_msg.append(fmt::format(
+          fmt::runtime(XE_LOCALIZE("\nProvided Path: {}")), path_to_file));
+    }
+
+    xe::ui::ImGuiDialog::ShowMessageBox(
+        imgui_drawer_.get(), XE_LOCALIZE("Title Launch Failed!"), display_msg);
 
     return X_STATUS_NO_SUCH_FILE;
   }
@@ -2214,7 +2265,7 @@ xe::X_STATUS EmulatorWindow::RunTitle(
       extension == ".tar" || extension == ".gz") {
     xe::ShowSimpleMessageBox(
         xe::SimpleMessageBoxType::Error,
-        fmt::format(
+        XE_LOCALIZE(
             "Unsupported format!\n"
             "Xenia does not support running software in an archived format."));
 
@@ -2240,8 +2291,9 @@ xe::X_STATUS EmulatorWindow::RunTitle(
     XELOGE("Failed to launch target: {:08X}", result);
 
     xe::ui::ImGuiDialog::ShowMessageBox(
-        imgui_drawer_.get(), "Title Launch Failed!",
-        "Failed to launch title.\n\nCheck xenia.log for technical details.");
+        imgui_drawer_.get(), XE_LOCALIZE("Title Launch Failed!"),
+        XE_LOCALIZE("Failed to launch title.\n\nCheck xenia.log for "
+                    "technical details."));
 
     emulator_->file_system()->Clear();
   } else {

--- a/src/xenia/app/profile_dialogs.cc
+++ b/src/xenia/app/profile_dialogs.cc
@@ -8,6 +8,7 @@
  */
 #include "xenia/app/profile_dialogs.h"
 #include "xenia/app/emulator_window.h"
+#include "xenia/base/locale.h"
 #include "xenia/base/png_utils.h"
 #include "xenia/base/system.h"
 #include "xenia/kernel/util/shim_utils.h"
@@ -40,7 +41,7 @@ void NoProfileDialog::OnDraw(ImGuiIO& io) {
   ImGui::SetNextWindowBgAlpha(1.0f);
 
   bool dialog_open = true;
-  if (!ImGui::Begin("No Profiles Found", &dialog_open,
+  if (!ImGui::Begin(XE_LOCALIZE("No Profiles Found").c_str(), &dialog_open,
                     ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
                         ImGuiWindowFlags_AlwaysAutoResize |
                         ImGuiWindowFlags_HorizontalScrollbar)) {
@@ -49,9 +50,9 @@ void NoProfileDialog::OnDraw(ImGuiIO& io) {
     return;
   }
 
-  const std::string message =
+  const std::string message = XE_LOCALIZE(
       "There is no profile available! You will not be able to save without "
-      "one.\n\nWould you like to create one?";
+      "one.\n\nWould you like to create one?");
 
   ImGui::TextUnformatted(message.c_str());
 
@@ -65,24 +66,24 @@ void NoProfileDialog::OnDraw(ImGuiIO& io) {
     ImGui::SetKeyboardFocusHere();
   }
   if (content_files.empty()) {
-    if (ImGui::Button("Create Profile")) {
+    if (ImGui::Button(XE_LOCALIZE("Create Profile").c_str())) {
       new kernel::xam::ui::CreateProfileUI(emulator_window_->imgui_drawer(),
                                            emulator_window_->emulator());
     }
   } else {
-    if (ImGui::Button("Create profile & migrate data")) {
+    if (ImGui::Button(XE_LOCALIZE("Create profile & migrate data").c_str())) {
       new kernel::xam::ui::CreateProfileUI(emulator_window_->imgui_drawer(),
                                            emulator_window_->emulator(), true);
     }
   }
 
   ImGui::SameLine();
-  if (ImGui::Button("Open profile menu")) {
+  if (ImGui::Button(XE_LOCALIZE("Open profile menu").c_str())) {
     emulator_window_->ToggleProfilesConfigDialog();
   }
 
   ImGui::SameLine();
-  if (ImGui::Button("Close") || !dialog_open) {
+  if (ImGui::Button(XE_LOCALIZE("Close").c_str()) || !dialog_open) {
     emulator_window_->SetHotkeysState(true);
     ImGui::End();
     Close();
@@ -163,7 +164,7 @@ void ProfileConfigDialog::OnDraw(ImGuiIO& io) {
   ImGui::SetNextWindowBgAlpha(0.8f);
 
   bool dialog_open = true;
-  if (!ImGui::Begin("Profiles Menu", &dialog_open,
+  if (!ImGui::Begin(XE_LOCALIZE("Profiles Menu").c_str(), &dialog_open,
                     ImGuiWindowFlags_NoCollapse |
                         ImGuiWindowFlags_AlwaysAutoResize |
                         ImGuiWindowFlags_HorizontalScrollbar)) {
@@ -182,7 +183,7 @@ void ProfileConfigDialog::OnDraw(ImGuiIO& io) {
   }
 
   if (profiles->empty()) {
-    ImGui::TextUnformatted("No profiles found!");
+    ImGui::TextUnformatted(XE_LOCALIZE("No profiles found!").c_str());
     ImGui::Spacing();
     ImGui::Separator();
   }
@@ -202,10 +203,10 @@ void ProfileConfigDialog::OnDraw(ImGuiIO& io) {
                                   : nullptr;
 
     auto context_menu_fun = [=, this]() -> bool {
-      if (ImGui::BeginPopupContextItem("Profile Menu")) {
+      if (ImGui::BeginPopupContextItem(XE_LOCALIZE("Profile Menu").c_str())) {
         //*selected_xuid = xuid;
         if (user_index == XUserIndexAny) {
-          if (ImGui::MenuItem("Login")) {
+          if (ImGui::MenuItem(XE_LOCALIZE("Login").c_str())) {
             profile_manager->Login(xuid);
             if (!profile_manager->GetProfile(xuid)
                      ->GetProfileIcon(kernel::xam::XTileType::kGamerTile)
@@ -213,9 +214,11 @@ void ProfileConfigDialog::OnDraw(ImGuiIO& io) {
               LoadProfileIcon(xuid);
             }
           }
-          if (ImGui::BeginMenu("Login to slot:")) {
+          if (ImGui::BeginMenu(XE_LOCALIZE("Login to slot:").c_str())) {
             for (uint8_t i = 1; i <= XUserMaxUserCount; i++) {
-              if (ImGui::MenuItem(fmt::format("slot {}", i).c_str())) {
+              if (ImGui::MenuItem(
+                      fmt::format(fmt::runtime(XE_LOCALIZE("slot {}")), i)
+                          .c_str())) {
                 uint64_t current_slot_xuid = 0;
 
                 if (const auto current_profile = profile_manager->GetProfile(
@@ -236,13 +239,13 @@ void ProfileConfigDialog::OnDraw(ImGuiIO& io) {
             ImGui::EndMenu();
           }
         } else {
-          if (ImGui::MenuItem("Logout")) {
+          if (ImGui::MenuItem(XE_LOCALIZE("Logout").c_str())) {
             profile_manager->Logout(user_index);
             LoadProfileIcon(xuid);
           }
         }
 
-        if (ImGui::MenuItem("Modify")) {
+        if (ImGui::MenuItem(XE_LOCALIZE("Modify").c_str())) {
           new kernel::xam::ui::GamercardUI(
               emulator_window_->window(), emulator_window_->imgui_drawer(),
               emulator_window_->emulator()->kernel_state(), xuid);
@@ -250,14 +253,14 @@ void ProfileConfigDialog::OnDraw(ImGuiIO& io) {
 
         const bool is_signedin = profile_manager->GetProfile(xuid) != nullptr;
         ImGui::BeginDisabled(!is_signedin);
-        if (ImGui::MenuItem("Show Played Titles")) {
+        if (ImGui::MenuItem(XE_LOCALIZE("Show Played Titles").c_str())) {
           new kernel::xam::ui::TitleListUI(
               emulator_window_->imgui_drawer(), next_window_position,
               profile_manager->GetProfile(user_index));
         }
         ImGui::EndDisabled();
 
-        if (ImGui::MenuItem("Show Content Directory")) {
+        if (ImGui::MenuItem(XE_LOCALIZE("Show Content Directory").c_str())) {
           const auto path = profile_manager->GetProfileContentPath(
               xuid, emulator_window_->emulator()->kernel_state()->title_id());
 
@@ -271,18 +274,19 @@ void ProfileConfigDialog::OnDraw(ImGuiIO& io) {
 
         if (!emulator_window_->emulator()->is_title_open()) {
           ImGui::Separator();
-          if (ImGui::BeginMenu("Delete Profile")) {
+          if (ImGui::BeginMenu(XE_LOCALIZE("Delete Profile").c_str())) {
             ImGui::BeginTooltip();
             ImGui::TextUnformatted(
                 fmt::format(
-                    "You're about to delete profile: {} (XUID: {:016X}). "
-                    "This will remove all data assigned to this profile "
-                    "including savefiles. Are you sure?",
+                    fmt::runtime(XE_LOCALIZE(
+                        "You're about to delete profile: {} (XUID: "
+                        "{:016X}). This will remove all data assigned to "
+                        "this profile including savefiles. Are you sure?")),
                     account.GetGamertagString(), xuid)
                     .c_str());
             ImGui::EndTooltip();
 
-            if (ImGui::MenuItem("Yes, delete it!")) {
+            if (ImGui::MenuItem(XE_LOCALIZE("Yes, delete it!").c_str())) {
               profile_manager->DeleteProfile(xuid);
               ImGui::EndMenu();
               ImGui::EndPopup();
@@ -312,7 +316,7 @@ void ProfileConfigDialog::OnDraw(ImGuiIO& io) {
 
   ImGui::Spacing();
 
-  if (ImGui::Button("Create Profile")) {
+  if (ImGui::Button(XE_LOCALIZE("Create Profile").c_str())) {
     new kernel::xam::ui::CreateProfileUI(emulator_window_->imgui_drawer(),
                                          emulator_window_->emulator());
   }

--- a/src/xenia/app/xenia_main.cc
+++ b/src/xenia/app/xenia_main.cc
@@ -19,6 +19,7 @@
 #include "xenia/base/assert.h"
 #include "xenia/base/cvar.h"
 #include "xenia/base/debugging.h"
+#include "xenia/base/locale.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/platform.h"
 #include "xenia/base/profiling.h"
@@ -495,6 +496,10 @@ bool EmulatorApp::OnInitialize() {
   XELOGI("Storage root: {}", storage_root);
 
   config::SetupConfig(storage_root);
+
+  // Load UI translations (if any) now that the "language" cvar has been
+  // read from the config file / command line.
+  xe::locale::Initialize();
 
 #if XE_ARCH_AMD64 == 1
   amd64::InitFeatureFlags();

--- a/src/xenia/base/locale.cc
+++ b/src/xenia/base/locale.cc
@@ -1,0 +1,179 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2026 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/base/locale.h"
+
+#include <algorithm>
+#include <unordered_map>
+
+#include "third_party/tomlplusplus/include/toml++/toml.hpp"
+#include "xenia/base/cvar.h"
+#include "xenia/base/filesystem.h"
+#include "xenia/base/logging.h"
+#include "xenia/base/string.h"
+#include "xenia/base/utf8.h"
+
+DEFINE_string(
+    language, "en",
+    "UI language. \"en\" (default) uses the built-in English strings as-is. "
+    "Any other value (e.g. \"it\") loads translations from "
+    "locale/<language>.toml next to the executable, falling back to "
+    "English for any string the file doesn't cover.",
+    "General");
+
+namespace xe {
+namespace locale {
+
+namespace {
+std::unordered_map<std::string, std::string> translations_;
+std::string active_language_ = "en";
+// The language that was active when Initialize() ran at startup - i.e. the
+// language the native menu bar (built once, early in startup) actually
+// reflects. Deliberately never updated by SwitchLanguage(), so UI code can
+// compare it against current_language() to know whether a restart is
+// actually needed to fully apply the user's choice.
+std::string startup_language_ = "en";
+
+// Loads (or clears, for "en") the translation table for `language_code`.
+// Shared by Initialize() (startup) and SwitchLanguage() (runtime change from
+// the settings UI).
+void LoadLanguage(std::string_view language_code) {
+  translations_.clear();
+  active_language_ = std::string(language_code);
+
+  if (active_language_.empty() || active_language_ == "en") {
+    // Nothing to load - English strings are used as their own translation.
+    return;
+  }
+
+  auto locale_path = xe::filesystem::GetExecutableFolder() / "locale" /
+                     (active_language_ + ".toml");
+  if (!std::filesystem::exists(locale_path)) {
+    XELOGW(
+        "locale: no translation file found for language \"{}\" (looked "
+        "for {}), falling back to English.",
+        active_language_, xe::path_to_utf8(locale_path));
+    return;
+  }
+
+  toml::parse_result result;
+  try {
+    result = toml::parse_file(xe::path_to_utf8(locale_path));
+  } catch (const toml::parse_error& error) {
+    XELOGE("locale: failed to parse {}: {}", xe::path_to_utf8(locale_path),
+           error.description());
+    return;
+  }
+
+  size_t loaded = 0;
+  for (auto&& [key, value] : result) {
+    auto translated = value.value<std::string>();
+    if (translated) {
+      translations_.emplace(std::string(key.str()), *translated);
+      ++loaded;
+    }
+  }
+
+  XELOGI("locale: loaded {} translated string(s) for language \"{}\" from {}",
+         loaded, active_language_, xe::path_to_utf8(locale_path));
+}
+
+// Built-in display names, in each language's own script, for locales Xenia
+// ships a translation for. Codes without an entry here simply show as their
+// uppercased code (e.g. "xx") until someone adds a proper name - this list
+// is meant to grow alongside contributed translation files.
+const std::unordered_map<std::string, std::string>& LanguageNames() {
+  static const std::unordered_map<std::string, std::string> kNames = {
+      {"en", "English"},
+      {"it", "Italiano"},
+  };
+  return kNames;
+}
+
+}  // namespace
+
+void Initialize() {
+  LoadLanguage(cvars::language);
+  startup_language_ = active_language_;
+}
+
+std::string Translate(std::string_view source) {
+  if (!translations_.empty()) {
+    auto it = translations_.find(std::string(source));
+    if (it != translations_.end() && !it->second.empty()) {
+      return it->second;
+    }
+  }
+  // Fallback: no translation loaded, or none defined for this string -
+  // just use the English source as-is.
+  return std::string(source);
+}
+
+const std::string& current_language() { return active_language_; }
+
+bool RestartRequired() { return active_language_ != startup_language_; }
+
+std::vector<std::string> AvailableLanguages() {
+  // Scanning the disk and logging on every call would mean doing it every
+  // single UI frame the language dropdown is open (60+ times a second) -
+  // wasteful, and it floods xenia.log. The set of translation files present
+  // next to the executable isn't expected to change while Xenia is running,
+  // so scan once and reuse the result.
+  static const std::vector<std::string> kCachedLanguages = [] {
+    std::vector<std::string> languages = {"en"};
+
+    auto locale_dir = xe::filesystem::GetExecutableFolder() / "locale";
+    if (!std::filesystem::exists(locale_dir)) {
+      XELOGI(
+          "locale: no \"locale\" folder found next to the executable "
+          "(looked for {}) - only English will be offered.",
+          xe::path_to_utf8(locale_dir));
+      return languages;
+    }
+
+    for (const auto& file : xe::filesystem::ListFiles(locale_dir)) {
+      if (file.type != xe::filesystem::FileInfo::Type::kFile) {
+        continue;
+      }
+      if (xe::utf8::equal_case(xe::path_to_utf8(file.name.extension()),
+                               ".toml")) {
+        std::string code = xe::path_to_utf8(file.name.stem());
+        if (code != "en" && std::find(languages.begin(), languages.end(),
+                                      code) == languages.end()) {
+          languages.push_back(code);
+        }
+      }
+    }
+
+    XELOGI("locale: found {} language(s) in {} (plus built-in English).",
+           languages.size() - 1, xe::path_to_utf8(locale_dir));
+    return languages;
+  }();
+
+  return kCachedLanguages;
+}
+
+std::string DisplayName(std::string_view language_code) {
+  const auto& names = LanguageNames();
+  auto it = names.find(std::string(language_code));
+  if (it != names.end()) {
+    return it->second;
+  }
+  std::string upper(language_code);
+  std::transform(upper.begin(), upper.end(), upper.begin(), ::toupper);
+  return upper;
+}
+
+void SwitchLanguage(std::string_view language_code) {
+  LoadLanguage(language_code);
+  OVERRIDE_string(language, active_language_);
+}
+
+}  // namespace locale
+}  // namespace xe

--- a/src/xenia/base/locale.h
+++ b/src/xenia/base/locale.h
@@ -1,0 +1,79 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2026 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_BASE_LOCALE_H_
+#define XENIA_BASE_LOCALE_H_
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace xe {
+namespace locale {
+
+// Loads the translation table for the language requested via the
+// "language" cvar (e.g. "it"). Looks for
+// <executable_folder>/locale/<language>.toml.
+//
+// If the cvar is "en" (the default), or the requested locale file cannot be
+// found/parsed, this is a no-op and Translate() will simply return the
+// English source strings unchanged. This keeps the feature entirely
+// opt-in and impossible to break existing behavior for anyone who doesn't
+// pick a language.
+void Initialize();
+
+// Returns the translated string matching `source`, if the currently loaded
+// locale defines one, otherwise returns `source` itself untouched.
+//
+// `source` is always the original English UI string, which doubles as the
+// lookup key - this mirrors the classic gettext `_()` convention, so the
+// English text keeps working as a sensible fallback even for languages
+// that have no (or an incomplete) translation file yet.
+std::string Translate(std::string_view source);
+
+// Returns the language code currently active (e.g. "en", "it").
+const std::string& current_language();
+
+// Returns true if the current language differs from the one the app was
+// started with (or last restarted into) - i.e. the native menu bar is out of
+// date and a restart is actually needed to fully apply the change. Dialogs
+// are unaffected either way; they always reflect current_language().
+bool RestartRequired();
+
+// Scans <executable_folder>/locale/*.toml and returns the language codes
+// found there, always including "en" first (the built-in English strings,
+// which needs no file on disk).
+std::vector<std::string> AvailableLanguages();
+
+// Returns a human-readable name for a language code, in that language's own
+// script (e.g. "it" -> "Italiano"), so it reads correctly even to someone who
+// doesn't yet know the current UI language. Falls back to the code itself
+// (uppercased) for languages not in the built-in name table - this never
+// blocks a translation file from being usable, it just shows a less pretty
+// label until a name is added here.
+std::string DisplayName(std::string_view language_code);
+
+// Switches the active language immediately (reloading its locale file, or
+// clearing translations for "en") without needing to relaunch Xenia. Also
+// updates the "language" cvar so the choice is saved to xenia.config.toml
+// on exit. Menu bar text built once at startup (native OS menu items) will
+// only reflect the new language after a restart; ImGui-drawn dialogs update
+// on the next frame.
+void SwitchLanguage(std::string_view language_code);
+
+}  // namespace locale
+}  // namespace xe
+
+// Shorthand for xe::locale::Translate, used at UI call sites so translatable
+// strings are easy to grep for and visually distinct from strings that are
+// intentionally left untranslated (hotkeys, format specifiers, ImGui ID
+// suffixes, file filters, log/debug messages, CVar names, etc).
+#define XE_LOCALIZE(str) ::xe::locale::Translate(str)
+
+#endif  // XENIA_BASE_LOCALE_H_

--- a/src/xenia/base/system.h
+++ b/src/xenia/base/system.h
@@ -27,6 +27,15 @@ void ShutdownAndroidSystem();
 void LaunchWebBrowser(const std::string_view url);
 void LaunchFileExplorer(const std::filesystem::path& path);
 
+// Launches a new instance of the current executable with the exact same
+// command line it was started with. Does NOT terminate the current process -
+// callers should follow a successful call with their normal clean shutdown
+// path (so config is saved, resources are released, etc. as usual). Returns
+// false (without launching anything) if this isn't supported on the current
+// platform - callers should fall back to asking the user to restart
+// manually in that case.
+bool RestartApplication();
+
 bool SetProcessPriorityClass(const uint32_t priority_class);
 
 // Determine if the Xbox Gamebar is enabled via the Windows registry

--- a/src/xenia/base/system_android.cc
+++ b/src/xenia/base/system_android.cc
@@ -283,6 +283,13 @@ void LaunchWebBrowser(const std::string_view url) {
 
 void LaunchFileExplorer(const std::filesystem::path& path) { assert_always(); }
 
+bool RestartApplication() {
+  // Not supported on Android - the OS doesn't expect (or make it easy for)
+  // apps to relaunch themselves this way. Callers fall back to asking the
+  // user to close and reopen Xenia manually.
+  return false;
+}
+
 void ShowSimpleMessageBox(SimpleMessageBoxType type, std::string_view message) {
   // TODO(Triang3l): Likely not needed much at all. ShowSimpleMessageBox is a
   // concept pretty unfriendly to platforms like Android because it's blocking,

--- a/src/xenia/base/system_gnulinux.cc
+++ b/src/xenia/base/system_gnulinux.cc
@@ -9,9 +9,13 @@
 
 #include <alloca.h>
 #include <dlfcn.h>
+#include <limits.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include <cstring>
+#include <fstream>
+#include <vector>
 
 #include "xenia/base/assert.h"
 #include "xenia/base/logging.h"
@@ -33,6 +37,72 @@ void LaunchFileExplorer(const std::filesystem::path& path) {
   auto cmd = std::string("xdg-open ");
   cmd.append(path);
   system(cmd.c_str());
+}
+
+bool RestartApplication() {
+  // Note for reviewers/static analysis: every value fed into fork()/execv()
+  // below comes from the kernel's own view of the *already-running* process
+  // (/proc/self/exe, /proc/self/cmdline) - i.e. exactly the binary path and
+  // arguments this same instance of Xenia was already launched with. There
+  // is no shell involved (execv, not system()/popen()) and no external or
+  // user-supplied string (e.g. a cvar value) is appended to argv, so this
+  // cannot be used to execute anything other than another copy of Xenia
+  // with its own original arguments.
+
+  // /proc/self/exe resolves to the actual running binary regardless of how
+  // it was invoked (relative path, $PATH lookup, symlink, etc.).
+  char exe_path[PATH_MAX];
+  ssize_t exe_path_length =
+      readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1);
+  if (exe_path_length <= 0) {
+    return false;
+  }
+  exe_path[exe_path_length] = '\0';
+
+  // /proc/self/cmdline holds the original argv, NUL-separated, terminated by
+  // a double NUL. Reproducing it exactly preserves whatever flags or content
+  // path Xenia was originally launched with.
+  std::ifstream cmdline_file("/proc/self/cmdline", std::ios::binary);
+  if (!cmdline_file.is_open()) {
+    return false;
+  }
+  std::vector<char> cmdline_bytes(
+      (std::istreambuf_iterator<char>(cmdline_file)),
+      std::istreambuf_iterator<char>());
+
+  std::vector<std::string> args;
+  size_t start = 0;
+  for (size_t i = 0; i < cmdline_bytes.size(); ++i) {
+    if (cmdline_bytes[i] == '\0') {
+      args.emplace_back(&cmdline_bytes[start], i - start);
+      start = i + 1;
+    }
+  }
+  if (args.empty()) {
+    // Fall back to just the executable path with no extra arguments.
+    args.emplace_back(exe_path);
+  }
+
+  std::vector<char*> argv;
+  argv.reserve(args.size() + 1);
+  for (auto& arg : args) {
+    argv.push_back(arg.data());
+  }
+  argv.push_back(nullptr);
+
+  pid_t child_pid = fork();
+  if (child_pid < 0) {
+    return false;
+  }
+  if (child_pid == 0) {
+    // Child: replace this process image with a fresh instance of Xenia.
+    execv(exe_path, argv.data());
+    // Only reached if execv failed.
+    _exit(127);
+  }
+  // Parent: the new instance is on its way up: let the caller shut this one
+  // down normally (saving config, releasing resources, etc).
+  return true;
 }
 
 void ShowSimpleMessageBox(SimpleMessageBoxType type, std::string_view message) {

--- a/src/xenia/base/system_gnulinux.cc
+++ b/src/xenia/base/system_gnulinux.cc
@@ -9,6 +9,7 @@
 
 #include <alloca.h>
 #include <dlfcn.h>
+#include <fcntl.h>
 #include <limits.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -25,6 +26,10 @@
 // Use headers in third party to not depend on system sdl headers for building
 #include "third_party/SDL2/include/SDL.h"
 
+// Not reliably declared by <unistd.h> on all libcs without feature-test
+// macros we don't otherwise need; declared explicitly for fexecve() below.
+extern char** environ;
+
 namespace xe {
 
 void LaunchWebBrowser(const std::string_view url) {
@@ -40,21 +45,34 @@ void LaunchFileExplorer(const std::filesystem::path& path) {
 }
 
 bool RestartApplication() {
-  // Note for reviewers/static analysis: every value fed into fork()/execv()
+  // Note for reviewers/static analysis: every value fed into fork()/exec()
   // below comes from the kernel's own view of the *already-running* process
   // (/proc/self/exe, /proc/self/cmdline) - i.e. exactly the binary path and
   // arguments this same instance of Xenia was already launched with. There
-  // is no shell involved (execv, not system()/popen()) and no external or
+  // is no shell involved (fexecve, not system()/popen()) and no external or
   // user-supplied string (e.g. a cvar value) is appended to argv, so this
   // cannot be used to execute anything other than another copy of Xenia
   // with its own original arguments.
+  //
+  // The executable is opened once here and executed via its file descriptor
+  // (fexecve) rather than by re-resolving "/proc/self/exe" as a path string
+  // a second time at exec() - this closes the Time-Of-Check-To-Time-Of-Use
+  // gap a path-based execv() would otherwise have between "look up the
+  // path" and "run whatever is at that path now": with fexecve, the binary
+  // actually launched is guaranteed to be the exact file that was just
+  // open()'d, not whatever a symlink might resolve to a moment later.
+  int exe_fd = open("/proc/self/exe", O_RDONLY | O_CLOEXEC);
+  if (exe_fd < 0) {
+    return false;
+  }
 
-  // /proc/self/exe resolves to the actual running binary regardless of how
-  // it was invoked (relative path, $PATH lookup, symlink, etc.).
+  // Only used for the argv[0] fallback below if /proc/self/cmdline can't be
+  // read - never used to choose what gets executed.
   char exe_path[PATH_MAX];
   ssize_t exe_path_length =
       readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1);
   if (exe_path_length <= 0) {
+    close(exe_fd);
     return false;
   }
   exe_path[exe_path_length] = '\0';
@@ -64,6 +82,7 @@ bool RestartApplication() {
   // path Xenia was originally launched with.
   std::ifstream cmdline_file("/proc/self/cmdline", std::ios::binary);
   if (!cmdline_file.is_open()) {
+    close(exe_fd);
     return false;
   }
   std::vector<char> cmdline_bytes(
@@ -92,16 +111,19 @@ bool RestartApplication() {
 
   pid_t child_pid = fork();
   if (child_pid < 0) {
+    close(exe_fd);
     return false;
   }
   if (child_pid == 0) {
-    // Child: replace this process image with a fresh instance of Xenia.
-    execv(exe_path, argv.data());
-    // Only reached if execv failed.
+    // Child: replace this process image with a fresh instance of Xenia,
+    // launched from the exact file descriptor opened above.
+    fexecve(exe_fd, argv.data(), environ);
+    // Only reached if fexecve failed.
     _exit(127);
   }
   // Parent: the new instance is on its way up: let the caller shut this one
   // down normally (saving config, releasing resources, etc).
+  close(exe_fd);
   return true;
 }
 

--- a/src/xenia/base/system_win.cc
+++ b/src/xenia/base/system_win.cc
@@ -25,6 +25,47 @@ void LaunchFileExplorer(const std::filesystem::path& url) {
                 SW_SHOWNORMAL);
 }
 
+bool RestartApplication() {
+  // Note for reviewers/static analysis: both arguments fed into
+  // CreateProcessW below come from the OS's own view of the *already
+  // running* process - GetModuleFileNameW (the on-disk path of this very
+  // executable) and GetCommandLineW() (the exact command line this same
+  // instance of Xenia was already launched with). No external or
+  // user-supplied string (e.g. a cvar value) is appended, so this cannot be
+  // used to execute anything other than another copy of Xenia with its own
+  // original arguments.
+
+  wchar_t module_path[MAX_PATH];
+  DWORD path_length = GetModuleFileNameW(nullptr, module_path, MAX_PATH);
+  if (!path_length || path_length == MAX_PATH) {
+    // Path missing or truncated - bail rather than launching something wrong.
+    return false;
+  }
+
+  // GetCommandLineW() returns the exact string this process was launched
+  // with (including the executable path itself as argv[0]), so simply
+  // passing it straight through to CreateProcessW reproduces the original
+  // invocation - whatever flags or content path the user originally used.
+  std::wstring command_line = GetCommandLineW();
+
+  STARTUPINFOW startup_info = {};
+  startup_info.cb = sizeof(startup_info);
+  PROCESS_INFORMATION process_info = {};
+
+  // CreateProcessW may modify its command-line buffer in place, so it must
+  // not point at read-only memory (unlike a string literal).
+  BOOL result =
+      CreateProcessW(module_path, command_line.data(), nullptr, nullptr, FALSE,
+                     0, nullptr, nullptr, &startup_info, &process_info);
+  if (!result) {
+    return false;
+  }
+
+  CloseHandle(process_info.hThread);
+  CloseHandle(process_info.hProcess);
+  return true;
+}
+
 void ShowSimpleMessageBox(SimpleMessageBoxType type,
                           const std::string_view message) {
   const wchar_t* title;

--- a/src/xenia/kernel/xam/ui/create_profile_ui.cc
+++ b/src/xenia/kernel/xam/ui/create_profile_ui.cc
@@ -8,6 +8,7 @@
  */
 
 #include "xenia/kernel/xam/ui/create_profile_ui.h"
+#include "xenia/base/locale.h"
 #include "xenia/emulator.h"
 
 namespace xe {
@@ -17,7 +18,7 @@ namespace ui {
 
 void CreateProfileUI::OnDraw(ImGuiIO& io) {
   if (!has_opened_) {
-    ImGui::OpenPopup("Create Profile");
+    ImGui::OpenPopup(XE_LOCALIZE("Create Profile").c_str());
     has_opened_ = true;
   }
 
@@ -25,10 +26,10 @@ void CreateProfileUI::OnDraw(ImGuiIO& io) {
       emulator_->kernel_state()->xam_state()->profile_manager();
 
   bool dialog_open = true;
-  if (!ImGui::BeginPopupModal("Create Profile", &dialog_open,
-                              ImGuiWindowFlags_NoCollapse |
-                                  ImGuiWindowFlags_AlwaysAutoResize |
-                                  ImGuiWindowFlags_HorizontalScrollbar)) {
+  if (!ImGui::BeginPopupModal(
+          XE_LOCALIZE("Create Profile").c_str(), &dialog_open,
+          ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_AlwaysAutoResize |
+              ImGuiWindowFlags_HorizontalScrollbar)) {
     Close();
     return;
   }
@@ -37,14 +38,15 @@ void CreateProfileUI::OnDraw(ImGuiIO& io) {
     ImGui::SetKeyboardFocusHere();
   }
 
-  ImGui::TextUnformatted("Gamertag:");
+  ImGui::TextUnformatted(XE_LOCALIZE("Gamertag:").c_str());
   const bool enter_pressed =
       ImGui::InputText("##Gamertag", gamertag_, sizeof(gamertag_),
                        ImGuiInputTextFlags_EnterReturnsTrue);
   valid_gamertag_ = profile_manager->IsGamertagValid(std::string(gamertag_));
 
   ImGui::BeginDisabled(!valid_gamertag_);
-  if (ImGui::Button("Create") || (enter_pressed && valid_gamertag_)) {
+  if (ImGui::Button(XE_LOCALIZE("Create").c_str()) ||
+      (enter_pressed && valid_gamertag_)) {
     bool autologin = (profile_manager->GetAccountCount() == 0);
     if (profile_manager->CreateProfile(std::string(gamertag_), autologin,
                                        migration_) &&
@@ -57,7 +59,7 @@ void CreateProfileUI::OnDraw(ImGuiIO& io) {
   ImGui::EndDisabled();
   ImGui::SameLine();
 
-  if (ImGui::Button("Cancel")) {
+  if (ImGui::Button(XE_LOCALIZE("Cancel").c_str())) {
     std::fill(std::begin(gamertag_), std::end(gamertag_), '\0');
     dialog_open = false;
   }

--- a/src/xenia/kernel/xam/ui/game_achievements_ui.cc
+++ b/src/xenia/kernel/xam/ui/game_achievements_ui.cc
@@ -8,6 +8,7 @@
  */
 
 #include "xenia/kernel/xam/ui/game_achievements_ui.h"
+#include "xenia/base/locale.h"
 
 namespace xe {
 namespace kernel {
@@ -57,7 +58,7 @@ bool GameAchievementsUI::LoadAchievementsData() {
 
 std::string GameAchievementsUI::GetAchievementTitle(
     const Achievement& achievement_entry) const {
-  std::string title = "Secret trophy";
+  std::string title = XE_LOCALIZE("Secret trophy");
 
   if (achievement_entry.IsUnlocked() || show_locked_info_ ||
       achievement_entry.flags &
@@ -70,7 +71,7 @@ std::string GameAchievementsUI::GetAchievementTitle(
 
 std::string GameAchievementsUI::GetAchievementDescription(
     const Achievement& achievement_entry) const {
-  std::string description = "Hidden description";
+  std::string description = XE_LOCALIZE("Hidden description");
 
   if (achievement_entry.flags &
       static_cast<uint32_t>(AchievementFlags::kShowUnachieved)) {
@@ -107,8 +108,9 @@ std::string GameAchievementsUI::GetUnlockedTime(
         std::chrono::system_clock::to_time_t(chrono::WinSystemClock::to_sys(
             achievement_entry.unlock_time.to_time_point()));
 
-    return fmt::format("Unlocked: Online {:%Y-%m-%d %H:%M}",
-                       *std::localtime(&unlock_time));
+    return fmt::format(
+        fmt::runtime(XE_LOCALIZE("Unlocked: Online {:%Y-%m-%d %H:%M}")),
+        *std::localtime(&unlock_time));
   }
 
   if (achievement_entry.unlock_time.is_valid()) {
@@ -116,10 +118,11 @@ std::string GameAchievementsUI::GetUnlockedTime(
         std::chrono::system_clock::to_time_t(chrono::WinSystemClock::to_sys(
             achievement_entry.unlock_time.to_time_point()));
 
-    return fmt::format("Unlocked: Offline ({:%Y-%m-%d %H:%M})",
-                       *std::localtime(&unlock_time));
+    return fmt::format(
+        fmt::runtime(XE_LOCALIZE("Unlocked: Offline ({:%Y-%m-%d %H:%M})")),
+        *std::localtime(&unlock_time));
   }
-  return fmt::format("Unlocked: Offline");
+  return XE_LOCALIZE("Unlocked: Offline");
 }
 
 void GameAchievementsUI::DrawTitleAchievementInfo(
@@ -188,7 +191,8 @@ void GameAchievementsUI::OnDraw(ImGuiIO& io) {
                    title_name.end());
 
   const std::string window_name =
-      fmt::format("{} Achievements###{}", title_name, window_id_);
+      fmt::format(fmt::runtime(XE_LOCALIZE("{} Achievements###{}")), title_name,
+                  window_id_);
   if (!ImGui::Begin(window_name.c_str(), &dialog_open,
                     ImGuiWindowFlags_NoCollapse |
                         ImGuiWindowFlags_AlwaysAutoResize |
@@ -198,11 +202,12 @@ void GameAchievementsUI::OnDraw(ImGuiIO& io) {
     return;
   }
 
-  ImGui::Checkbox("Show locked achievements information", &show_locked_info_);
+  ImGui::Checkbox(XE_LOCALIZE("Show locked achievements information").c_str(),
+                  &show_locked_info_);
   ImGui::Separator();
 
   if (achievements_info_.empty()) {
-    ImGui::TextUnformatted(fmt::format("No achievements data!").c_str());
+    ImGui::TextUnformatted(XE_LOCALIZE("No achievements data!").c_str());
   } else {
     if (ImGui::BeginTable("", 3, ImGuiTableFlags_BordersInnerH)) {
       for (const auto& entry : achievements_info_) {

--- a/src/xenia/kernel/xam/ui/passcode_ui.cc
+++ b/src/xenia/kernel/xam/ui/passcode_ui.cc
@@ -8,6 +8,7 @@
  */
 
 #include "xenia/kernel/xam/ui/passcode_ui.h"
+#include "xenia/base/locale.h"
 
 namespace xe {
 namespace kernel {
@@ -25,11 +26,11 @@ ProfilePasscodeUI::ProfilePasscodeUI(xe::ui::ImGuiDrawer* imgui_drawer,
   std::memset(result_ptr, 0, sizeof(MESSAGEBOX_RESULT));
 
   if (title_.empty()) {
-    title_ = "Enter Pass Code";
+    title_ = XE_LOCALIZE("Enter Pass Code");
   }
 
   if (description_.empty()) {
-    description_ = "Enter your Xbox LIVE pass code.";
+    description_ = XE_LOCALIZE("Enter your Xbox LIVE pass code.");
   }
 }
 

--- a/src/xenia/kernel/xam/ui/signin_ui.cc
+++ b/src/xenia/kernel/xam/ui/signin_ui.cc
@@ -8,6 +8,7 @@
  */
 
 #include "xenia/kernel/xam/ui/signin_ui.h"
+#include "xenia/base/locale.h"
 
 namespace xe {
 namespace kernel {
@@ -21,7 +22,7 @@ SigninUI::SigninUI(xe::ui::ImGuiDrawer* imgui_drawer,
       profile_manager_(profile_manager),
       last_user_(last_used_slot),
       users_needed_(users_needed),
-      title_("Sign In") {}
+      title_(XE_LOCALIZE("Sign In")) {}
 
 void SigninUI::OnDraw(ImGuiIO& io) {
   bool first_draw = false;
@@ -131,15 +132,15 @@ void SigninUI::OnDraw(ImGuiIO& io) {
 
     ImGui::Spacing();
 
-    if (ImGui::Button("Create Profile")) {
+    if (ImGui::Button(XE_LOCALIZE("Create Profile").c_str())) {
       creating_profile_ = true;
-      ImGui::OpenPopup("Create Profile");
+      ImGui::OpenPopup(XE_LOCALIZE("Create Profile").c_str());
       first_draw = true;
     }
     ImGui::Spacing();
 
     if (creating_profile_) {
-      if (ImGui::BeginPopupModal("Create Profile", nullptr,
+      if (ImGui::BeginPopupModal(XE_LOCALIZE("Create Profile").c_str(), nullptr,
                                  ImGuiWindowFlags_NoCollapse |
                                      ImGuiWindowFlags_AlwaysAutoResize |
                                      ImGuiWindowFlags_HorizontalScrollbar)) {
@@ -147,14 +148,14 @@ void SigninUI::OnDraw(ImGuiIO& io) {
           ImGui::SetKeyboardFocusHere();
         }
 
-        ImGui::TextUnformatted("Gamertag:");
+        ImGui::TextUnformatted(XE_LOCALIZE("Gamertag:").c_str());
         if (ImGui::InputText("##Gamertag", gamertag_, sizeof(gamertag_))) {
           valid_gamertag_ =
               profile_manager_->IsGamertagValid(std::string(gamertag_));
         }
 
         ImGui::BeginDisabled(!valid_gamertag_);
-        if (ImGui::Button("Create")) {
+        if (ImGui::Button(XE_LOCALIZE("Create").c_str())) {
           profile_manager_->CreateProfile(std::string(gamertag_), false);
           std::fill(std::begin(gamertag_), std::end(gamertag_), '\0');
           ImGui::CloseCurrentPopup();
@@ -164,7 +165,7 @@ void SigninUI::OnDraw(ImGuiIO& io) {
         ImGui::EndDisabled();
         ImGui::SameLine();
 
-        if (ImGui::Button("Cancel")) {
+        if (ImGui::Button(XE_LOCALIZE("Cancel").c_str())) {
           std::fill(std::begin(gamertag_), std::end(gamertag_), '\0');
           ImGui::CloseCurrentPopup();
           creating_profile_ = false;
@@ -176,7 +177,7 @@ void SigninUI::OnDraw(ImGuiIO& io) {
       }
     }
 
-    if (ImGui::Button("OK")) {
+    if (ImGui::Button(XE_LOCALIZE("OK").c_str())) {
       std::map<uint8_t, uint64_t> profile_map;
       for (uint32_t i = 0; i < users_needed_; i++) {
         uint8_t slot = chosen_slots_[i];
@@ -192,7 +193,7 @@ void SigninUI::OnDraw(ImGuiIO& io) {
     }
     ImGui::SameLine();
 
-    if (ImGui::Button("Cancel")) {
+    if (ImGui::Button(XE_LOCALIZE("Cancel").c_str())) {
       ImGui::CloseCurrentPopup();
       Close();
     }

--- a/src/xenia/kernel/xam/ui/title_info_ui.cc
+++ b/src/xenia/kernel/xam/ui/title_info_ui.cc
@@ -10,6 +10,7 @@
 #include "xenia/kernel/xam/ui/title_info_ui.h"
 #include "xenia/kernel/xam/ui/game_achievements_ui.h"
 
+#include "xenia/base/locale.h"
 #include "xenia/base/system.h"
 
 namespace xe {
@@ -25,7 +26,8 @@ TitleListUI::TitleListUI(xe::ui::ImGuiDrawer* imgui_drawer,
       profile_(profile),
       profile_manager_(kernel_state()->xam_state()->profile_manager()),
       dialog_name_(
-          fmt::format("{}'s Games List###{}", profile->name(), GetWindowId())) {
+          fmt::format(fmt::runtime(XE_LOCALIZE("{}'s Games List###{}")),
+                      profile->name(), GetWindowId())) {
   LoadProfileTitleList(imgui_drawer, profile);
 }
 
@@ -88,11 +90,12 @@ void TitleListUI::DrawTitleEntry(ImGuiIO& io, TitleInfo& entry) {
         std::chrono::system_clock::time_point(
             entry.last_played.time_since_epoch()));
 
-    ImGui::TextUnformatted(fmt::format("Last played: {:%Y-%m-%d %H:%M}",
-                                       *std::localtime(&time_date))
-                               .c_str());
+    ImGui::TextUnformatted(
+        fmt::format(fmt::runtime(XE_LOCALIZE("Last played: {:%Y-%m-%d %H:%M}")),
+                    *std::localtime(&time_date))
+            .c_str());
   } else {
-    ImGui::TextUnformatted("Last played: Unknown");
+    ImGui::TextUnformatted(XE_LOCALIZE("Last played: Unknown").c_str());
   }
   ImGui::TableNextColumn();
 
@@ -112,7 +115,8 @@ void TitleListUI::DrawTitleEntry(ImGuiIO& io, TitleInfo& entry) {
   }
 
   if (ImGui::BeginPopupContextItem(
-          fmt::format("Title Menu {:08X}", entry.id).c_str())) {
+          fmt::format(fmt::runtime(XE_LOCALIZE("Title Menu {:08X}")), entry.id)
+              .c_str())) {
     selected_title_ = entry.id;
 
     const auto savefile_path = profile_manager_->GetProfileContentPath(
@@ -124,18 +128,18 @@ void TitleListUI::DrawTitleEntry(ImGuiIO& io, TitleInfo& entry) {
     const auto tu_path = profile_manager_->GetProfileContentPath(
         0, entry.id, XContentType::kInstaller);
 
-    if (ImGui::MenuItem("Open savefile directory", nullptr, nullptr,
-                        std::filesystem::exists(savefile_path))) {
+    if (ImGui::MenuItem(XE_LOCALIZE("Open savefile directory").c_str(), nullptr,
+                        nullptr, std::filesystem::exists(savefile_path))) {
       std::thread path_open(LaunchFileExplorer, savefile_path);
       path_open.detach();
     }
-    if (ImGui::MenuItem("Open DLC directory", nullptr, nullptr,
-                        std::filesystem::exists(dlc_path))) {
+    if (ImGui::MenuItem(XE_LOCALIZE("Open DLC directory").c_str(), nullptr,
+                        nullptr, std::filesystem::exists(dlc_path))) {
       std::thread path_open(LaunchFileExplorer, dlc_path);
       path_open.detach();
     }
-    if (ImGui::MenuItem("Open Title Update directory", nullptr, nullptr,
-                        std::filesystem::exists(tu_path))) {
+    if (ImGui::MenuItem(XE_LOCALIZE("Open Title Update directory").c_str(),
+                        nullptr, nullptr, std::filesystem::exists(tu_path))) {
       std::thread path_open(LaunchFileExplorer, tu_path);
       path_open.detach();
     }
@@ -146,7 +150,8 @@ void TitleListUI::DrawTitleEntry(ImGuiIO& io, TitleInfo& entry) {
         kernel_state()->xam_state()->user_tracker()->GetUserTitleInfo(
             profile_->xuid(), entry.id);
 
-    if (ImGui::MenuItem("Refresh title stats", nullptr, nullptr, true)) {
+    if (ImGui::MenuItem(XE_LOCALIZE("Refresh title stats").c_str(), nullptr,
+                        nullptr, true)) {
       kernel_state()->xam_state()->user_tracker()->RefreshTitleSummary(
           profile_->xuid(), entry.id);
 
@@ -156,7 +161,7 @@ void TitleListUI::DrawTitleEntry(ImGuiIO& io, TitleInfo& entry) {
     }
 
     if (title_info) {
-      if (ImGui::MenuItem("Delete title", nullptr, nullptr,
+      if (ImGui::MenuItem(XE_LOCALIZE("Delete title").c_str(), nullptr, nullptr,
                           !title_info->unlocked_achievements_count)) {
         kernel_state()->xam_state()->user_tracker()->RemoveTitleFromPlayedList(
             profile_->xuid(), entry.id);
@@ -188,7 +193,7 @@ void TitleListUI::OnDraw(ImGuiIO& io) {
 
   if (!info_.empty()) {
     if (info_.size() > 10) {
-      ImGui::Text("Search: ");
+      ImGui::Text("%s", XE_LOCALIZE("Search: ").c_str());
       ImGui::SameLine();
       ImGui::InputText("##Search", title_name_filter_, title_name_filter_size);
       ImGui::Separator();
@@ -213,7 +218,8 @@ void TitleListUI::OnDraw(ImGuiIO& io) {
     }
   } else {
     // Align text to the center
-    std::string no_entries_message = "There are no titles, so far.";
+    std::string no_entries_message =
+        XE_LOCALIZE("There are no titles, so far.");
 
     ImGui::PushFont(imgui_drawer()->GetTitleFont());
     float windowWidth = ImGui::GetContentRegionAvail().x;

--- a/src/xenia/kernel/xam/xam_ui.cc
+++ b/src/xenia/kernel/xam/xam_ui.cc
@@ -9,6 +9,7 @@
 
 #include "xenia/kernel/xam/xam_ui.h"
 #include "xenia/app/emulator_window.h"
+#include "xenia/base/locale.h"
 #include "xenia/base/png_utils.h"
 #include "xenia/base/system.h"
 #include "xenia/hid/input_system.h"
@@ -283,7 +284,7 @@ void KeyboardInputDialog::OnDraw(ImGuiIO& io) {
                          ImGuiInputTextFlags_EnterReturnsTrue);
     // Context menu for paste functionality
     if (ImGui::BeginPopupContextItem("input_context_menu")) {
-      if (ImGui::MenuItem("Paste")) {
+      if (ImGui::MenuItem(XE_LOCALIZE("Paste").c_str())) {
         if (ImGui::GetClipboardText() != nullptr) {
           std::string clipboard_text = ImGui::GetClipboardText();
           xe::string_util::copy_truncating(text_buffer_.data(), clipboard_text,
@@ -299,14 +300,14 @@ void KeyboardInputDialog::OnDraw(ImGuiIO& io) {
       ImGui::CloseCurrentPopup();
       Close();
     }
-    if (ImGui::Button("OK")) {
+    if (ImGui::Button(XE_LOCALIZE("OK").c_str())) {
       text_ = std::string(text_buffer_.data(), text_buffer_.size());
       cancelled_ = false;
       ImGui::CloseCurrentPopup();
       Close();
     }
     ImGui::SameLine();
-    if (ImGui::Button("Cancel")) {
+    if (ImGui::Button(XE_LOCALIZE("Cancel").c_str())) {
       text_ = "";
       cancelled_ = true;
       ImGui::CloseCurrentPopup();
@@ -872,13 +873,19 @@ bool xeDrawProfileContent(xe::ui::ImGuiDrawer* imgui_drawer,
     ImGui::BeginGroup();
     {
       ImGui::TextUnformatted(
-          fmt::format("User: {}\n", account->GetGamertagString()).c_str());
-      ImGui::TextUnformatted(fmt::format("XUID: {:016X}  \n", xuid).c_str());
+          fmt::format(fmt::runtime(XE_LOCALIZE("User: {}\n")),
+                      account->GetGamertagString())
+              .c_str());
+      ImGui::TextUnformatted(
+          fmt::format(fmt::runtime(XE_LOCALIZE("XUID: {:016X}  \n")), xuid)
+              .c_str());
       if (user_index != XUserIndexAny) {
         ImGui::TextUnformatted(
-            fmt::format("Assigned to slot: {}\n", user_index + 1).c_str());
+            fmt::format(fmt::runtime(XE_LOCALIZE("Assigned to slot: {}\n")),
+                        user_index + 1)
+                .c_str());
       } else {
-        ImGui::TextUnformatted(fmt::format("Profile is not signed in").c_str());
+        ImGui::TextUnformatted(XE_LOCALIZE("Profile is not signed in").c_str());
       }
     }
     ImGui::EndGroup();


### PR DESCRIPTION
<!-- Suggested PR title: Add opt-in UI localization system + Italian translation -->

## What this does

Xenia's UI (main menu, ImGui dialogs) is currently English-only, with every string hardcoded in C++ - there's no localization mechanism at all (no gettext, no resource tables, no `.po`/`.json` files).

This PR adds a small, fully **opt-in** localization system and uses it to ship a community-contributed **Italian** translation as a first example. Nothing changes for existing users unless they explicitly pick a different language: default behavior (`language = "en"`) is byte-for-byte identical to before this PR.

## How it works

- A new `language` cvar (default `"en"`), saved to `xenia-canary.config.toml` like any other setting.
- `src/xenia/base/locale.{h,cc}`: if `language == "en"`, this is a no-op - no file is read, `XE_LOCALIZE(x)` just returns `x`. For any other value (e.g. `"it"`), it loads `locale/<language>.toml` next to the executable into an in-memory `english string -> translated string` map. Strings missing from the file simply fall back to English - a partial/incomplete translation never breaks anything or shows blank text.
- `XE_LOCALIZE("English string")` is used at UI call sites, mirroring the classic gettext `_()` convention: the English string doubles as both the fallback and the lookup key.
- TOML was chosen (over JSON/gettext) because the project already depends on `tomlplusplus` for `xenia-canary.config.toml` - same dependency, same parsing style, no new library added.

## In-app language picker

Console → Console settings → new **"Interface"** tab:
- a dropdown lists every `locale/*.toml` file found next to the executable (scanned once, cached for the session), plus built-in English;
- picking a language translates all ImGui dialogs **immediately**;
- the native OS menu bar (File/Profile/CPU/...) is only rebuilt at the next launch, since Xenia currently only constructs it once at startup through the native Win32/GTK/Android APIs. A **"Restart Now"** button (disabled until the selection actually differs from the language Xenia was started with) explicitly saves the general config and relaunches Xenia with the exact same command line, so the menu bar picks up the change too.
- This new function, `xe::RestartApplication()` in `src/xenia/base/system.{h,cc}`, is implemented for Windows and Linux; on Android (unsupported) it returns `false` and the UI asks the user to restart manually instead.
- This tab is intentionally not gated behind `is_title_open()` (unlike the "User"/"System" tabs, which deliberately are, since they touch the emulated console's configuration): Xenia's own UI language is unrelated to emulation state, so it can be changed at any time.

## Italian translation (`assets/locale/it.toml`)

193 translated strings covering the main menu, console settings, profile management (including the in-game profile switcher popup), sign-in/passcode dialogs, the post-processing settings window, the XMP audio player window, the controller hotkeys reference dialog, and the played-titles/achievements windows.

One implementation note on the controller hotkeys dialog: the hotkey descriptions live in a `std::map` built at static-initialization time, before `locale::Initialize()` has run, and a `std::regex` swaps the literal word "Guide" for "Back" depending on input configuration. Translating that map directly would have baked in stale/English text and broken the regex. Instead, translation happens at display time, *after* the Guide/Back substitution runs on the original English text - the substitution logic is untouched, only the final assembled string gets localized.

### Deliberately left untranslated

| What | Example | Why |
|---|---|---|
| Keyboard shortcuts | `"Alt+F4"`, `"Ctrl+O"` | Functional values compared by code, not text |
| Format placeholders | `{}`, `{:08X}`, `{:%Y-%m-%d %H:%M}` | Must stay verbatim - order/type matters |
| ImGui internal ID suffixes | `"##ResetCAS..."`, `"##Gamertag"` | Invisible to the user, used by the widget engine |
| Log messages (`XELOGE`/`XELOGI`) | the logged version of launch-failure messages | Kept in English on purpose: bug reports are read by developers, not necessarily Italian speakers |
| `gamercard_ui.cc` (excluded entirely) | country/language/color lists | Reconstructs the real Xbox 360 dashboard's own value list, not Xenia's UI text |
| Value lists in `console_settings_dialog.cc` (`kLanguageMap`, `kCountryMap`, `kAVRegion`) | `"NTSC"`, `"Japanese"` | Same reasoning: values the emulated Xbox 360 firmware itself expects |
| `MessageBoxDialog`/generic XAM dialog content (`title_`/`description_`/`buttons_`) | text passed in by callers simulating `XamShowMessageBoxUI` | Often game-provided content, not Xenia's own UI - only the dialog chrome Xenia itself always adds (e.g. "Paste", "OK", "Cancel" in the keyboard input dialog) is translated |

## Design choices worth a maintainer's opinion

- A couple of spots used to share one string between an `XELOGE` log message and a user-facing dialog (e.g. title launch failure). I split them: the **log stays English**, the **on-screen dialog gets translated**. Flagging this explicitly since it's a behavior change from a single shared string.
- Some ImGui window/popup titles also double as their internal ID (e.g. "Create Profile"). Translating them changes that ID across a language switch - harmless (no crash), but can reset that particular window's open/closed state at the moment the language changes. Where the code already used the `"Visible Title###stable_id"` trick (games list, achievements), the ID stays stable and only the visible part is translated.
- See the controller-hotkeys note above for the static-initialization/regex interaction.

## How to test

1. Build normally.
2. Copy `assets/locale/it.toml` to `<executable folder>/locale/it.toml`.
3. Launch Xenia normally (English, as always).
4. Console → Console settings → **"Interface"** tab → pick "Italiano". Dialogs translate immediately; hit "Restart Now" to also update the menu bar.
5. Anything not yet translated simply stays in English - no broken layout, no blank strings (see screenshots below).

<details>
<summary>📸 Screenshots (click to expand)</summary>

### Main menu

<!-- drop screenshots here -->

### Console settings - Interface / User / System tabs

<!-- drop screenshots here -->

### Profile management

<!-- drop screenshots here -->

### XMP audio player / Controller hotkeys

<!-- drop screenshots here -->

### Post-processing settings

<!-- drop screenshots here -->

</details>

## Adding more languages

Contributing a translation only requires adding `assets/locale/<code>.toml` with the same key/value format - no C++ changes needed. This opens the door to a lightweight, community-editable translation process, similar to the one already used for Xenia Manager.

## Scope

This intentionally does not touch: developer-facing debug tools (`debug_window.cc`, `trace_viewer.cc`), `gamercard_ui.cc`, or any text belonging to the emulated Xbox 360 firmware itself. The goal here is to show maintainers a concrete, minimal, fully opt-in mechanism before investing in translating the entire UI surface or formalizing a translation contribution process.


<details><summary>📸 Screenshots</summary>
<img width="1282" height="772" alt="Screenshot 2026-07-18 144112" src="https://github.com/user-attachments/assets/b689902a-c884-44c6-a4db-79e43336927a" />
<img width="294" height="165" alt="Screenshot 2026-07-18 144123" src="https://github.com/user-attachments/assets/fc205055-3153-4797-b86c-a730302a3ba0" />
<img width="207" height="28" alt="Screenshot 2026-07-18 144127" src="https://github.com/user-attachments/assets/27ac4025-bcc8-473c-9fbb-99d4da37284d" />
<img width="381" height="125" alt="Screenshot 2026-07-18 144130" src="https://github.com/user-attachments/assets/1ad252f1-e315-4066-b8aa-df040f8065b8" />
<img width="238" height="59" alt="Screenshot 2026-07-18 144132" src="https://github.com/user-attachments/assets/588ab92e-f57e-4c75-97f8-a0f42057c58b" />
<img width="282" height="81" alt="Screenshot 2026-07-18 144134" src="https://github.com/user-attachments/assets/14fee2f9-e70f-4e0d-ad18-e9197ada310f" />
<img width="289" height="50" alt="Screenshot 2026-07-18 144136" src="https://github.com/user-attachments/assets/77dc12cb-8fe7-4858-8398-35f2a86629ae" />
<img width="197" height="28" alt="Screenshot 2026-07-18 144138" src="https://github.com/user-attachments/assets/6466a601-3a8d-4374-a37a-83314afc672d" />
<img width="235" height="28" alt="Screenshot 2026-07-18 144140" src="https://github.com/user-attachments/assets/4825af1c-af69-4ac9-945e-9096a83fee09" />
<img width="268" height="143" alt="Screenshot 2026-07-18 144142" src="https://github.com/user-attachments/assets/d98a2171-9b0c-46d0-af52-68bb5530c9b3" />
<img width="1282" height="772" alt="Screenshot 2026-07-18 144146" src="https://github.com/user-attachments/assets/6edaab86-4bfa-4827-ac76-096acb7f1365" />
<img width="1282" height="772" alt="Screenshot 2026-07-18 144150" src="https://github.com/user-attachments/assets/ea1155d5-7b6b-4ada-b13b-3bdb11dd916c" />
<img width="1282" height="772" alt="Screenshot 2026-07-18 144152" src="https://github.com/user-attachments/assets/fc328ea6-b1a4-45cd-9057-0cfd6cd3c69d" />
<img width="1282" height="772" alt="Screenshot 2026-07-18 144330" src="https://github.com/user-attachments/assets/9c6ece76-97bb-40df-a117-f22550066b64" />
<img width="1282" height="772" alt="Screenshot 2026-07-18 150525" src="https://github.com/user-attachments/assets/d229f673-47a9-458e-a528-c78404ef937d" />
<img width="1282" height="772" alt="Screenshot 2026-07-18 150549" src="https://github.com/user-attachments/assets/95c2044b-aeaf-4ab6-828f-85a76f41d01c" />
<img width="1282" height="772" alt="Screenshot 2026-07-18 150600" src="https://github.com/user-attachments/assets/321cca61-8bee-4c7d-a675-b0cf880178ea" />
<img width="1282" height="772" alt="Screenshot 2026-07-18 152144" src="https://github.com/user-attachments/assets/d24b51e4-d37d-4995-83bd-6f363b2c4b49" />

</details>