### PR TITLE
[CPU] Publish JIT entry results under the entry table lock

### DIFF
--- a/src/xenia/cpu/entry_table.cc
+++ b/src/xenia/cpu/entry_table.cc
@@ -83,6 +83,19 @@ Entry::Status EntryTable::GetOrCreate(uint32_t address, Entry** out_entry) {
   return status;
 }
 
+void EntryTable::MarkReady(Entry* entry, Function* function,
+                           uint32_t end_address) {
+  auto global_lock = global_critical_region_.Acquire();
+  entry->function = function;
+  entry->end_address = end_address;
+  entry->status = Entry::STATUS_READY;
+}
+
+void EntryTable::MarkFailed(Entry* entry) {
+  auto global_lock = global_critical_region_.Acquire();
+  entry->status = Entry::STATUS_FAILED;
+}
+
 void EntryTable::Delete(uint32_t address) {
   auto global_lock = global_critical_region_.Acquire();
   // doesnt this leak memory by not deleting the entry?

--- a/src/xenia/cpu/entry_table.h
+++ b/src/xenia/cpu/entry_table.h
@@ -41,6 +41,16 @@ class EntryTable {
 
   Entry* Get(uint32_t address);
   Entry::Status GetOrCreate(uint32_t address, Entry** out_entry);
+  // Publishes the result of compiling `entry` (obtained via GetOrCreate
+  // returning STATUS_NEW) under the same lock GetOrCreate's spin-wait uses to
+  // read entry->status. Callers must go through these instead of writing
+  // entry->status/function/end_address directly -- unsynchronized writes here
+  // raced against the lock-protected reads in GetOrCreate's spin-wait, so a
+  // waiting thread on a weak memory model (e.g. Apple Silicon) could observe
+  // STATUS_READY before entry->function was actually visible, returning a
+  // stale/torn function pointer.
+  void MarkReady(Entry* entry, Function* function, uint32_t end_address);
+  void MarkFailed(Entry* entry);
   void Delete(uint32_t address);
 
   std::vector<Function*> FindWithAddress(uint32_t address);

--- a/src/xenia/cpu/processor.cc
+++ b/src/xenia/cpu/processor.cc
@@ -263,12 +263,12 @@ Function* Processor::ResolveFunction(uint32_t address) {
     auto function = LookupFunction(address);
 
     if (!function) {
-      entry->status = Entry::STATUS_FAILED;
+      entry_table_.MarkFailed(entry);
       return nullptr;
     }
 
     if (!DemandFunction(function)) {
-      entry->status = Entry::STATUS_FAILED;
+      entry_table_.MarkFailed(entry);
       return nullptr;
     }
     // only add it to the list of resolved functions if resolving succeeded
@@ -282,9 +282,8 @@ Function* Processor::ResolveFunction(uint32_t address) {
       }
     }
 
-    entry->function = function;
-    entry->end_address = function->end_address();
-    status = entry->status = Entry::STATUS_READY;
+    entry_table_.MarkReady(entry, function, function->end_address());
+    status = Entry::STATUS_READY;
   }
   if (status == Entry::STATUS_READY) {
     // Ready to use.


### PR DESCRIPTION

`EntryTable::GetOrCreate` reads `entry->status` under the global critical region,
but `ResolveFunction` publishes `function`, `end_address` and `status` with no
lock held.

that leaves a data race. a thread can see `STATUS_READY` and still read a stale
function pointer

on x86 this is benign because of TSO. on AArch64 it isn't.

this change adds `MarkReady`/`MarkFailed` and publishes the result under the same
lock used by `GetOrCreate`. no deadlock,, `GetOrCreate` has already dropped it by
then and the region is recursive anyway.

TSAN reports 2 races before the change and none after:

```
Write of size 4 at 0x...26a8 by thread T1:
Previous read of size 4 at 0x...26a8 by thread T7 (mutexes: write M0):
    #0 xe::cpu::EntryTable::Get(unsigned int) entry_table.cc:37
Location is heap block of size 24 allocated by
    #1 xe::cpu::EntryTable::GetOrCreate(...) entry_table.cc:72
```

i never reproduced a crash from this, so i'm only  claiming a race fix, not a fix
for any specific bug.

tested on macOS AArch64.

<details>
<summary>TSAN harness</summary>

```
clang++ -std=c++20 -fsanitize=thread -g -O1 -I src -I . -I third_party \
  -DRACY_PUBLISH=1 entry_table_race_test.cc \
  src/xenia/cpu/entry_table.cc src/xenia/base/mutex.cc -o racy
```

```cpp
// ThreadSanitizer reproduction for the EntryTable publication race.
//
// Build twice against the real xe::cpu::EntryTable:
//   -DRACY_PUBLISH=1  reproduces the original code, which wrote
//                     entry->function / end_address / status directly from the
//                     compiling thread with no lock held.
//   -DRACY_PUBLISH=0  uses EntryTable::MarkReady, which publishes under the
//                     same global critical region GetOrCreate's spin-wait uses
//                     to read entry->status.
//
// GetOrCreate reads entry->status while holding the global critical region.
// The original publication path never took that lock, so there is no
// happens-before edge between the writes and those reads: a reader may observe
// STATUS_READY while entry->function is still the pre-publication value. On
// x86's TSO this is almost always benign; on AArch64 the stores can be
// observed out of order.

#include <atomic>
#include <cstdint>
#include <cstdio>
#include <thread>
#include <vector>

#include "xenia/cpu/entry_table.h"

// GetOrCreate's spin-wait calls this. The real implementation lives in
// threading_posix.cc, which drags in the rest of xenia-base; the sleep duration
// has no bearing on whether the publication is synchronized, so a local
// definition keeps the reproduction self-contained. The mutex is NOT stubbed --
// xenia/base/mutex.cc is linked in, because the lock is the whole point.
namespace xe {
namespace threading {
void Sleep(std::chrono::microseconds duration) {
  std::this_thread::sleep_for(duration);
}
}  // namespace threading
}  // namespace xe

namespace {

constexpr uint32_t kAddressCount = 64;
constexpr int kCompilerThreads = 4;
constexpr int kReaderThreads = 4;
constexpr int kRounds = 200;

// EntryTable only ever stores Function* as an opaque pointer, so a distinct
// non-null sentinel per address is enough to detect a torn/stale publication.
xe::cpu::Function* FakeFunctionFor(uint32_t address) {
  return reinterpret_cast<xe::cpu::Function*>(static_cast<uintptr_t>(address) |
                                              0x1000);
}

std::atomic<uint64_t> g_bad_reads{0};
std::atomic<uint64_t> g_ready_reads{0};

}  // namespace

int main() {
  for (int round = 0; round < kRounds; ++round) {
    xe::cpu::EntryTable table;
    std::atomic<bool> start{false};
    std::vector<std::thread> threads;

    for (int t = 0; t < kCompilerThreads; ++t) {
      threads.emplace_back([&table, &start, t]() {
        while (!start.load(std::memory_order_acquire)) {
        }
        for (uint32_t i = t; i < kAddressCount; i += kCompilerThreads) {
          uint32_t address = 0x82000000u + i * 4u;
          xe::cpu::Entry* entry = nullptr;
          if (table.GetOrCreate(address, &entry) != xe::cpu::Entry::STATUS_NEW) {
            continue;
          }
          // Stand in for codegen: the real processor releases the lock here.
          std::this_thread::yield();
#if RACY_PUBLISH
          entry->function = FakeFunctionFor(address);
          entry->end_address = address + 4u;
          entry->status = xe::cpu::Entry::STATUS_READY;
#else
          table.MarkReady(entry, FakeFunctionFor(address), address + 4u);
#endif
        }
      });
    }

    for (int t = 0; t < kReaderThreads; ++t) {
      threads.emplace_back([&table, &start]() {
        while (!start.load(std::memory_order_acquire)) {
        }
        for (uint32_t i = 0; i < kAddressCount; ++i) {
          uint32_t address = 0x82000000u + i * 4u;
          xe::cpu::Entry* entry = table.Get(address);
          if (!entry) {
            continue;
          }
          if (entry->status == xe::cpu::Entry::STATUS_READY) {
            g_ready_reads.fetch_add(1, std::memory_order_relaxed);
            // Anyone observing STATUS_READY must also see the function that was
            // published before it.
            if (entry->function != FakeFunctionFor(address)) {
              g_bad_reads.fetch_add(1, std::memory_order_relaxed);
            }
          }
        }
      });
    }

    start.store(true, std::memory_order_release);
    for (auto& thread : threads) {
      thread.join();
    }
  }

  std::printf("mode=%s ready_reads=%llu stale_function_reads=%llu\n",
              RACY_PUBLISH ? "racy(original)" : "marked(fixed)",
              static_cast<unsigned long long>(g_ready_reads.load()),
              static_cast<unsigned long long>(g_bad_reads.load()));
  return 0;
}
```

</details>
