### PR TITLE
[XAM/TASK] - Correct params and struct for XamTaskSchedule

### DIFF
--- a/src/xenia/kernel/xam/xam.h
+++ b/src/xenia/kernel/xam/xam.h
@@ -378,6 +378,12 @@ enum LoaderLaunchFlags : uint32_t {
   GetVersionFromExecutionId = 0x00010000,
 };
 
+struct X_TASK_ARGS {
+  be<uint32_t> flags;
+  be<uint32_t> value2;
+};
+static_assert_size(X_TASK_ARGS, 0x8);
+
 }  // namespace xam
 }  // namespace kernel
 }  // namespace xe

--- a/src/xenia/kernel/xam/xam_msg.cc
+++ b/src/xenia/kernel/xam/xam_msg.cc
@@ -45,15 +45,10 @@ dword_result_t XMsgSystemProcessCall_entry(dword_t app, dword_t message,
 }
 DECLARE_XAM_EXPORT1(XMsgSystemProcessCall, kNone, kImplemented);
 
-struct XMSGSTARTIOREQUEST_UNKNOWNARG {
-  be<uint32_t> unk_0;
-  be<uint32_t> unk_1;
-};
-
 X_HRESULT xeXMsgStartIORequestEx(uint32_t app, uint32_t message,
                                  uint32_t overlapped_ptr, uint32_t buffer_ptr,
                                  uint32_t buffer_length,
-                                 XMSGSTARTIOREQUEST_UNKNOWNARG* unknown) {
+                                 X_TASK_ARGS* xam_task_args_ptr) {
   auto result = kernel_state()->app_manager()->DispatchMessageAsync(
       app, message, buffer_ptr, buffer_length);
   if (result == X_E_NOTFOUND) {
@@ -74,9 +69,9 @@ X_HRESULT xeXMsgStartIORequestEx(uint32_t app, uint32_t message,
 dword_result_t XMsgStartIORequestEx_entry(
     dword_t app, dword_t message, pointer_t<XAM_OVERLAPPED> overlapped_ptr,
     dword_t buffer_ptr, dword_t buffer_length,
-    pointer_t<XMSGSTARTIOREQUEST_UNKNOWNARG> unknown_ptr) {
+    pointer_t<X_TASK_ARGS> xam_task_args_ptr) {
   return xeXMsgStartIORequestEx(app, message, overlapped_ptr, buffer_ptr,
-                                buffer_length, unknown_ptr);
+                                buffer_length, xam_task_args_ptr);
 }
 DECLARE_XAM_EXPORT1(XMsgStartIORequestEx, kNone, kImplemented);
 

--- a/src/xenia/kernel/xam/xam_task.cc
+++ b/src/xenia/kernel/xam/xam_task.cc
@@ -23,35 +23,16 @@ namespace xe {
 namespace kernel {
 namespace xam {
 
-struct XTASK_MESSAGE {
-  be<uint32_t> unknown_00;
-  be<uint32_t> unknown_04;
-  be<uint32_t> unknown_08;
-  be<uint32_t> callback_arg_ptr;
-  be<uint32_t> event_handle;
-  be<uint32_t> unknown_14;
-  be<uint32_t> task_handle;
-};
-
-struct XAM_TASK_ARGS {
-  be<uint32_t> flags;
-  be<uint32_t> value2;
-  // i think there might be another value here, it might be padding
-};
-static_assert_size(XTASK_MESSAGE, 0x1C);
-
-dword_result_t XamTaskSchedule_entry(lpvoid_t callback,
-                                     pointer_t<XTASK_MESSAGE> message,
-                                     dword_t optional_ptr, lpdword_t handle_ptr,
+dword_result_t XamTaskSchedule_entry(lpvoid_t callback, lpvoid_t message,
+                                     pointer_t<X_TASK_ARGS> optional_ptr,
+                                     lpdword_t handle_ptr,
                                      const ppc_context_t& ctx) {
   // TODO(gibbed): figure out what this is for
   *handle_ptr = 12345;
 
   if (optional_ptr) {
-    auto option = ctx->TranslateVirtual<XAM_TASK_ARGS*>(optional_ptr);
-
-    auto v1 = option->flags;
-    auto v2 = option->value2;  // typically 0?
+    auto v1 = optional_ptr->flags;   // 4, 8, 0x4000008, 0x402008, etc
+    auto v2 = optional_ptr->value2;  // 10, 1000, 0xea60, etc
 
     XELOGI("Got xam task args: v1 = {:08X}, v2 = {:08X}", v1.get(), v2.get());
   }


### PR DESCRIPTION
- Correct params and struct for XamTaskSchedule and XMsgStartIORequestEx
- Remove XTASK_MESSAGE pointer as its only used in xmsg calls. Message ptr can vary