### PR TITLE
[XAM] Resolve directory-backed package payloads

### DIFF
--- a/src/xenia/kernel/xam/content_manager.cc
+++ b/src/xenia/kernel/xam/content_manager.cc
@@ -32,6 +32,42 @@ static const char* kSpaFilename = "spa.bin";
 
 static int content_device_id_ = 0;
 
+class ResolvedContentPackage {
+ public:
+  ResolvedContentPackage(KernelState* kernel_state,
+                         const std::filesystem::path& package_path)
+      : kernel_state_(kernel_state),
+        device_path_(fmt::format("\\Device\\ResolvedContent\\{:08X}",
+                                 ++content_device_id_)) {
+    auto fs = kernel_state_->file_system();
+    auto device = std::make_unique<vfs::HostPathDevice>(device_path_,
+                                                        package_path, false);
+    if (device->Initialize() && fs->RegisterDevice(std::move(device))) {
+      mounted_ = fs->ResolvePath(device_path_) != nullptr;
+      if (!mounted_) {
+        fs->UnregisterDevice(device_path_);
+      }
+    }
+  }
+
+  ~ResolvedContentPackage() {
+    if (mounted_) {
+      kernel_state_->file_system()->UnregisterDevice(device_path_);
+    }
+  }
+
+  bool mounted() const { return mounted_; }
+
+  std::string ResolvePath(const std::string_view path) const {
+    return xe::utf8::join_guest_paths(device_path_, path);
+  }
+
+ private:
+  KernelState* kernel_state_;
+  std::string device_path_;
+  bool mounted_ = false;
+};
+
 ContentPackage::ContentPackage(KernelState* kernel_state,
                                const std::string_view root_name,
                                const XCONTENT_AGGREGATE_DATA& data,
@@ -289,6 +325,51 @@ std::unique_ptr<ContentPackage> ContentManager::ResolvePackage(
   auto package = std::make_unique<ContentPackage>(kernel_state_, root_name,
                                                   data, package_path);
   return package;
+}
+
+std::optional<std::string> ContentManager::ResolvePackagePayloadPath(
+    const uint64_t xuid, const XCONTENT_AGGREGATE_DATA& data) {
+  const std::string file_name = xe::string_util::trim(data.file_name());
+  if (file_name.empty()) {
+    return std::nullopt;
+  }
+
+  auto global_lock = global_critical_region_.Acquire();
+  const std::filesystem::path package_path = ResolvePackagePath(xuid, data);
+  const std::filesystem::path payload_path =
+      package_path / xe::to_path(file_name);
+
+  std::error_code error_code;
+  if (!std::filesystem::is_regular_file(payload_path, error_code) ||
+      error_code) {
+    return std::nullopt;
+  }
+
+  auto fs = kernel_state_->file_system();
+  const std::string package_key = xe::path_to_utf8(package_path);
+  auto existing_package = resolved_packages_.find(package_key);
+  if (existing_package != resolved_packages_.end()) {
+    const std::string guest_path =
+        existing_package->second->ResolvePath(file_name);
+    if (fs->ResolvePath(guest_path)) {
+      return guest_path;
+    }
+    resolved_packages_.erase(existing_package);
+  }
+
+  auto package =
+      std::make_unique<ResolvedContentPackage>(kernel_state_, package_path);
+  if (!package->mounted()) {
+    return std::nullopt;
+  }
+
+  const std::string guest_path = package->ResolvePath(file_name);
+  if (!fs->ResolvePath(guest_path)) {
+    return std::nullopt;
+  }
+
+  resolved_packages_.emplace(package_key, std::move(package));
+  return guest_path;
 }
 
 bool ContentManager::ContentExists(const uint64_t xuid,

--- a/src/xenia/kernel/xam/content_manager.h
+++ b/src/xenia/kernel/xam/content_manager.h
@@ -11,6 +11,7 @@
 #define XENIA_KERNEL_XAM_CONTENT_MANAGER_H_
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -32,6 +33,8 @@ class KernelState;
 namespace xe {
 namespace kernel {
 namespace xam {
+
+class ResolvedContentPackage;
 
 // If set in XCONTENT_AGGREGATE_DATA, will be substituted with the running
 // titles ID
@@ -235,6 +238,9 @@ class ContentManager {
       const std::string_view root_name, const uint64_t xuid,
       const XCONTENT_AGGREGATE_DATA& data, const uint32_t disc_number = -1);
 
+  std::optional<std::string> ResolvePackagePayloadPath(
+      const uint64_t xuid, const XCONTENT_AGGREGATE_DATA& data);
+
   bool ContentExists(const uint64_t xuid, const XCONTENT_AGGREGATE_DATA& data);
   X_RESULT WriteContentHeaderFile(const uint64_t xuid,
                                   XCONTENT_AGGREGATE_DATA data);
@@ -287,6 +293,8 @@ class ContentManager {
   // TODO(benvanik): remove use of global lock, it's bad here!
   xe::global_critical_region global_critical_region_;
   std::unordered_map<string_key_insensitive, ContentPackage*> open_packages_;
+  std::unordered_map<std::string, std::unique_ptr<ResolvedContentPackage>>
+      resolved_packages_;
 };
 
 }  // namespace xam

--- a/src/xenia/kernel/xam/xam_content.cc
+++ b/src/xenia/kernel/xam/xam_content.cc
@@ -85,9 +85,11 @@ dword_result_t xeXamContentResolve(
     if (content_data_size == sizeof(XCONTENT_DATA)) {
       content_data = *content_data_ptr.as<XCONTENT_DATA*>();
     } else if (content_data_size == sizeof(XCONTENT_DATA_INTERNAL)) {
-      // Due to the current implementation of content data we can't use
-      // XCONTENT_DATA_INTERNAL
-      content_data = *content_data_ptr.as<XCONTENT_AGGREGATE_DATA*>();
+      const auto& internal_data =
+          *content_data_ptr.as<XCONTENT_DATA_INTERNAL*>();
+      content_data = XCONTENT_AGGREGATE_DATA(internal_data);
+      content_data.xuid = internal_data.xuid;
+      content_data.title_id = internal_data.title_id;
     } else {
       assert_always();
       return X_ERROR_INVALID_PARAMETER;
@@ -127,10 +129,24 @@ dword_result_t xeXamContentResolve(
         static_cast<uint32_t>(content_data.content_type.get()),
         content_data.file_name());
 
-    string_util::copy_truncating(path_ptr, root_device_path + relative_path,
-                                 path_size);
+    std::string resolved_path = root_device_path + relative_path;
+    if (content_data.device_id == static_cast<uint32_t>(DummyDeviceId::HDD)) {
+      // Xenia represents content packages as host directories. 4343081F
+      // creates same-named files inside saved-game packages, then opens the
+      // path returned by XamContentResolve as a file. Mount such a package and
+      // return a guest path to its payload. This is an approximation for
+      // directory-backed packages, not evidence that the console exposes an
+      // inner file path.
+      auto payload_path =
+          kernel_state()->content_manager()->ResolvePackagePayloadPath(
+              xuid, content_data);
+      if (payload_path) {
+        resolved_path = *payload_path;
+      }
+    }
 
-    // Check if it exists and try to mount that package
+    string_util::copy_truncating(path_ptr, resolved_path, path_size);
+
     // Result of buffer_ptr is sent to RtlInitAnsiString.
     // buffer_size is usually 260 (max path).
     return X_ERROR_SUCCESS;


### PR DESCRIPTION
## Summary

- resolve same-named regular-file payloads inside directory-backed HDD content packages
- keep the existing path fallback for other package layouts and ODD content
- convert `XCONTENT_DATA_INTERNAL` to aggregate content data without reading it as the wrong structure

## Background

Xenia stores content packages as host directories. In one observed saved-content layout, the package directory contains a regular-file payload with the same name as the package. Software may open the path returned by `XamContentResolve` as a file, while the existing implementation returns the directory-backed package path.

For this layout, the content manager now mounts the package directory on a temporary guest device and returns the path to the same-named payload. Both the mount root and payload are resolved before the path is returned, and the content manager owns the mount for its lifetime. If the payload is absent or cannot be resolved, behavior falls back to the existing path.

This is limited to a general host-storage layout and contains no title-specific conditional. The implementation is an approximation for Xenia's directory-backed packages, not a claim that original hardware exposes an inner host-style file path.

## Validation

- `./xb lint --origin`
- native Debug `xenia-app` build
- five built kernel tests
- `xenia-vfs-tests` target build
- [GitHub Actions](https://github.com/jaypfe/xenia-canary/actions/runs/29799444397) lint, Windows x86-64, and Linux x86-64 builds on commit `95f9f688`
- official Windows artifact runtime validation through Proton with isolated content for title ID `4343081F`:
  - an existing saved-content payload was listed and loaded
  - the payload was overwritten successfully
  - a fresh emulator process listed and loaded the updated payload
  - the control content tree remained byte-for-byte unchanged
  - the predecessor's parent-device resolution failure was absent

## Related

- Related to #603
- Related to xenia-canary/game-compatibility#754
