### PR TITLE
[XAM] Deliver initial XMP state snapshot to new notification listeners

### DIFF
--- a/src/xenia/kernel/xam/xam_notify.cc
+++ b/src/xenia/kernel/xam/xam_notify.cc
@@ -17,7 +17,7 @@
 #include "xenia/xbox.h"
 
 DEFINE_bool(
-    xmp_initial_state_notification, true,
+    xmp_initial_state_notification, false,
     "Deliver an initial XMP state snapshot (player idle, title holds playback "
     "control) to each newly created notification listener, mirroring the "
     "state a real console's dashboard exposes to a starting title. Titles "

--- a/src/xenia/kernel/xam/xam_notify.cc
+++ b/src/xenia/kernel/xam/xam_notify.cc
@@ -7,6 +7,7 @@
  ******************************************************************************
  */
 
+#include "xenia/base/cvar.h"
 #include "xenia/kernel/kernel_state.h"
 #include "xenia/kernel/util/shim_utils.h"
 #include "xenia/kernel/xam/xam_private.h"
@@ -14,6 +15,16 @@
 #include "xenia/kernel/xnotifylistener.h"
 #include "xenia/kernel/xthread.h"
 #include "xenia/xbox.h"
+
+DEFINE_bool(
+    xmp_initial_state_notification, true,
+    "Deliver an initial XMP state snapshot (player idle, title holds playback "
+    "control) to each newly created notification listener, mirroring the "
+    "state a real console's dashboard exposes to a starting title. Titles "
+    "that mute their own soundtrack until told that no user custom "
+    "soundtrack is active (TCR compliance) otherwise wait forever and play "
+    "no music (e.g. Call of Duty: Black Ops II).",
+    "Kernel");
 
 namespace xe {
 namespace kernel {
@@ -30,6 +41,20 @@ uint32_t xeXamNotifyCreateListener(uint64_t mask, uint32_t is_system,
   auto listener =
       object_ref<XNotifyListener>(new XNotifyListener(kernel_state()));
   listener->Initialize(mask, is_system, max_version);
+
+  // On real hardware XAM leaves a title's fresh listener knowing where the
+  // system media player stands; without this, a title that boots with its
+  // music muted and waits to be told "no user soundtrack is active" waits
+  // forever. Payloads mirror the reactive broadcasts elsewhere in this
+  // codebase: state 0 = XmpApp::State::kIdle (audio_media_player.cc) and
+  // 1 = title holds playback control (xmp_app.cc, XMPSetPlaybackController).
+  // EnqueueNotification filters against the listener's own mask, so
+  // listeners that do not subscribe to the XMP area are unaffected.
+  if (cvars::xmp_initial_state_notification) {
+    listener->EnqueueNotification(kXNotificationXmpStateChanged, 0);
+    listener->EnqueueNotification(kXNotificationXmpPlaybackControllerChanged,
+                                  1);
+  }
 
   // Handle ref is incremented, so return that.
   uint32_t handle = listener->handle();


### PR DESCRIPTION
Titles are required to mute their own soundtrack while the user plays a custom soundtrack through the system music player. On real hardware XAM exposes the media player's state to a starting title, so the title knows nothing is playing and unmutes its music. Xenia never broadcasts any XMP state at boot (a fresh listener starts with an empty queue, and XMP notifications only fire reactively), so a title that boots muted and waits to be told no user music is active waits forever.

That's the cause of Black Ops II's long-standing `apu-silent` symptom ("music not playing anywhere but the main menu"): all engine music is silent (MP/Zombies menu themes, round intros, campaign score) while SFX and the frontend menu loop play. It reproduces for everyone because nothing user-visible feeds into it.

This change enqueues an initial snapshot on each newly created listener, `XmpStateChanged(idle)` and `XmpPlaybackControllerChanged(title in control)`, using the same payload values the reactive broadcasts already use. `EnqueueNotification` filters by the listener's own area mask, so titles that don't subscribe to the XMP area see no change.

Gated behind a new cvar `xmp_initial_state_notification`, **defaulting to off**. The equivalent change in #1108 was merged and then reverted for breaking several games, so this is strictly opt-in: with the default off nothing changes for any title, and the ones that need the snapshot to unmute their music can enable it. I did not find #1108 before opening this, apologies for the duplicate.

Tested with Black Ops II (TU18 + DLC): all missing music returns, and toggling the cvar off restores the silence. Repeatable both directions.
