### PR TITLE
[GPU/Memory] Edge backports, part 2

### DIFF
--- a/src/xenia/gpu/d3d12/d3d12_command_processor.cc
+++ b/src/xenia/gpu/d3d12/d3d12_command_processor.cc
@@ -2079,7 +2079,8 @@ void D3D12CommandProcessor::WriteFetchFromMem(uint32_t start_index,
       ((start_index - XE_GPU_REG_SHADER_CONSTANT_FETCH_00_0) / 6);
   uint32_t last_fetch =  // i think last_fetch should be inclusive if its modulo
                          // is nz...
-      (((start_index + num_registers) - XE_GPU_REG_SHADER_CONSTANT_FETCH_00_0) /
+      (((start_index + num_registers - 1) -
+        XE_GPU_REG_SHADER_CONSTANT_FETCH_00_0) /
        6);
   texture_cache_->TextureFetchConstantsWritten(first_fetch, last_fetch);
 

--- a/src/xenia/gpu/d3d12/d3d12_texture_cache.cc
+++ b/src/xenia/gpu/d3d12/d3d12_texture_cache.cc
@@ -1732,7 +1732,36 @@ bool D3D12TextureCache::LoadTextureDataFromResidentMemoryImpl(Texture& texture,
           source_box.front + std::max(depth >> level, uint32_t(1));
       source_box_ptr = &source_box;
     } else {
+      // Non-packed level: copy the whole footprint. The footprint is sized as
+      // the guest mip reduced then scaled, while the host mip subresource is
+      // the base scaled then reduced, so for the deepest mips of scaled
+      // textures the footprint can be a row or column larger. Compressed dests
+      // round up to the block and absorb it. For uncompressed dests clamp the
+      // copy to the exact subresource with an explicit source box to avoid
+      // overrunning. Clamp per axis to min(footprint, subresource) since a
+      // non-power-of-two axis can be smaller than the subresource while another
+      // axis is larger, and the box must not exceed the source footprint
+      // either.
       source_box_ptr = nullptr;
+      if (!host_block_compressed) {
+        const D3D12_SUBRESOURCE_FOOTPRINT& footprint =
+            location_source.PlacedFootprint.Footprint;
+        uint32_t dst_width = std::max(
+            (width * texture_resolution_scale_x) >> level, uint32_t(1));
+        uint32_t dst_height = std::max(
+            (height * texture_resolution_scale_y) >> level, uint32_t(1));
+        uint32_t dst_depth = std::max(depth >> level, uint32_t(1));
+        if (footprint.Width > dst_width || footprint.Height > dst_height ||
+            footprint.Depth > dst_depth) {
+          source_box.left = 0;
+          source_box.top = 0;
+          source_box.front = 0;
+          source_box.right = std::min(footprint.Width, dst_width);
+          source_box.bottom = std::min(footprint.Height, dst_height);
+          source_box.back = std::min(footprint.Depth, dst_depth);
+          source_box_ptr = &source_box;
+        }
+      }
     }
     for (uint32_t slice = 0; slice < array_size; ++slice) {
       command_list.D3DCopyTextureRegion(&location_dest, 0, 0, 0,

--- a/src/xenia/gpu/d3d12/d3d12_texture_cache.cc
+++ b/src/xenia/gpu/d3d12/d3d12_texture_cache.cc
@@ -140,6 +140,32 @@ bool D3D12TextureCache::Initialize() {
   }
   scaled_resolve_heap_count_ = 0;
 
+  // GetSamplerParameters drops samplers for non-filterable formats.
+  for (uint32_t i = 0; i < xe::countof(host_formats_); ++i) {
+    const HostFormat& host_format = host_formats_[i];
+    uint64_t format_bit = uint64_t(1) << i;
+    if (host_format.dxgi_format_unsigned != DXGI_FORMAT_UNKNOWN) {
+      D3D12_FEATURE_DATA_FORMAT_SUPPORT format_support = {
+          host_format.dxgi_format_unsigned};
+      if (SUCCEEDED(device->CheckFeatureSupport(D3D12_FEATURE_FORMAT_SUPPORT,
+                                                &format_support,
+                                                sizeof(format_support))) &&
+          (format_support.Support1 & D3D12_FORMAT_SUPPORT1_SHADER_SAMPLE)) {
+        host_filterable_unsigned_ |= format_bit;
+      }
+    }
+    if (host_format.dxgi_format_signed != DXGI_FORMAT_UNKNOWN) {
+      D3D12_FEATURE_DATA_FORMAT_SUPPORT format_support = {
+          host_format.dxgi_format_signed};
+      if (SUCCEEDED(device->CheckFeatureSupport(D3D12_FEATURE_FORMAT_SUPPORT,
+                                                &format_support,
+                                                sizeof(format_support))) &&
+          (format_support.Support1 & D3D12_FORMAT_SUPPORT1_SHADER_SAMPLE)) {
+        host_filterable_signed_ |= format_bit;
+      }
+    }
+  }
+
   // Create the loading root signature.
   D3D12_ROOT_PARAMETER root_parameters[3];
   // Parameter 0 is constants (changed multiple times when untiling).
@@ -795,7 +821,6 @@ D3D12TextureCache::SamplerParameters D3D12TextureCache::GetSamplerParameters(
       mip_filter == xenos::TextureFilter::kLinear;
   bool mip_base_map = mip_filter == xenos::TextureFilter::kBaseMap;
   // high cache miss count here, prefetch fetch earlier
-  //  TODO(Triang3l): Disable filtering for texture formats not supporting it.
   xenos::AnisoFilter aniso_filter =
       binding.aniso_filter == xenos::AnisoFilter::kUseFetchConst
           ? fetch.aniso_filter
@@ -819,6 +844,27 @@ D3D12TextureCache::SamplerParameters D3D12TextureCache::GetSamplerParameters(
     parameters.mip_linear = mip_filter == xenos::TextureFilter::kLinear;
   }
   parameters.mip_base_map = mip_base_map;
+
+  // Fall back to point sampling if the host formats don't report
+  // D3D12_FORMAT_SUPPORT1_SHADER_SAMPLE.
+  if (parameters.mag_linear || parameters.min_linear || parameters.mip_linear ||
+      parameters.aniso_filter != xenos::AnisoFilter::kDisabled) {
+    TextureKey texture_key;
+    uint8_t texture_swizzled_signs;
+    BindingInfoFromFetchConstant(fetch, texture_key, &texture_swizzled_signs);
+    uint64_t format_bit =
+        texture_key.is_valid ? uint64_t(1) << uint32_t(texture_key.format) : 0;
+    if (!texture_key.is_valid ||
+        (texture_util::IsAnySignNotSigned(texture_swizzled_signs) &&
+         (host_filterable_unsigned_ & format_bit) == 0) ||
+        (texture_util::IsAnySignSigned(texture_swizzled_signs) &&
+         (host_filterable_signed_ & format_bit) == 0)) {
+      parameters.mag_linear = 0;
+      parameters.min_linear = 0;
+      parameters.mip_linear = 0;
+      parameters.aniso_filter = xenos::AnisoFilter::kDisabled;
+    }
+  }
 
   return parameters;
 }

--- a/src/xenia/gpu/d3d12/d3d12_texture_cache.h
+++ b/src/xenia/gpu/d3d12/d3d12_texture_cache.h
@@ -821,6 +821,10 @@ class D3D12TextureCache final : public TextureCache {
   D3D12CommandProcessor& command_processor_;
   bool bindless_resources_used_;
 
+  // Bits per format, for checking if the host format should be point-filtered.
+  uint64_t host_filterable_unsigned_ = 0;
+  uint64_t host_filterable_signed_ = 0;
+
   Microsoft::WRL::ComPtr<ID3D12RootSignature> load_root_signature_;
   std::array<Microsoft::WRL::ComPtr<ID3D12PipelineState>, kLoadShaderCount>
       load_pipelines_;

--- a/src/xenia/gpu/dxbc_shader_translator.h
+++ b/src/xenia/gpu/dxbc_shader_translator.h
@@ -816,6 +816,15 @@ class DxbcShaderTranslator : public ShaderTranslator {
   // Adds the surviving coverage MSAA counts from ROV params to the active ZPD
   // counter slot after the final PS depth/stencil decision.
   void ROV_AddPassedMSAASamplesToZPD();
+  // Converts the float32 components of the register to extended-range float16
+  // in their low 16 bits. Exponent 31 holds finite values up to 131008 of
+  // either sign on the Xbox 360 instead of Inf or NaN, and NaN maps to 0.
+  // Pushes and pops its own temporary registers.
+  void Float32ToF16ExtendedRange(uint32_t reg, uint32_t components);
+  // Converts extended-range float16 in the low 16 bits of the components of
+  // the register, with zeros above, back to float32. Pushes and pops its own
+  // temporary registers.
+  void Float16ExtendedRangeTo32(uint32_t reg, uint32_t components);
   // Unpacks a 32bpp or a 64bpp color in packed_temp.packed_temp_components to
   // color_temp, using 2 temporary VGPRs.
   void ROV_UnpackColor(uint32_t rt_index, uint32_t packed_temp,

--- a/src/xenia/gpu/dxbc_shader_translator_fetch.cc
+++ b/src/xenia/gpu/dxbc_shader_translator_fetch.cc
@@ -147,13 +147,40 @@ void DxbcShaderTranslator::ProcessVertexFetchInstruction(
     address_src = address_temp_src;
   }
 
+  // Words at or past the end of the fetch buffer must read as 0. The shared
+  // memory binding covers all of physical memory, so a word out of bounds
+  // would load unrelated guest data where the hardware clamps and returns
+  // zeros. Games rely on that. An overallocated draw expects the vertices it
+  // never wrote to collapse into degenerate primitives. Compute the exclusive
+  // end of the buffer in bytes from the fetch constant and a mask of which
+  // words of the element fall inside it.
+  uint32_t bounds_temp = PushSystemTemp(0, 2);
+  uint32_t word_mask_temp = bounds_temp + 1;
+  // bounds_temp.x = buffer size in words (bits 2:25 of the second fetch
+  // constant word).
+  a_.OpUBFE(dxbc::Dest::R(bounds_temp, 0b0001), dxbc::Src::LU(24),
+            dxbc::Src::LU(2), fetch_constant_src.SelectFromSwizzled(1));
+  // bounds_temp.y = base address of the buffer in bytes.
+  a_.OpAnd(dxbc::Dest::R(bounds_temp, 0b0010),
+           fetch_constant_src.SelectFromSwizzled(0),
+           dxbc::Src::LU(~uint32_t(3)));
+  // bounds_temp.x = exclusive end of the buffer in bytes.
+  a_.OpUMAd(dxbc::Dest::R(bounds_temp, 0b0001),
+            dxbc::Src::R(bounds_temp, dxbc::Src::kXXXX), dxbc::Src::LU(4),
+            dxbc::Src::R(bounds_temp, dxbc::Src::kYYYY));
+  // word_mask_temp = byte addresses of the words of the element.
+  a_.OpIAdd(dxbc::Dest::R(word_mask_temp), address_src,
+            dxbc::Src::LI((0 - int32_t(first_word_index)) * 4,
+                          (1 - int32_t(first_word_index)) * 4,
+                          (2 - int32_t(first_word_index)) * 4,
+                          (3 - int32_t(first_word_index)) * 4));
+  // word_mask_temp = whether each word is within the buffer bounds.
+  a_.OpULT(dxbc::Dest::R(word_mask_temp, needed_words),
+           dxbc::Src::R(word_mask_temp),
+           dxbc::Src::R(bounds_temp, dxbc::Src::kXXXX));
+
   // - Load needed words to system_temp_result_, words 0, 1, 2, 3 to X, Y, Z, W
   //   respectively.
-
-  // FIXME(Triang3l): Bound checking is not done here, but haven't encountered
-  // any games relying on out-of-bounds access. On Adreno 200 on Android (LG
-  // P705), however, words (not full elements) out of glBufferData bounds
-  // contain 0.
 
   // Loading the FXC way, Load4.xyw becomes Load2 and Load - would be a
   // compromise between AMD, where there are load_dwordx2/3/4, and Nvidia, where
@@ -223,6 +250,10 @@ void DxbcShaderTranslator::ProcessVertexFetchInstruction(
     }
   }
   a_.OpEndIf();
+
+  a_.OpAnd(dxbc::Dest::R(system_temp_result_, needed_words),
+           dxbc::Src::R(system_temp_result_), dxbc::Src::R(word_mask_temp));
+  PopSystemTemp(2);
 
   dxbc::Src result_src(dxbc::Src::R(system_temp_result_));
 

--- a/src/xenia/gpu/dxbc_shader_translator_fetch.cc
+++ b/src/xenia/gpu/dxbc_shader_translator_fetch.cc
@@ -885,7 +885,10 @@ void DxbcShaderTranslator::ProcessTextureFetchInstruction(
         size_needed_components |= 0b0001;
         break;
       case xenos::FetchOpDimension::k2D:
-        if (instr.attributes.unnormalized_coordinates) {
+        // A tfetch1D promoted by its source swizzle may still use a 1D fetch
+        // constant. Its size interpretation is selected below at runtime.
+        if (instr.dimension == xenos::FetchOpDimension::k1D ||
+            instr.attributes.unnormalized_coordinates) {
           size_needed_components |= 0b0011;
         }
         break;
@@ -937,6 +940,26 @@ void DxbcShaderTranslator::ProcessTextureFetchInstruction(
         a_.OpUBFE(dxbc::Dest::R(size_and_is_3d_temp, size_needed_components),
                   dxbc::Src::LU(13, 13, 0, 0), dxbc::Src::LU(0, 13, 0, 0),
                   RequestTextureFetchConstantWord(tfetch_index, 2));
+        if (instr.dimension == xenos::FetchOpDimension::k1D) {
+          assert_true((size_needed_components & 0b0011) == 0b0011);
+          size_1d_width_minus_1_temp = PushSystemTemp();
+          a_.OpUBFE(dxbc::Dest::R(size_1d_width_minus_1_temp, 0b0001),
+                    dxbc::Src::LU(xenos::kTexture1DMaxWidthLog2),
+                    dxbc::Src::LU(0),
+                    RequestTextureFetchConstantWord(tfetch_index, 2));
+          a_.OpMov(dxbc::Dest::R(size_1d_width_minus_1_temp, 0b0010),
+                   dxbc::Src::LU(0));
+          a_.OpUBFE(dxbc::Dest::R(size_and_is_3d_temp, 0b1000),
+                    dxbc::Src::LU(2), dxbc::Src::LU(9),
+                    RequestTextureFetchConstantWord(tfetch_index, 5));
+          a_.OpIEq(dxbc::Dest::R(size_and_is_3d_temp, 0b1000),
+                   dxbc::Src::R(size_and_is_3d_temp, dxbc::Src::kWWWW),
+                   dxbc::Src::LU(uint32_t(xenos::DataDimension::k1D)));
+          a_.OpMovC(dxbc::Dest::R(size_and_is_3d_temp, 0b0011),
+                    dxbc::Src::R(size_and_is_3d_temp, dxbc::Src::kWWWW),
+                    dxbc::Src::R(size_1d_width_minus_1_temp),
+                    dxbc::Src::R(size_and_is_3d_temp));
+        }
         break;
       case xenos::FetchOpDimension::k3DOrStacked:
         // tfetch3D is used for both stacked and 3D - first, check if 3D.
@@ -1262,7 +1285,7 @@ void DxbcShaderTranslator::ProcessTextureFetchInstruction(
         }
       }
     }
-    switch (coordinate_dimension) {
+    switch (instr.dimension) {
       case xenos::FetchOpDimension::k1D: {
         // Check if the fetch constant's actual dimension is k1D (word 5, bits
         // 9-10). If not, skip wide 1D handling as size bits differ per
@@ -1315,6 +1338,9 @@ void DxbcShaderTranslator::ProcessTextureFetchInstruction(
                    dxbc::Src::LF(float(xenos::kTexture2DCubeMaxWidthHeight)));
           a_.OpRoundPI(dxbc::Dest::R(coord_and_sampler_temp, 0b0100),
                        dxbc::Src::R(coord_and_sampler_temp, dxbc::Src::kZZZZ));
+          a_.OpMin(dxbc::Dest::R(coord_and_sampler_temp, 0b0100),
+                   dxbc::Src::R(coord_and_sampler_temp, dxbc::Src::kZZZZ),
+                   dxbc::Src::LF(float(xenos::kTexture1DWideMaxRows)));
           // coord.y = (row_index + 0.5) / num_rows - sample at the center of
           // the row, not its edge. At the edge, linear filtering would blend
           // 50/50 with the previous row (texels 8192 apart), and even point
@@ -1333,15 +1359,23 @@ void DxbcShaderTranslator::ProcessTextureFetchInstruction(
         a_.OpElse();
         {
           // Normal 1D texture - pad to 2D array coordinates.
-          a_.OpMov(dxbc::Dest::R(coord_and_sampler_temp, 0b0110),
-                   dxbc::Src::LF(0.0f));
+          a_.OpMov(
+              dxbc::Dest::R(coord_and_sampler_temp,
+                            coordinate_dimension == xenos::FetchOpDimension::k1D
+                                ? 0b0110
+                                : 0b0100),
+              dxbc::Src::LF(0.0f));
         }
         a_.OpEndIf();
         a_.OpElse();
         {
-          // Non-1D texture bound to 1D fetch - just pad coordinates.
-          a_.OpMov(dxbc::Dest::R(coord_and_sampler_temp, 0b0110),
-                   dxbc::Src::LF(0.0f));
+          // Keep Y when the source swizzle promoted the fetch to 2D.
+          a_.OpMov(
+              dxbc::Dest::R(coord_and_sampler_temp,
+                            coordinate_dimension == xenos::FetchOpDimension::k1D
+                                ? 0b0110
+                                : 0b0100),
+              dxbc::Src::LF(0.0f));
         }
         a_.OpEndIf();
       } break;

--- a/src/xenia/gpu/dxbc_shader_translator_memexport.cc
+++ b/src/xenia/gpu/dxbc_shader_translator_memexport.cc
@@ -487,64 +487,16 @@ void DxbcShaderTranslator::ExportToMemory(uint8_t export_eM) {
     }
     a_.OpBreak();
 
-    // Xbox 360 float16 uses extended range: exponent 31 is NOT Inf/NaN
-    // but a valid large value (up to ±131008). Standard DXBC f32tof16
-    // clamps to ±65504 and produces Inf for larger values. This helper
-    // detects where standard conversion overflowed to Inf/NaN and
-    // re-encodes those values using the extended range representation:
-    // halve the value, convert to standard f16 (giving exponent <= 30),
-    // then increment the exponent by 1 (placing it in the exponent 31
-    // slot that Xbox 360 treats as a normal value, not Inf/NaN).
+    // Convert to extended-range float16 with the helper shared with the ROV
+    // render target packing.
     auto f32_to_f16_extended_range = [&](uint32_t components) {
-      uint32_t ext_original_temp = PushSystemTemp();
-      uint32_t ext_mask_temp = PushSystemTemp();
-
       uint8_t eM_remaining_ext = export_eM;
       uint32_t eM_index_ext;
       while (xe::bit_scan_forward(eM_remaining_ext, &eM_index_ext)) {
         eM_remaining_ext &= ~(uint8_t(1) << eM_index_ext);
-        uint32_t eM = system_temps_memexport_data_[eM_index_ext];
-
-        // Save original float32 values before conversion.
-        a_.OpMov(dxbc::Dest::R(ext_original_temp, components),
-                 dxbc::Src::R(eM));
-
-        // Standard f32 to f16 conversion (handles ±0..65504 correctly).
-        a_.OpF32ToF16(dxbc::Dest::R(eM, components), dxbc::Src::R(eM));
-
-        // Detect where standard conversion produced Inf or NaN
-        // (exponent field = 31, i.e. bits [14:10] all set = 0x7C00).
-        a_.OpAnd(dxbc::Dest::R(ext_mask_temp, components), dxbc::Src::R(eM),
-                 dxbc::Src::LU(0x7C00));
-        a_.OpIEq(dxbc::Dest::R(ext_mask_temp, components),
-                 dxbc::Src::R(ext_mask_temp), dxbc::Src::LU(0x7C00));
-
-        // For values that overflowed, compute extended range encoding
-        // from the saved original float32 values:
-        // 1. Clamp to ±131008.0 (max extended float16 can represent).
-        a_.OpMin(dxbc::Dest::R(ext_original_temp, components),
-                 dxbc::Src::R(ext_original_temp), dxbc::Src::LF(131008.0f));
-        a_.OpMax(dxbc::Dest::R(ext_original_temp, components),
-                 dxbc::Src::R(ext_original_temp), dxbc::Src::LF(-131008.0f));
-        // 2. Halve to bring into standard float16 range (max 65504).
-        a_.OpMul(dxbc::Dest::R(ext_original_temp, components),
-                 dxbc::Src::R(ext_original_temp), dxbc::Src::LF(0.5f));
-        // 3. Convert the halved value (will have exponent <= 30).
-        a_.OpF32ToF16(dxbc::Dest::R(ext_original_temp, components),
-                      dxbc::Src::R(ext_original_temp));
-        // 4. Increment exponent by 1 (add 1 << 10 = 0x0400) to
-        //    compensate for the halving → places value at exponent 31.
-        a_.OpIAdd(dxbc::Dest::R(ext_original_temp, components),
-                  dxbc::Src::R(ext_original_temp), dxbc::Src::LU(0x0400));
-
-        // Select: use extended result where standard gave Inf/NaN,
-        // keep standard result otherwise.
-        a_.OpMovC(dxbc::Dest::R(eM, components), dxbc::Src::R(ext_mask_temp),
-                  dxbc::Src::R(ext_original_temp), dxbc::Src::R(eM));
+        Float32ToF16ExtendedRange(system_temps_memexport_data_[eM_index_ext],
+                                  components);
       }
-
-      // Release ext_mask_temp and ext_original_temp.
-      PopSystemTemp(2);
     };
 
     a_.OpCase(dxbc::Src::LU(uint32_t(xenos::ColorFormat::k_16_FLOAT)));

--- a/src/xenia/gpu/dxbc_shader_translator_om.cc
+++ b/src/xenia/gpu/dxbc_shader_translator_om.cc
@@ -1294,8 +1294,9 @@ void DxbcShaderTranslator::ROV_UnpackColor(
               dxbc::Src::LU(0, 16, 0, 16),
               dxbc::Src::R(packed_temp,
                            0b01010000 + packed_temp_components * 0b01010101));
-    // Convert from 16-bit float.
-    a_.OpF16ToF32(color_components_dest, dxbc::Src::R(color_temp));
+    // Convert from extended-range float16, exponent 31 holds finite values on
+    // the guest.
+    Float16ExtendedRangeTo32(color_temp, i ? 0b1111 : 0b0011);
     a_.OpBreak();
   }
 
@@ -1465,18 +1466,20 @@ void DxbcShaderTranslator::ROV_PackPreClampedColor(
     a_.OpCase(dxbc::Src::LU(RenderTargetCache::AddPSIColorFormatFlags(
         i ? xenos::ColorRenderTargetFormat::k_16_16_16_16_FLOAT
           : xenos::ColorRenderTargetFormat::k_16_16_FLOAT)));
+    // Convert to extended-range float16 instead of the plain IEEE conversion,
+    // exponent 31 holds finite values on the guest.
+    Float32ToF16ExtendedRange(color_temp, i ? 0b1111 : 0b0011);
     for (uint32_t j = 0; j < (uint32_t(2) << i); ++j) {
       dxbc::Dest packed_dest_half(
           dxbc::Dest::R(packed_temp, 1 << (packed_temp_components + (j >> 1))));
-      // Convert to 16-bit float.
-      a_.OpF32ToF16((j & 1) ? temp1_dest : packed_dest_half,
-                    dxbc::Src::R(color_temp).Select(j));
-      // Pack green or alpha.
+      // Pack green or alpha into the high half.
       if (j & 1) {
         a_.OpBFI(packed_dest_half, dxbc::Src::LU(16), dxbc::Src::LU(16),
-                 temp1_src,
+                 dxbc::Src::R(color_temp).Select(j),
                  dxbc::Src::R(packed_temp)
                      .Select(packed_temp_components + (j >> 1)));
+      } else {
+        a_.OpMov(packed_dest_half, dxbc::Src::R(color_temp).Select(j));
       }
     }
     a_.OpBreak();
@@ -3456,6 +3459,73 @@ void DxbcShaderTranslator::CompletePixelShader() {
     CompletePixelShader_WriteToRTVs();
     CompletePixelShader_DSV_DepthTo24Bit();
   }
+}
+
+void DxbcShaderTranslator::Float32ToF16ExtendedRange(uint32_t reg,
+                                                     uint32_t components) {
+  uint32_t original_temp = PushSystemTemp();
+  uint32_t mask_temp = PushSystemTemp();
+  // The Xbox 360 float16 has no NaN, map it to 0 before converting. Otherwise
+  // the overflow check below reads its exponent as an overflow, and since min
+  // and max drop the NaN operand in DXBC, the clamp would turn it into
+  // +131008.
+  a_.OpNE(dxbc::Dest::R(mask_temp, components), dxbc::Src::R(reg),
+          dxbc::Src::R(reg));
+  a_.OpMovC(dxbc::Dest::R(reg, components), dxbc::Src::R(mask_temp),
+            dxbc::Src::LF(0.0f), dxbc::Src::R(reg));
+  // Keep the original float32 values for the overflow path.
+  a_.OpMov(dxbc::Dest::R(original_temp, components), dxbc::Src::R(reg));
+  // The standard conversion covers magnitudes up to 65504, anything larger
+  // becomes Inf with all five exponent bits set.
+  a_.OpF32ToF16(dxbc::Dest::R(reg, components), dxbc::Src::R(reg));
+  // Find the lanes that overflowed.
+  a_.OpAnd(dxbc::Dest::R(mask_temp, components), dxbc::Src::R(reg),
+           dxbc::Src::LU(0x7C00));
+  a_.OpIEq(dxbc::Dest::R(mask_temp, components), dxbc::Src::R(mask_temp),
+           dxbc::Src::LU(0x7C00));
+  // Encode the overflowed lanes into exponent 31, which the Xbox 360 treats
+  // as finite. Clamp to the 131008 limit, halve so the exponent lands at 30
+  // or below, convert, then add one to the exponent to undo the halving.
+  a_.OpMin(dxbc::Dest::R(original_temp, components),
+           dxbc::Src::R(original_temp), dxbc::Src::LF(131008.0f));
+  a_.OpMax(dxbc::Dest::R(original_temp, components),
+           dxbc::Src::R(original_temp), dxbc::Src::LF(-131008.0f));
+  a_.OpMul(dxbc::Dest::R(original_temp, components),
+           dxbc::Src::R(original_temp), dxbc::Src::LF(0.5f));
+  a_.OpF32ToF16(dxbc::Dest::R(original_temp, components),
+                dxbc::Src::R(original_temp));
+  a_.OpIAdd(dxbc::Dest::R(original_temp, components),
+            dxbc::Src::R(original_temp), dxbc::Src::LU(0x0400));
+  // Choose the encoded value for the overflowed lanes.
+  a_.OpMovC(dxbc::Dest::R(reg, components), dxbc::Src::R(mask_temp),
+            dxbc::Src::R(original_temp), dxbc::Src::R(reg));
+  // Release original_temp and mask_temp.
+  PopSystemTemp(2);
+}
+
+void DxbcShaderTranslator::Float16ExtendedRangeTo32(uint32_t reg,
+                                                    uint32_t components) {
+  uint32_t reduced_temp = PushSystemTemp();
+  uint32_t mask_temp = PushSystemTemp();
+  // Find the exponent 31 lanes, which hold finite values on the Xbox 360
+  // rather than Inf or NaN.
+  a_.OpAnd(dxbc::Dest::R(mask_temp, components), dxbc::Src::R(reg),
+           dxbc::Src::LU(0x7C00));
+  a_.OpIEq(dxbc::Dest::R(mask_temp, components), dxbc::Src::R(mask_temp),
+           dxbc::Src::LU(0x7C00));
+  // Lower their exponent by one so the conversion sees a normal float16, then
+  // double the result to undo it.
+  a_.OpIAdd(dxbc::Dest::R(reduced_temp, components), dxbc::Src::R(reg),
+            dxbc::Src::LI(-0x0400));
+  a_.OpMovC(dxbc::Dest::R(reg, components), dxbc::Src::R(mask_temp),
+            dxbc::Src::R(reduced_temp), dxbc::Src::R(reg));
+  a_.OpF16ToF32(dxbc::Dest::R(reg, components), dxbc::Src::R(reg));
+  a_.OpMul(dxbc::Dest::R(reduced_temp, components), dxbc::Src::R(reg),
+           dxbc::Src::LF(2.0f));
+  a_.OpMovC(dxbc::Dest::R(reg, components), dxbc::Src::R(mask_temp),
+            dxbc::Src::R(reduced_temp), dxbc::Src::R(reg));
+  // Release reduced_temp and mask_temp.
+  PopSystemTemp(2);
 }
 
 void DxbcShaderTranslator::PreClampedFloat32To7e3(

--- a/src/xenia/gpu/primitive_processor.cc
+++ b/src/xenia/gpu/primitive_processor.cc
@@ -296,17 +296,18 @@ bool PrimitiveProcessor::Process(ProcessingResult& result_out) {
       regs.Get<reg::VGT_HOS_CNTL>().tess_mode;
   Shader::HostVertexShaderType host_vertex_shader_type;
   if (tessellation_enabled) {
-    // Currently only supporting tessellation in known cases for safety, and not
-    // yet converting patch strips / fans to patch lists until games using them
-    // are found for easier debugging when it actually happens.
-    // TODO(Triang3l): Conversion of patch strips / fans if found.
+    // Currently only supporting tessellation in known cases for safety.
     host_vertex_shader_type = Shader::HostVertexShaderType(-1);
     switch (guest_primitive_type) {
       case xenos::PrimitiveType::kTriangleList:
+      case xenos::PrimitiveType::kTriangleFan:
+      case xenos::PrimitiveType::kTriangleStrip:
         // Also supported by triangle strips and fans according to:
         // https://www.khronos.org/registry/OpenGL/extensions/AMD/AMD_vertex_shader_tessellator.txt
-        // Would need to convert those to triangle lists, but haven't seen any
-        // games using tessellated strips / fans so far.
+        // Convert strips and fans to triangle lists for tessellation.
+        if (guest_primitive_type != xenos::PrimitiveType::kTriangleList) {
+          host_primitive_type = xenos::PrimitiveType::kTriangleList;
+        }
         switch (tessellation_mode) {
           case xenos::TessellationMode::kDiscrete:
             // - 415607E1 - nets above barrels in the beginning of the first
@@ -534,11 +535,34 @@ bool PrimitiveProcessor::Process(ProcessingResult& result_out) {
                       xenos::PrimitiveType::kTriangleList);
           cacheable.host_draw_vertex_count =
               GetTriangleFanListIndexCount(cacheable.host_draw_vertex_count);
-          cacheable.index_buffer_type =
-              ProcessedIndexBufferType::kHostBuiltinForAuto;
-          assert_true(builtin_ib_offset_triangle_fans_to_lists_ != SIZE_MAX);
-          cacheable.host_index_buffer_handle =
-              builtin_ib_offset_triangle_fans_to_lists_;
+          if (builtin_ib_offset_triangle_fans_to_lists_ != SIZE_MAX) {
+            cacheable.index_buffer_type =
+                ProcessedIndexBufferType::kHostBuiltinForAuto;
+            cacheable.host_index_buffer_handle =
+                builtin_ib_offset_triangle_fans_to_lists_;
+          } else if (cacheable.host_draw_vertex_count) {
+            // The backend didn't request the builtin fan to list conversion
+            // at initialization, so there's no prebuilt index buffer. This is
+            // only reached via the tessellation path above, which forces
+            // host_primitive_type to kTriangleList, so build the conversion at
+            // runtime.
+            cacheable.index_buffer_type =
+                ProcessedIndexBufferType::kHostConverted;
+            auto host_indices = reinterpret_cast<uint16_t*>(
+                RequestHostConvertedIndexBufferForCurrentFrame(
+                    xenos::IndexFormat::kInt16,
+                    cacheable.host_draw_vertex_count, false, 0,
+                    cacheable.host_index_buffer_handle));
+            if (!host_indices) {
+              return false;
+            }
+            uint16_t* host_indices_write = host_indices;
+            for (uint32_t i = 2; i < guest_draw_vertex_count; ++i) {
+              *(host_indices_write++) = uint16_t(i - 1);
+              *(host_indices_write++) = uint16_t(i);
+              *(host_indices_write++) = 0;
+            }
+          }
           break;
         case xenos::PrimitiveType::kLineLoop:
           // Plus 1 element (if there's anything to draw) in the strip, still
@@ -562,6 +586,40 @@ bool PrimitiveProcessor::Process(ProcessingResult& result_out) {
                       SIZE_MAX);
           cacheable.host_index_buffer_handle =
               builtin_ib_offset_quad_lists_to_triangle_lists_;
+          break;
+        case xenos::PrimitiveType::kTriangleStrip:
+          assert_true(host_primitive_type ==
+                      xenos::PrimitiveType::kTriangleList);
+          cacheable.host_draw_vertex_count =
+              GetTriangleStripListIndexCount(cacheable.host_draw_vertex_count);
+          if (cacheable.host_draw_vertex_count) {
+            // There's no prebuilt strip to list index buffer. This is only
+            // reached via the tessellation path above, which forces
+            // host_primitive_type to kTriangleList, so build the conversion at
+            // runtime.
+            cacheable.index_buffer_type =
+                ProcessedIndexBufferType::kHostConverted;
+            auto host_indices = reinterpret_cast<uint16_t*>(
+                RequestHostConvertedIndexBufferForCurrentFrame(
+                    xenos::IndexFormat::kInt16,
+                    cacheable.host_draw_vertex_count, false, 0,
+                    cacheable.host_index_buffer_handle));
+            if (!host_indices) {
+              return false;
+            }
+            uint16_t* host_indices_write = host_indices;
+            for (uint32_t i = 2; i < guest_draw_vertex_count; ++i) {
+              if ((i & 1) == 0) {
+                *(host_indices_write++) = uint16_t(i - 2);
+                *(host_indices_write++) = uint16_t(i - 1);
+                *(host_indices_write++) = uint16_t(i);
+              } else {
+                *(host_indices_write++) = uint16_t(i - 1);
+                *(host_indices_write++) = uint16_t(i - 2);
+                *(host_indices_write++) = uint16_t(i);
+              }
+            }
+          }
           break;
         default:
           assert_always();

--- a/src/xenia/gpu/primitive_processor.h
+++ b/src/xenia/gpu/primitive_processor.h
@@ -548,6 +548,12 @@ class PrimitiveProcessor {
       uint32_t fan_index_count) {
     return fan_index_count > 2 ? (fan_index_count - 2) * 3 : 0;
   }
+  // Triangle strip to triangle list conversion.
+  // A strip with N vertices produces (N-2) triangles, each needing 3 indices.
+  static constexpr uint32_t GetTriangleStripListIndexCount(
+      uint32_t strip_index_count) {
+    return strip_index_count > 2 ? (strip_index_count - 2) * 3 : 0;
+  }
   template <typename Index, typename IndexTransform>
   static void TriangleFanToList(Index* dest, const Index* source,
                                 uint32_t source_index_count,

--- a/src/xenia/gpu/render_target_cache.cc
+++ b/src/xenia/gpu/render_target_cache.cc
@@ -283,11 +283,11 @@ void RenderTargetCache::GetPSIColorFormatInfo(
       break;
     case xenos::ColorRenderTargetFormat::k_16_16_FLOAT:
     case xenos::ColorRenderTargetFormat::k_16_16_16_16_FLOAT:
-      // No NaNs on the Xbox 360 GPU, though can't use the extended range with
-      // Direct3D and Vulkan conversions.
-      // TODO(Triang3l): Use the extended-range encoding in all implementations.
-      clamp_rgb_low = clamp_alpha_low = -65504.0f;
-      clamp_rgb_high = clamp_alpha_high = 65504.0f;
+      // No NaNs on the Xbox 360 GPU. The interlock paths of both backends
+      // emulate the extended-range encoding in their pack and unpack, so the
+      // whole guest range survives the clamp.
+      clamp_rgb_low = clamp_alpha_low = -131008.0f;
+      clamp_rgb_high = clamp_alpha_high = 131008.0f;
       if (!(write_mask & 0b0001)) {
         keep_mask_low |= 0xFFFFu;
       }

--- a/src/xenia/gpu/shared_memory.cc
+++ b/src/xenia/gpu/shared_memory.cc
@@ -341,6 +341,8 @@ void SharedMemory::MakeRangeValid(uint32_t start, uint32_t length,
   }
 
   if (memory_invalidation_callback_handle_) {
+    // A page that isn't writable here gets no watch. A later guest
+    // protect-to-writable invalidates it so its writes are still caught.
     memory().EnablePhysicalMemoryAccessCallbacks(
         valid_page_first << page_size_log2_,
         (valid_page_last - valid_page_first + 1) << page_size_log2_, true,

--- a/src/xenia/gpu/spirv_shader_translator.cc
+++ b/src/xenia/gpu/spirv_shader_translator.cc
@@ -119,7 +119,7 @@ void SpirvShaderTranslator::Reset() {
   // Vertex shader inputs.
   input_vertex_index_ = spv::NoResult;
   // Tessellation evaluation shader inputs.
-  input_primitive_id_ = spv::NoResult;
+  input_control_point_index_ = spv::NoResult;
   input_tess_coord_ = spv::NoResult;
   // Pixel shader inputs.
   input_point_coordinates_ = spv::NoResult;
@@ -797,16 +797,22 @@ std::vector<uint8_t> SpirvShaderTranslator::CompleteTranslation() {
           assert_unhandled_case(host_type);
           break;
       }
-      // Tessellation spacing - fractional_even for continuous mode, equal
-      // (integer) for discrete mode. The actual mode is determined by the TCS
-      // (hull shader), but we use fractional_even here as the default since it
-      // provides smooth results. The TCS sets the actual tessellation levels.
-      // For now, use fractional_even as it's more compatible.
+      // Tessellation spacing. In SPIR-V the spacing is part of the domain
+      // shader rather than the hull shader. Match the Direct3D 12 hull shader
+      // partitioning. Integer (equal) for discrete, fractional even for
+      // continuous and adaptive.
       builder_->addExecutionMode(function_main_,
-                                 spv::ExecutionModeSpacingFractionalEven);
-      // Vertex ordering - counter-clockwise (Vulkan default for front face).
+                                 shader_modification.vertex.tessellation_mode ==
+                                         xenos::TessellationMode::kDiscrete
+                                     ? spv::ExecutionModeSpacingEqual
+                                     : spv::ExecutionModeSpacingFractionalEven);
+      // Vertex ordering. Xenia does not flip the clip space Y on Vulkan
+      // (origin_bottom_left is false, so ndc_scale.y keeps the guest sign), so
+      // the tessellator must wind the same way as the Direct3D 12 hull shaders,
+      // which use triangle_cw. Counter-clockwise here inverts the facing and
+      // the guest backface culling removes the whole surface.
       builder_->addExecutionMode(function_main_,
-                                 spv::ExecutionModeVertexOrderCcw);
+                                 spv::ExecutionModeVertexOrderCw);
     } else {
       execution_model = spv::ExecutionModelVertex;
     }
@@ -1275,11 +1281,33 @@ void SpirvShaderTranslator::EnsureBuildPointAvailable() {
 void SpirvShaderTranslator::StartVertexOrTessEvalShaderBeforeMain() {
   // Create the inputs.
   if (IsSpirvTessEvalShader()) {
-    input_primitive_id_ = builder_->createVariable(
-        spv::NoPrecision, spv::StorageClassInput, type_int_, "gl_PrimitiveID");
-    builder_->addDecoration(input_primitive_id_, spv::DecorationBuiltIn,
-                            static_cast<int>(spv::BuiltIn::PrimitiveId));
-    main_interface_.push_back(input_primitive_id_);
+    // Per-control-point index input from the hull shader, mirroring the control
+    // point input read by the Direct3D 12 domain shader. The hull shader has
+    // already applied the endian swap, the vertex index offset, the low 24-bit
+    // wrap and the min/max clamp, so this is the index the guest expects rather
+    // than the raw gl_PrimitiveID. The array size matches the hull shader's
+    // output control point count for the domain type.
+    uint32_t control_point_count = 1;
+    switch (GetSpirvShaderModification().vertex.host_vertex_shader_type) {
+      case Shader::HostVertexShaderType::kTriangleDomainCPIndexed:
+        control_point_count = 3;
+        break;
+      case Shader::HostVertexShaderType::kQuadDomainCPIndexed:
+        control_point_count = 4;
+        break;
+      default:
+        // Patch-indexed (and line) domains output a single control point.
+        control_point_count = 1;
+        break;
+    }
+    input_control_point_index_ = builder_->createVariable(
+        spv::NoPrecision, spv::StorageClassInput,
+        builder_->makeArrayType(
+            type_float_, builder_->makeUintConstant(control_point_count), 0),
+        "xe_in_control_point_index");
+    builder_->addDecoration(input_control_point_index_, spv::DecorationLocation,
+                            0);
+    main_interface_.push_back(input_control_point_index_);
 
     // Tessellation coordinates (barycentric coordinates for the tessellated
     // vertex within the patch).
@@ -1564,32 +1592,56 @@ void SpirvShaderTranslator::StartVertexOrTessEvalShaderInMain() {
           break;
         }
         case Shader::HostVertexShaderType::kQuadDomainCPIndexed: {
-          // Quad domain requires at least 2 registers (r0 for domain location,
-          // r1 for control point indices).
+          // Quad domain requires at least 2 registers (r0 for the domain
+          // location and the first control point index, r1 for the other
+          // three).
           assert_true(register_count() >= 2);
-          // Quad domain CP-indexed: gl_TessCoord.xy -> r0.yz, r0.x = 0, r0.w =
-          // 1 XY swizzle according to the ground shader in 4D5307F2.
-          uint_vector_temp_.clear();
-          uint_vector_temp_.push_back(0);  // x -> r0.y
-          uint_vector_temp_.push_back(1);  // y -> r0.z
-          spv::Id tess_coord_xy = builder_->createRvalueSwizzle(
-              spv::NoPrecision, type_float2_, tess_coord, uint_vector_temp_);
-          // Store to r0
+          // Quad domain CP-indexed, matching the Direct3D 12 domain shader:
+          // r0.xy = domain location, r0.z = control point index 0,
+          // r1.xyz = control point indices 1, 2, 3 (already endian swapped and
+          // converted to float by the host vertex and hull shaders).
+          spv::Id tess_coord_x =
+              builder_->createCompositeExtract(tess_coord, type_float_, 0);
+          spv::Id tess_coord_y =
+              builder_->createCompositeExtract(tess_coord, type_float_, 1);
+          // Load control point index 0.
+          id_vector_temp_.clear();
+          id_vector_temp_.push_back(const_int_0_);
+          spv::Id control_point_index_0 = builder_->createLoad(
+              builder_->createAccessChain(spv::StorageClassInput,
+                                          input_control_point_index_,
+                                          id_vector_temp_),
+              spv::NoPrecision);
+          // Store r0 = (domain.x, domain.y, control point index 0, 0).
           id_vector_temp_.clear();
           id_vector_temp_.push_back(const_int_0_);
           spv::Id r0_ptr = builder_->createAccessChain(
               spv::StorageClassFunction, var_main_registers_, id_vector_temp_);
-          // Build float4 with x=0, yz from tess coord, w=1
           id_vector_temp_.clear();
+          id_vector_temp_.push_back(tess_coord_x);
+          id_vector_temp_.push_back(tess_coord_y);
+          id_vector_temp_.push_back(control_point_index_0);
           id_vector_temp_.push_back(const_float_0_);
-          id_vector_temp_.push_back(
-              builder_->createCompositeExtract(tess_coord_xy, type_float_, 0));
-          id_vector_temp_.push_back(
-              builder_->createCompositeExtract(tess_coord_xy, type_float_, 1));
-          id_vector_temp_.push_back(const_float_1_);
           builder_->createStore(
               builder_->createCompositeConstruct(type_float4_, id_vector_temp_),
               r0_ptr);
+          // Store r1.xyz = control point indices 1, 2, 3.
+          for (uint32_t i = 1; i <= 3; ++i) {
+            id_vector_temp_.clear();
+            id_vector_temp_.push_back(builder_->makeIntConstant(int(i)));
+            spv::Id control_point_index = builder_->createLoad(
+                builder_->createAccessChain(spv::StorageClassInput,
+                                            input_control_point_index_,
+                                            id_vector_temp_),
+                spv::NoPrecision);
+            id_vector_temp_.clear();
+            id_vector_temp_.push_back(builder_->makeIntConstant(1));
+            id_vector_temp_.push_back(builder_->makeIntConstant(int(i - 1)));
+            builder_->createStore(control_point_index,
+                                  builder_->createAccessChain(
+                                      spv::StorageClassFunction,
+                                      var_main_registers_, id_vector_temp_));
+          }
           break;
         }
         case Shader::HostVertexShaderType::kQuadDomainPatchIndexed: {
@@ -1604,11 +1656,17 @@ void SpirvShaderTranslator::StartVertexOrTessEvalShaderInMain() {
           uint_vector_temp_.push_back(1);  // y -> r0.z
           spv::Id tess_coord_xy = builder_->createRvalueSwizzle(
               spv::NoPrecision, type_float2_, tess_coord, uint_vector_temp_);
-          // Load primitive ID (patch index) and convert to float.
-          spv::Id primitive_id =
-              builder_->createLoad(input_primitive_id_, spv::NoPrecision);
-          spv::Id patch_index_float = builder_->createUnaryOp(
-              spv::OpConvertSToF, type_float_, primitive_id);
+          // Read the patch index from control point 0 (already endian swapped,
+          // offset, wrapped and clamped by the host vertex and hull shaders),
+          // matching the Direct3D 12 domain shader, rather than using the raw
+          // gl_PrimitiveID.
+          id_vector_temp_.clear();
+          id_vector_temp_.push_back(const_int_0_);
+          spv::Id patch_index_float = builder_->createLoad(
+              builder_->createAccessChain(spv::StorageClassInput,
+                                          input_control_point_index_,
+                                          id_vector_temp_),
+              spv::NoPrecision);
           // Store to r0: x = patch index, yz = tess coord, w = 1
           id_vector_temp_.clear();
           id_vector_temp_.push_back(const_int_0_);
@@ -1654,11 +1712,17 @@ void SpirvShaderTranslator::StartVertexOrTessEvalShaderInMain() {
       if (register_count() >= 2) {
         if (host_type ==
             Shader::HostVertexShaderType::kTriangleDomainPatchIndexed) {
-          // Load primitive ID (patch index) and convert to float.
-          spv::Id primitive_id =
-              builder_->createLoad(input_primitive_id_, spv::NoPrecision);
-          spv::Id patch_index_float = builder_->createUnaryOp(
-              spv::OpConvertSToF, type_float_, primitive_id);
+          // Read the patch index from control point 0 (already endian swapped,
+          // offset, wrapped and clamped by the host vertex and hull shaders),
+          // matching the Direct3D 12 domain shader, rather than using the raw
+          // gl_PrimitiveID.
+          id_vector_temp_.clear();
+          id_vector_temp_.push_back(const_int_0_);
+          spv::Id patch_index_float = builder_->createLoad(
+              builder_->createAccessChain(spv::StorageClassInput,
+                                          input_control_point_index_,
+                                          id_vector_temp_),
+              spv::NoPrecision);
           // Store patch index to r1.x
           id_vector_temp_.clear();
           id_vector_temp_.push_back(builder_->makeIntConstant(1));
@@ -1677,6 +1741,27 @@ void SpirvShaderTranslator::StartVertexOrTessEvalShaderInMain() {
                                 builder_->createAccessChain(
                                     spv::StorageClassFunction,
                                     var_main_registers_, id_vector_temp_));
+        } else if (host_type ==
+                   Shader::HostVertexShaderType::kTriangleDomainCPIndexed) {
+          // Store the three control point indices (already endian swapped and
+          // converted to float by the host vertex and hull shaders) to r1.xyz,
+          // matching the Direct3D 12 domain shader.
+          for (uint32_t i = 0; i < 3; ++i) {
+            id_vector_temp_.clear();
+            id_vector_temp_.push_back(builder_->makeIntConstant(int(i)));
+            spv::Id control_point_index = builder_->createLoad(
+                builder_->createAccessChain(spv::StorageClassInput,
+                                            input_control_point_index_,
+                                            id_vector_temp_),
+                spv::NoPrecision);
+            id_vector_temp_.clear();
+            id_vector_temp_.push_back(builder_->makeIntConstant(1));
+            id_vector_temp_.push_back(builder_->makeIntConstant(int(i)));
+            builder_->createStore(control_point_index,
+                                  builder_->createAccessChain(
+                                      spv::StorageClassFunction,
+                                      var_main_registers_, id_vector_temp_));
+          }
         }
       }
     } else if (IsSpirvVertexShader()) {

--- a/src/xenia/gpu/spirv_shader_translator.cc
+++ b/src/xenia/gpu/spirv_shader_translator.cc
@@ -545,6 +545,9 @@ void SpirvShaderTranslator::StartTranslation() {
     var_main_vfetch_address_ = builder_->createVariable(
         spv::NoPrecision, spv::StorageClassFunction, type_int_,
         "xe_var_vfetch_address", const_int_0_);
+    var_main_vfetch_bound_ = builder_->createVariable(
+        spv::NoPrecision, spv::StorageClassFunction, type_int_,
+        "xe_var_vfetch_bound", const_int_0_);
     var_main_tfetch_lod_ = builder_->createVariable(
         spv::NoPrecision, spv::StorageClassFunction, type_float_,
         "xe_var_tfetch_lod", const_float_0_);

--- a/src/xenia/gpu/spirv_shader_translator.cc
+++ b/src/xenia/gpu/spirv_shader_translator.cc
@@ -15,11 +15,19 @@
 #include "third_party/fmt/include/fmt/format.h"
 #include "third_party/glslang/SPIRV/GLSL.std.450.h"
 #include "xenia/base/assert.h"
+#include "xenia/base/cvar.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/math.h"
 #include "xenia/base/string_buffer.h"
 #include "xenia/gpu/spirv_compatibility.h"
 #include "xenia/gpu/spirv_shader.h"
+
+DEFINE_bool(
+    spirv_disable_rounding_mode_rte, false,
+    "Disable RoundingModeRTE capability in SPIR-V shaders. Enable this to "
+    "allow shader debugging in RenderDoc, which doesn't support this "
+    "capability.",
+    "GPU");
 
 namespace xe {
 namespace gpu {
@@ -835,7 +843,8 @@ std::vector<uint8_t> SpirvShaderTranslator::CompleteTranslation() {
     builder_->addExecutionMode(function_main_,
                                spv::ExecutionModeSignedZeroInfNanPreserve, 32);
   }
-  if (features_.rounding_mode_rte_float32) {
+  if (features_.rounding_mode_rte_float32 &&
+      !cvars::spirv_disable_rounding_mode_rte) {
     builder_->addCapability(spv::CapabilityRoundingModeRTE);
     builder_->addExecutionMode(function_main_,
                                spv::ExecutionModeRoundingModeRTE, 32);

--- a/src/xenia/gpu/spirv_shader_translator.h
+++ b/src/xenia/gpu/spirv_shader_translator.h
@@ -34,7 +34,7 @@ class SpirvShaderTranslator : public ShaderTranslator {
     // TODO(Triang3l): Change to 0xYYYYMMDD once it's out of the rapid
     // prototyping stage (easier to do small granular updates with an
     // incremental counter).
-    static constexpr uint32_t kVersion = 17;
+    static constexpr uint32_t kVersion = 18;
 
     enum class DepthStencilMode : uint32_t {
       kNoModifiers,
@@ -86,6 +86,11 @@ class SpirvShaderTranslator : public ShaderTranslator {
       // cull distance written after the user clip plane cull distances. The
       // "or" operator sets the position to NaN instead and needs no bit here.
       uint32_t vertex_kill_and : 1;
+      // The tessellation mode for domain shaders, selecting the tessellation
+      // evaluation shader spacing (Direct3D 12 sets it in the hull shaders, but
+      // in SPIR-V the spacing lives in the domain shader). Discrete uses equal
+      // spacing, continuous and adaptive use fractional even.
+      xenos::TessellationMode tessellation_mode : 2;
     } vertex;
     struct PixelShaderModification {
       // uint32_t 0.
@@ -1024,8 +1029,9 @@ class SpirvShaderTranslator : public ShaderTranslator {
 
   // VS as VS only - int.
   spv::Id input_vertex_index_;
-  // VS as TES only - int.
-  spv::Id input_primitive_id_;
+  // VS as TES only - per-control-point float array carrying the patch/control
+  // point index computed by the host vertex and hull shaders.
+  spv::Id input_control_point_index_;
   // VS as TES only - float3 (barycentric coordinates).
   spv::Id input_tess_coord_;
   // PS, only when needed - float2.

--- a/src/xenia/gpu/spirv_shader_translator.h
+++ b/src/xenia/gpu/spirv_shader_translator.h
@@ -1118,6 +1118,9 @@ class SpirvShaderTranslator : public ShaderTranslator {
   // `base + index * stride` in dwords from the last vfetch_full as it may be
   // needed by vfetch_mini - int.
   spv::Id var_main_vfetch_address_;
+  // Exclusive end (base + size) in dwords of the last vfetch_full's buffer, for
+  // clamping out-of-bounds words to 0 in both it and its vfetch_mini - int.
+  spv::Id var_main_vfetch_bound_;
   // float.
   spv::Id var_main_tfetch_lod_;
   // float3.

--- a/src/xenia/gpu/spirv_shader_translator.h
+++ b/src/xenia/gpu/spirv_shader_translator.h
@@ -729,6 +729,10 @@ class SpirvShaderTranslator : public ShaderTranslator {
   // must be called with absolute values of operands - use GetAbsoluteOperand!
   spv::Id ZeroIfAnyOperandIsZero(spv::Id value, spv::Id operand_0_abs,
                                  spv::Id operand_1_abs);
+  // Pack/unpack two floats as Xbox 360 extended-range float16, where exponent
+  // 31 is a large finite value (up to +-131008), not Inf/NaN.
+  spv::Id PackFloat16x2ExtendedRange(spv::Id float2_value);
+  spv::Id UnpackFloat16x2ExtendedRange(spv::Id packed_uint);
   // Conditionally discard the current fragment. Changes the build point.
   void KillPixel(spv::Id condition,
                  uint8_t memexport_eM_potentially_written_before);

--- a/src/xenia/gpu/spirv_shader_translator_alu.cc
+++ b/src/xenia/gpu/spirv_shader_translator_alu.cc
@@ -1051,8 +1051,10 @@ spv::Id SpirvShaderTranslator::ProcessScalarAluOperation(
       GetOperandScalarXY(operand_storage[0], instr.scalar_operands[0], a, b);
       if (instr.scalar_opcode == ucode::AluScalarOpcode::kMaxAs ||
           instr.scalar_opcode == ucode::AluScalarOpcode::kMaxAsf) {
-        // maxas: a0 = (int)clamp(floor(src0.a + 0.5), -256.0, 255.0)
-        // maxasf: a0 = (int)clamp(floor(src0.a), -256.0, 255.0)
+        // Scalar maxas/maxasf clamp a0 to [0, 255] (non-negative), unlike the
+        // vector maxa which allows [-256, 255]. Matches DxbcShaderTranslator.
+        // maxas: a0 = (int)clamp(floor(src0.a + 0.5), 0.0, 255.0)
+        // maxasf: a0 = (int)clamp(floor(src0.a), 0.0, 255.0)
         spv::Id maxa_address;
         if (instr.scalar_opcode == ucode::AluScalarOpcode::kMaxAs) {
           maxa_address = builder_->createNoContractionBinOp(
@@ -1068,7 +1070,7 @@ spv::Id SpirvShaderTranslator::ProcessScalarAluOperation(
                     builder_->createUnaryBuiltinCall(
                         type_float_, ext_inst_glsl_std_450_, GLSLstd450Floor,
                         maxa_address),
-                    builder_->makeFloatConstant(-256.0f),
+                    builder_->makeFloatConstant(0.0f),
                     builder_->makeFloatConstant(255.0f))),
             var_main_address_register_);
       }

--- a/src/xenia/gpu/spirv_shader_translator_fetch.cc
+++ b/src/xenia/gpu/spirv_shader_translator_fetch.cc
@@ -1245,12 +1245,9 @@ void SpirvShaderTranslator::ProcessTextureFetchInstruction(
     } else {
       // kTextureFetch or kGetTextureComputedLod.
 
-      // Normalize the XY coordinates, and apply the offset.
-      // When a texture is from a resolution-scaled resolve, offsets are in
-      // guest texels but the size is in host texels. We need to scale offsets
-      // to compensate:
-      // - For normalized coords: coord + (offset * scale) / size_scaled
-      // - For unnormalized coords: (coord + offset) * scale / size_scaled
+      // Normalize the XY coordinates, and apply the offset. When the texture
+      // is resolution-scaled, size has already been scaled up to host texels
+      // above so dividing the offset by it yields a 1-host-texel step.
       for (uint32_t i = 0;
            i <= uint32_t(coordinate_dimension != xenos::FetchOpDimension::k1D);
            ++i) {
@@ -1260,15 +1257,10 @@ void SpirvShaderTranslator::ProcessTextureFetchInstruction(
                              : spv::NoResult;
         spv::Id size_component = size[i];
         if (instr.attributes.unnormalized_coordinates) {
-          if (component_offset != spv::NoResult) {
-            coordinate_ref = builder_->createNoContractionBinOp(
-                spv::OpFAdd, type_float_, coordinate_ref, component_offset);
-          }
-          // For resolution-scaled textures with unnormalized coords, we need
-          // to scale the coordinate (which now includes offset) before
-          // dividing by the scaled size. This ensures:
-          // (coord + offset) * scale / size_scaled = (coord + offset) /
-          // guest_size
+          // Convert the guest-texel coord to host texels for resolution-scaled
+          // textures, since size below is in host texels. Done before the
+          // offset add so the offset stays at 1 host texel rather than being
+          // multiplied with the coord.
           if (is_texture_resolved != spv::NoResult &&
               ((i == 0 && draw_resolution_scale_x_ > 1) ||
                (i == 1 && draw_resolution_scale_y_ > 1))) {
@@ -1281,32 +1273,19 @@ void SpirvShaderTranslator::ProcessTextureFetchInstruction(
                 spv::OpSelect, type_float_, is_texture_resolved, scaled_coord,
                 coordinate_ref);
           }
+          if (component_offset != spv::NoResult) {
+            coordinate_ref = builder_->createNoContractionBinOp(
+                spv::OpFAdd, type_float_, coordinate_ref, component_offset);
+          }
           assert_true(size_component != spv::NoResult);
           coordinate_ref = builder_->createNoContractionBinOp(
               spv::OpFDiv, type_float_, coordinate_ref, size_component);
         } else {
           if (component_offset != spv::NoResult) {
             assert_true(size_component != spv::NoResult);
-            // For resolution-scaled textures with normalized coords, scale the
-            // offset before normalizing. This ensures:
-            // coord + (offset * scale) / size_scaled = coord + offset /
-            // guest_size
-            spv::Id effective_offset = component_offset;
-            if (is_texture_resolved != spv::NoResult &&
-                ((i == 0 && draw_resolution_scale_x_ > 1) ||
-                 (i == 1 && draw_resolution_scale_y_ > 1))) {
-              float scale = (i == 0) ? float(draw_resolution_scale_x_)
-                                     : float(draw_resolution_scale_y_);
-              spv::Id scaled_offset = builder_->createNoContractionBinOp(
-                  spv::OpFMul, type_float_, component_offset,
-                  builder_->makeFloatConstant(scale));
-              effective_offset = builder_->createTriOp(
-                  spv::OpSelect, type_float_, is_texture_resolved,
-                  scaled_offset, component_offset);
-            }
             spv::Id component_offset_normalized =
                 builder_->createNoContractionBinOp(
-                    spv::OpFDiv, type_float_, effective_offset, size_component);
+                    spv::OpFDiv, type_float_, component_offset, size_component);
             coordinate_ref = builder_->createNoContractionBinOp(
                 spv::OpFAdd, type_float_, coordinate_ref,
                 component_offset_normalized);

--- a/src/xenia/gpu/spirv_shader_translator_fetch.cc
+++ b/src/xenia/gpu/spirv_shader_translator_fetch.cc
@@ -903,7 +903,10 @@ void SpirvShaderTranslator::ProcessTextureFetchInstruction(
           size_needed_components |= 0b0001;
           break;
         case xenos::FetchOpDimension::k2D:
-          if (instr.attributes.unnormalized_coordinates) {
+          // A tfetch1D promoted by its source swizzle may still use a 1D fetch
+          // constant. Its size interpretation is selected below at runtime.
+          if (instr.dimension == xenos::FetchOpDimension::k1D ||
+              instr.attributes.unnormalized_coordinates) {
             size_needed_components |= 0b0011;
           }
           break;
@@ -1001,6 +1004,38 @@ void SpirvShaderTranslator::ProcessTextureFetchInstruction(
             size[1] = builder_->createTriOp(
                 spv::OpBitFieldUExtract, type_uint_, fetch_constant_word_2,
                 width_height_bit_count, width_height_bit_count);
+          }
+          if (instr.dimension == xenos::FetchOpDimension::k1D) {
+            assert_true((size_needed_components & 0b11) == 0b11);
+            id_vector_temp_.clear();
+            id_vector_temp_.push_back(const_int_0_);
+            id_vector_temp_.push_back(builder_->makeIntConstant(
+                int((fetch_constant_word_0_index + 5) >> 2)));
+            id_vector_temp_.push_back(builder_->makeIntConstant(
+                int((fetch_constant_word_0_index + 5) & 3)));
+            spv::Id fetch_constant_word_5 = builder_->createLoad(
+                builder_->createAccessChain(spv::StorageClassUniform,
+                                            uniform_fetch_constants_,
+                                            id_vector_temp_),
+                spv::NoPrecision);
+            spv::Id data_is_1d = builder_->createBinOp(
+                spv::OpIEqual, type_bool_,
+                builder_->createTriOp(spv::OpBitFieldUExtract, type_uint_,
+                                      fetch_constant_word_5,
+                                      builder_->makeUintConstant(9),
+                                      builder_->makeUintConstant(2)),
+                builder_->makeUintConstant(
+                    static_cast<unsigned int>(xenos::DataDimension::k1D)));
+            spv::Id width_1d_minus_1 = builder_->createTriOp(
+                spv::OpBitFieldUExtract, type_uint_, fetch_constant_word_2,
+                const_uint_0_,
+                builder_->makeUintConstant(xenos::kTexture1DMaxWidthLog2));
+            size[0] =
+                builder_->createTriOp(spv::OpSelect, type_uint_, data_is_1d,
+                                      width_1d_minus_1, size[0]);
+            size[1] = builder_->createTriOp(spv::OpSelect, type_uint_,
+                                            data_is_1d, const_uint_0_, size[1]);
+            size_1d_width_minus_1_uint = width_1d_minus_1;
           }
           assert_zero(size_needed_components & 0b100);
         } break;
@@ -1341,12 +1376,15 @@ void SpirvShaderTranslator::ProcessTextureFetchInstruction(
           spv::Id row_width_float = builder_->makeFloatConstant(
               float(xenos::kTexture2DCubeMaxWidthHeight));
 
-          // num_rows = ceil(original_width / row_width)
-          spv::Id num_rows = builder_->createUnaryBuiltinCall(
-              type_float_, ext_inst_glsl_std_450_, GLSLstd450Ceil,
-              builder_->createNoContractionBinOp(spv::OpFDiv, type_float_,
-                                                 original_width_float,
-                                                 row_width_float));
+          // Keep this in sync with the texture cache's materialized row cap.
+          spv::Id num_rows = builder_->createBinBuiltinCall(
+              type_float_, ext_inst_glsl_std_450_, GLSLstd450NMin,
+              builder_->createUnaryBuiltinCall(
+                  type_float_, ext_inst_glsl_std_450_, GLSLstd450Ceil,
+                  builder_->createNoContractionBinOp(spv::OpFDiv, type_float_,
+                                                     original_width_float,
+                                                     row_width_float)),
+              builder_->makeFloatConstant(float(xenos::kTexture1DWideMaxRows)));
 
           // linear_x = coord * original_width (denormalize to texel space)
           spv::Id linear_x = builder_->createNoContractionBinOp(

--- a/src/xenia/gpu/spirv_shader_translator_fetch.cc
+++ b/src/xenia/gpu/spirv_shader_translator_fetch.cc
@@ -1469,6 +1469,14 @@ void SpirvShaderTranslator::ProcessTextureFetchInstruction(
             z_stacked = builder_->createNoContractionBinOp(
                 spv::OpFAdd, type_float_, z_stacked, z_offset);
           }
+          // Clamp the layer index to a valid range so an Inf or NaN coordinate
+          // does not select an undefined array layer.
+          z_stacked = builder_->createTriBuiltinCall(
+              type_float_, ext_inst_glsl_std_450_, GLSLstd450NClamp, z_stacked,
+              const_float_0_,
+              builder_->createNoContractionBinOp(
+                  spv::OpFSub, type_float_, z_size,
+                  builder_->makeFloatConstant(1.0f)));
           builder_->createBranch(&block_dimension_merge);
           // Select one of the two.
           builder_->setBuildPoint(&block_dimension_merge);

--- a/src/xenia/gpu/spirv_shader_translator_fetch.cc
+++ b/src/xenia/gpu/spirv_shader_translator_fetch.cc
@@ -43,11 +43,33 @@ void SpirvShaderTranslator::ProcessVertexFetchInstruction(
   EnsureBuildPointAvailable();
 
   uint32_t fetch_constant_word_0_index = instr.operands[1].storage_index << 1;
+  uint32_t fetch_constant_word_1_index = fetch_constant_word_0_index + 1;
+
+  // Load the second fetch constant word up front. It holds the endianness
+  // (bits 0:1) for the swap below and the buffer size in words (bits 2:25)
+  // used for bound checking here.
+  id_vector_temp_.clear();
+  // The only element of the fetch constant buffer.
+  id_vector_temp_.push_back(const_int_0_);
+  // Vector index.
+  id_vector_temp_.push_back(
+      builder_->makeIntConstant(int(fetch_constant_word_1_index >> 2)));
+  // Component index.
+  id_vector_temp_.push_back(
+      builder_->makeIntConstant(int(fetch_constant_word_1_index & 3)));
+  spv::Id fetch_constant_word_1 = builder_->createLoad(
+      builder_->createAccessChain(spv::StorageClassUniform,
+                                  uniform_fetch_constants_, id_vector_temp_),
+      spv::NoPrecision);
 
   spv::Id address;
+  // Exclusive end of the fetch buffer in dwords (base + size). Words at or past
+  // it read as 0, like the hardware clamping out-of-bounds lanes.
+  spv::Id fetch_end;
   if (instr.is_mini_fetch) {
-    // `base + index * stride` loaded by vfetch_full.
+    // `base + index * stride` and the end bound loaded by vfetch_full.
     address = builder_->createLoad(var_main_vfetch_address_, spv::NoPrecision);
+    fetch_end = builder_->createLoad(var_main_vfetch_bound_, spv::NoPrecision);
   } else {
     // Get the base address in dwords from the bits 2:31 of the first fetch
     // constant word.
@@ -73,6 +95,20 @@ void SpirvShaderTranslator::ProcessVertexFetchInstruction(
         builder_->createBinOp(spv::OpShiftRightLogical, type_uint_,
                               fetch_constant_word_0,
                               builder_->makeUintConstant(2)));
+    // address is the base now. The exclusive end is base + size (size in words
+    // in bits 2:25 of the second word). Store it for the subsequent
+    // vfetch_mini, which reuses this fetch constant.
+    fetch_end = builder_->createBinOp(
+        spv::OpIAdd, type_int_, address,
+        builder_->createUnaryOp(
+            spv::OpBitcast, type_int_,
+            builder_->createBinOp(
+                spv::OpBitwiseAnd, type_uint_,
+                builder_->createBinOp(spv::OpShiftRightLogical, type_uint_,
+                                      fetch_constant_word_1,
+                                      builder_->makeUintConstant(2)),
+                builder_->makeUintConstant((uint32_t(1) << 24) - 1))));
+    builder_->createStore(fetch_end, var_main_vfetch_bound_);
     if (instr.attributes.stride) {
       // Convert the index to an integer by flooring or by rounding to the
       // nearest (as floor(index + 0.5) because rounding to the nearest even
@@ -129,12 +165,15 @@ void SpirvShaderTranslator::ProcessVertexFetchInstruction(
                                 builder_->makeIntConstant(int(word_offset)));
     }
     word_composite_indices[word_index] = word_count;
-    // FIXME(Triang3l): Bound checking is not done here, but haven't encountered
-    // any games relying on out-of-bounds access. On Adreno 200 on Android (LG
-    // P705), however, words (not full elements) out of glBufferData bounds
-    // contain 0.
-    word_composite_constituents[word_count++] =
-        LoadUint32FromSharedMemory(word_address);
+    // Words at or past the end of the fetch buffer read as 0, matching the
+    // hardware's bounds clamping. Games rely on this. An overallocated draw
+    // expects the vertices it never wrote to collapse into degenerate
+    // primitives.
+    spv::Id loaded_word = LoadUint32FromSharedMemory(word_address);
+    spv::Id word_in_bounds = builder_->createBinOp(spv::OpULessThan, type_bool_,
+                                                   word_address, fetch_end);
+    word_composite_constituents[word_count++] = builder_->createTriOp(
+        spv::OpSelect, type_uint_, word_in_bounds, loaded_word, const_uint_0_);
   }
   spv::Id words;
   if (word_count > 1) {
@@ -151,21 +190,7 @@ void SpirvShaderTranslator::ProcessVertexFetchInstruction(
   }
 
   // Endian swap the words, getting the endianness from bits 0:1 of the second
-  // fetch constant word.
-  uint32_t fetch_constant_word_1_index = fetch_constant_word_0_index + 1;
-  id_vector_temp_.clear();
-  // The only element of the fetch constant buffer.
-  id_vector_temp_.push_back(const_int_0_);
-  // Vector index.
-  id_vector_temp_.push_back(
-      builder_->makeIntConstant(int(fetch_constant_word_1_index >> 2)));
-  // Component index.
-  id_vector_temp_.push_back(
-      builder_->makeIntConstant(int(fetch_constant_word_1_index & 3)));
-  spv::Id fetch_constant_word_1 = builder_->createLoad(
-      builder_->createAccessChain(spv::StorageClassUniform,
-                                  uniform_fetch_constants_, id_vector_temp_),
-      spv::NoPrecision);
+  // fetch constant word (loaded above).
   words = EndianSwap32Uint(
       words, builder_->createBinOp(spv::OpBitwiseAnd, type_uint_,
                                    fetch_constant_word_1,

--- a/src/xenia/gpu/spirv_shader_translator_memexport.cc
+++ b/src/xenia/gpu/spirv_shader_translator_memexport.cc
@@ -650,95 +650,8 @@ void SpirvShaderTranslator::ExportToMemory(uint8_t export_eM) {
     add_format_case(fixed16_packed, 3);
   }
 
-  // Xbox 360 float16 uses extended range: exponent 31 is NOT Inf/NaN
-  // but a valid large value (up to +/-131008). Standard PackHalf2x16
-  // clamps to +/-65504 and produces Inf for larger values. This helper
-  // detects where standard conversion overflowed to Inf/NaN and
-  // re-encodes those values using the extended range representation:
-  // halve the value, convert to standard f16 (giving exponent <= 30),
-  // then increment the exponent by 1 (placing it in the exponent 31
-  // slot that Xbox 360 treats as a normal value, not Inf/NaN).
-  // Operates on a float2 packed via PackHalf2x16 into a uint32, with
-  // per-lane overflow detection and selection.
-  auto pack_half_2x16_extended_range = [&](spv::Id float2_value) -> spv::Id {
-    // Standard f32 to f16 conversion (handles +/-0..65504 correctly).
-    spv::Id standard =
-        builder_->createUnaryBuiltinCall(type_uint_, ext_inst_glsl_std_450_,
-                                         GLSLstd450PackHalf2x16, float2_value);
-
-    // Detect where standard conversion produced Inf or NaN
-    // (exponent field = 31, i.e. bits [14:10] all set = 0x7C00)
-    // in each 16-bit lane of the packed result.
-    spv::Id const_0x7C00 = builder_->makeUintConstant(0x7C00);
-    spv::Id lower_exp = builder_->createBinOp(spv::OpBitwiseAnd, type_uint_,
-                                              standard, const_0x7C00);
-    spv::Id lower_overflow = builder_->createBinOp(spv::OpIEqual, type_bool_,
-                                                   lower_exp, const_0x7C00);
-    spv::Id upper_bits =
-        builder_->createBinOp(spv::OpShiftRightLogical, type_uint_, standard,
-                              builder_->makeUintConstant(16));
-    spv::Id upper_exp = builder_->createBinOp(spv::OpBitwiseAnd, type_uint_,
-                                              upper_bits, const_0x7C00);
-    spv::Id upper_overflow = builder_->createBinOp(spv::OpIEqual, type_bool_,
-                                                   upper_exp, const_0x7C00);
-
-    // For values that overflowed, compute extended range encoding:
-    // 1. Clamp to +/-131008.0 (max extended float16 can represent).
-    spv::Id const_131008 = builder_->makeFloatConstant(131008.0f);
-    spv::Id const_neg_131008 = builder_->makeFloatConstant(-131008.0f);
-    id_vector_temp_.clear();
-    id_vector_temp_.push_back(const_neg_131008);
-    id_vector_temp_.push_back(const_neg_131008);
-    spv::Id const_neg_131008_vec2 =
-        builder_->makeCompositeConstant(type_float2_, id_vector_temp_);
-    id_vector_temp_.clear();
-    id_vector_temp_.push_back(const_131008);
-    id_vector_temp_.push_back(const_131008);
-    spv::Id const_131008_vec2 =
-        builder_->makeCompositeConstant(type_float2_, id_vector_temp_);
-    spv::Id clamped = builder_->createTriBuiltinCall(
-        type_float2_, ext_inst_glsl_std_450_, GLSLstd450FClamp, float2_value,
-        const_neg_131008_vec2, const_131008_vec2);
-
-    // 2. Halve to bring into standard float16 range (max 65504).
-    spv::Id const_half = builder_->makeFloatConstant(0.5f);
-    id_vector_temp_.clear();
-    id_vector_temp_.push_back(const_half);
-    id_vector_temp_.push_back(const_half);
-    spv::Id const_half_vec2 =
-        builder_->makeCompositeConstant(type_float2_, id_vector_temp_);
-    spv::Id halved = builder_->createBinOp(spv::OpFMul, type_float2_, clamped,
-                                           const_half_vec2);
-
-    // 3. Convert the halved value (will have exponent <= 30).
-    spv::Id halved_packed = builder_->createUnaryBuiltinCall(
-        type_uint_, ext_inst_glsl_std_450_, GLSLstd450PackHalf2x16, halved);
-
-    // 4. Increment exponent by 1 in both lanes (add 0x0400 to each
-    //    16-bit half = 0x04000400) to compensate for the halving.
-    spv::Id extended =
-        builder_->createBinOp(spv::OpIAdd, type_uint_, halved_packed,
-                              builder_->makeUintConstant(0x04000400));
-
-    // Select: use extended result where standard gave Inf/NaN,
-    // keep standard result otherwise. Per-lane selection via masking.
-    spv::Id const_0xFFFF = builder_->makeUintConstant(0xFFFF);
-    spv::Id const_0xFFFF0000 = builder_->makeUintConstant(0xFFFF0000);
-    spv::Id result_lower = builder_->createTriOp(
-        spv::OpSelect, type_uint_, lower_overflow,
-        builder_->createBinOp(spv::OpBitwiseAnd, type_uint_, extended,
-                              const_0xFFFF),
-        builder_->createBinOp(spv::OpBitwiseAnd, type_uint_, standard,
-                              const_0xFFFF));
-    spv::Id result_upper = builder_->createTriOp(
-        spv::OpSelect, type_uint_, upper_overflow,
-        builder_->createBinOp(spv::OpBitwiseAnd, type_uint_, extended,
-                              const_0xFFFF0000),
-        builder_->createBinOp(spv::OpBitwiseAnd, type_uint_, standard,
-                              const_0xFFFF0000));
-    return builder_->createBinOp(spv::OpBitwiseOr, type_uint_, result_lower,
-                                 result_upper);
-  };
+  // Xbox 360 float16 uses extended range: exponent 31 is a large finite value,
+  // not Inf/NaN. See PackFloat16x2ExtendedRange.
 
   // k_16_FLOAT
   format_switch.makeBeginCase(
@@ -750,7 +663,7 @@ void SpirvShaderTranslator::ExportToMemory(uint8_t export_eM) {
       id_vector_temp_.push_back(builder_->createCompositeExtract(
           eM_swapped[eM_index], type_float_, 0));
       id_vector_temp_.push_back(const_float_0_);
-      spv::Id format_packed_16_float_x = pack_half_2x16_extended_range(
+      spv::Id format_packed_16_float_x = PackFloat16x2ExtendedRange(
           builder_->createCompositeConstruct(type_float2_, id_vector_temp_));
       id_vector_temp_.clear();
       id_vector_temp_.resize(4, const_uint_0_);
@@ -771,7 +684,7 @@ void SpirvShaderTranslator::ExportToMemory(uint8_t export_eM) {
       uint_vector_temp_.push_back(0);
       uint_vector_temp_.push_back(1);
       spv::Id format_packed_16_16_float_xy =
-          pack_half_2x16_extended_range(builder_->createRvalueSwizzle(
+          PackFloat16x2ExtendedRange(builder_->createRvalueSwizzle(
               spv::NoPrecision, type_float2_, eM_swapped[eM_index],
               uint_vector_temp_));
       id_vector_temp_.clear();
@@ -796,7 +709,7 @@ void SpirvShaderTranslator::ExportToMemory(uint8_t export_eM) {
         uint_vector_temp_.push_back(2 * component_index);
         uint_vector_temp_.push_back(2 * component_index + 1);
         format_packed_16_16_16_16_float_xy_zw[component_index] =
-            pack_half_2x16_extended_range(builder_->createRvalueSwizzle(
+            PackFloat16x2ExtendedRange(builder_->createRvalueSwizzle(
                 spv::NoPrecision, type_float2_, eM_swapped[eM_index],
                 uint_vector_temp_));
       }

--- a/src/xenia/gpu/spirv_shader_translator_rb.cc
+++ b/src/xenia/gpu/spirv_shader_translator_rb.cc
@@ -645,6 +645,22 @@ void SpirvShaderTranslator::CompleteFragmentShaderInMain() {
             block_rt_0_alpha_tests_rt_written_head->getId());
         main_fsi_sample_mask_ =
             builder_->createOp(spv::OpPhi, type_uint_, id_vector_temp_);
+      } else if (edram_fragment_shader_interlock_) {
+        // Demote path: the alpha test demotes instead of touching the mask, but
+        // alpha to coverage still modified main_fsi_sample_mask_ inside the
+        // written branch. Merge in fsi_sample_mask_in_rt_0_alpha_tests, the
+        // mask from before the branch, on the edge where the render target
+        // wasn't written so the value dominates the merge. Otherwise it is
+        // undefined there (invalid SPIR-V dominance and garbage coverage).
+        id_vector_temp_.clear();
+        id_vector_temp_.push_back(main_fsi_sample_mask_);
+        id_vector_temp_.push_back(
+            block_rt_0_alpha_tests_rt_written_end.getId());
+        id_vector_temp_.push_back(fsi_sample_mask_in_rt_0_alpha_tests);
+        id_vector_temp_.push_back(
+            block_rt_0_alpha_tests_rt_written_head->getId());
+        main_fsi_sample_mask_ =
+            builder_->createOp(spv::OpPhi, type_uint_, id_vector_temp_);
       }
     }
   }
@@ -1741,12 +1757,12 @@ void SpirvShaderTranslator::FSI_LoadSampleMask(spv::Id msaa_samples) {
                                 input_sample_mask_value),
         builder_->makeUintConstant(32 - 2));
   } else {
-    // 0 and 3 to 0 and 1.
+    // 0 and 3 to 0 and 1. Guest sample 1 comes from host sample 3.
     sample_mask_2x = builder_->createQuadOp(
         spv::OpBitFieldInsert, type_uint_, input_sample_mask_value,
         builder_->createTriOp(spv::OpBitFieldUExtract, type_uint_,
-                              input_sample_mask_value, const_uint_2,
-                              const_uint_1),
+                              input_sample_mask_value,
+                              builder_->makeUintConstant(3), const_uint_1),
         const_uint_1, builder_->makeUintConstant(32 - 1));
   }
   builder_->createBranch(&block_msaa_merge);

--- a/src/xenia/gpu/spirv_shader_translator_rb.cc
+++ b/src/xenia/gpu/spirv_shader_translator_rb.cc
@@ -4401,8 +4401,11 @@ void SpirvShaderTranslator::FSI_AlphaToMask() {
     FSI_AlphaToMaskSample(false, 1, 1.0f, threshold_offset, 1.0f / 8.0f, alpha,
                           coverage_2x);
   } else {
-    // FBO: Account for native 2x vs 2x-as-4x sample mapping.
-    if (native_2x_msaa_no_attachments_) {
+    // FBO: Account for native 2x vs 2x-as-4x sample mapping. This epilogue only
+    // runs when there is a color attachment (sample mask output), so whether 2x
+    // is native must be taken from the capability with attachments, matching
+    // the choice made for the host pipeline.
+    if (native_2x_msaa_with_attachments_) {
       // Native 2x: D3D10.1+ standard - top is 1, bottom is 0.
       FSI_AlphaToMaskSample(true, 1, 0.5f, threshold_offset, 1.0f / 8.0f, alpha,
                             coverage_2x);

--- a/src/xenia/gpu/spirv_shader_translator_rb.cc
+++ b/src/xenia/gpu/spirv_shader_translator_rb.cc
@@ -2680,6 +2680,132 @@ void SpirvShaderTranslator::FSI_DepthStencilTest(
   }
 }
 
+spv::Id SpirvShaderTranslator::PackFloat16x2ExtendedRange(
+    spv::Id float2_value) {
+  // The Xbox 360 float16 has no NaN, map it to 0. Also keeps the overflow
+  // detection below from misreading a NaN's exponent 31 as a finite extended
+  // value, and FClamp's NaN result is undefined.
+  float2_value = builder_->createTriOp(
+      spv::OpSelect, type_float2_,
+      builder_->createUnaryOp(spv::OpIsNan, type_bool2_, float2_value),
+      const_float2_0_, float2_value);
+  // The standard conversion covers magnitudes up to 65504. Anything larger
+  // overflows to Inf (exponent field 0x7C00). Re-encode the overflowed lanes
+  // using the extended range: halve into the standard range, convert
+  // (exponent <= 30), then bump the exponent by 1 into the exponent 31 slot
+  // the Xbox 360 treats as finite.
+  spv::Id standard = builder_->createUnaryBuiltinCall(
+      type_uint_, ext_inst_glsl_std_450_, GLSLstd450PackHalf2x16, float2_value);
+  spv::Id const_0x7C00 = builder_->makeUintConstant(0x7C00);
+  spv::Id lower_overflow =
+      builder_->createBinOp(spv::OpIEqual, type_bool_,
+                            builder_->createBinOp(spv::OpBitwiseAnd, type_uint_,
+                                                  standard, const_0x7C00),
+                            const_0x7C00);
+  spv::Id upper_overflow = builder_->createBinOp(
+      spv::OpIEqual, type_bool_,
+      builder_->createBinOp(
+          spv::OpBitwiseAnd, type_uint_,
+          builder_->createBinOp(spv::OpShiftRightLogical, type_uint_, standard,
+                                builder_->makeUintConstant(16)),
+          const_0x7C00),
+      const_0x7C00);
+  id_vector_temp_.clear();
+  id_vector_temp_.resize(2, builder_->makeFloatConstant(-131008.0f));
+  spv::Id const_neg_131008 =
+      builder_->makeCompositeConstant(type_float2_, id_vector_temp_);
+  id_vector_temp_.clear();
+  id_vector_temp_.resize(2, builder_->makeFloatConstant(131008.0f));
+  spv::Id const_131008 =
+      builder_->makeCompositeConstant(type_float2_, id_vector_temp_);
+  spv::Id clamped = builder_->createTriBuiltinCall(
+      type_float2_, ext_inst_glsl_std_450_, GLSLstd450FClamp, float2_value,
+      const_neg_131008, const_131008);
+  id_vector_temp_.clear();
+  id_vector_temp_.resize(2, builder_->makeFloatConstant(0.5f));
+  spv::Id halved = builder_->createBinOp(
+      spv::OpFMul, type_float2_, clamped,
+      builder_->makeCompositeConstant(type_float2_, id_vector_temp_));
+  spv::Id halved_packed = builder_->createUnaryBuiltinCall(
+      type_uint_, ext_inst_glsl_std_450_, GLSLstd450PackHalf2x16, halved);
+  // halved_packed has exponent <= 30 in both lanes, so adding 0x0400 per lane
+  // bumps the exponent without ever carrying across lanes.
+  spv::Id extended =
+      builder_->createBinOp(spv::OpIAdd, type_uint_, halved_packed,
+                            builder_->makeUintConstant(0x04000400));
+  spv::Id const_0xFFFF = builder_->makeUintConstant(0xFFFF);
+  spv::Id const_0xFFFF0000 = builder_->makeUintConstant(0xFFFF0000);
+  spv::Id result_lower =
+      builder_->createTriOp(spv::OpSelect, type_uint_, lower_overflow,
+                            builder_->createBinOp(spv::OpBitwiseAnd, type_uint_,
+                                                  extended, const_0xFFFF),
+                            builder_->createBinOp(spv::OpBitwiseAnd, type_uint_,
+                                                  standard, const_0xFFFF));
+  spv::Id result_upper =
+      builder_->createTriOp(spv::OpSelect, type_uint_, upper_overflow,
+                            builder_->createBinOp(spv::OpBitwiseAnd, type_uint_,
+                                                  extended, const_0xFFFF0000),
+                            builder_->createBinOp(spv::OpBitwiseAnd, type_uint_,
+                                                  standard, const_0xFFFF0000));
+  return builder_->createBinOp(spv::OpBitwiseOr, type_uint_, result_lower,
+                               result_upper);
+}
+
+spv::Id SpirvShaderTranslator::UnpackFloat16x2ExtendedRange(
+    spv::Id packed_uint) {
+  // Inverse of PackFloat16x2ExtendedRange. Exponent 31 lanes are large finite
+  // values rather than Inf or NaN. Decrement their exponent by 1 into the
+  // standard range, unpack, then double to compensate.
+  spv::Id const_0x7C00 = builder_->makeUintConstant(0x7C00);
+  spv::Id lower_overflow =
+      builder_->createBinOp(spv::OpIEqual, type_bool_,
+                            builder_->createBinOp(spv::OpBitwiseAnd, type_uint_,
+                                                  packed_uint, const_0x7C00),
+                            const_0x7C00);
+  spv::Id upper_overflow = builder_->createBinOp(
+      spv::OpIEqual, type_bool_,
+      builder_->createBinOp(
+          spv::OpBitwiseAnd, type_uint_,
+          builder_->createBinOp(spv::OpShiftRightLogical, type_uint_,
+                                packed_uint, builder_->makeUintConstant(16)),
+          const_0x7C00),
+      const_0x7C00);
+  spv::Id standard =
+      builder_->createUnaryBuiltinCall(type_float2_, ext_inst_glsl_std_450_,
+                                       GLSLstd450UnpackHalf2x16, packed_uint);
+  // Decrement the exponent only in overflowed lanes (0x0400 in the low lane,
+  // 0x04000000 in the high one) so the subtraction never borrows across lanes.
+  spv::Id sub_lower =
+      builder_->createTriOp(spv::OpSelect, type_uint_, lower_overflow,
+                            builder_->makeUintConstant(0x0400), const_uint_0_);
+  spv::Id sub_upper = builder_->createTriOp(
+      spv::OpSelect, type_uint_, upper_overflow,
+      builder_->makeUintConstant(0x04000000), const_uint_0_);
+  spv::Id reduced =
+      builder_->createBinOp(spv::OpISub, type_uint_, packed_uint,
+                            builder_->createBinOp(spv::OpBitwiseOr, type_uint_,
+                                                  sub_lower, sub_upper));
+  spv::Id reduced_unpacked = builder_->createUnaryBuiltinCall(
+      type_float2_, ext_inst_glsl_std_450_, GLSLstd450UnpackHalf2x16, reduced);
+  id_vector_temp_.clear();
+  id_vector_temp_.resize(2, builder_->makeFloatConstant(2.0f));
+  spv::Id extended = builder_->createBinOp(
+      spv::OpFMul, type_float2_, reduced_unpacked,
+      builder_->makeCompositeConstant(type_float2_, id_vector_temp_));
+  spv::Id result_x = builder_->createTriOp(
+      spv::OpSelect, type_float_, lower_overflow,
+      builder_->createCompositeExtract(extended, type_float_, 0),
+      builder_->createCompositeExtract(standard, type_float_, 0));
+  spv::Id result_y = builder_->createTriOp(
+      spv::OpSelect, type_float_, upper_overflow,
+      builder_->createCompositeExtract(extended, type_float_, 1),
+      builder_->createCompositeExtract(standard, type_float_, 1));
+  id_vector_temp_.clear();
+  id_vector_temp_.push_back(result_x);
+  id_vector_temp_.push_back(result_y);
+  return builder_->createCompositeConstruct(type_float2_, id_vector_temp_);
+}
+
 std::array<spv::Id, 2> SpirvShaderTranslator::FSI_ClampAndPackColor(
     spv::Id color_float4, spv::Id format_with_flags) {
   spv::Block& block_format_head = *builder_->getBuildPoint();
@@ -2977,31 +3103,14 @@ std::array<spv::Id, 2> SpirvShaderTranslator::FSI_ClampAndPackColor(
   std::array<spv::Id, 2> packed_16_float;
   {
     builder_->setBuildPoint(&block_format_16_float);
-    // TODO(Triang3l): Xenos extended-range float16.
-    id_vector_temp_.clear();
-    id_vector_temp_.resize(4, builder_->makeFloatConstant(-65504.0f));
-    spv::Id const_float4_minus_float16_max =
-        builder_->makeCompositeConstant(type_float4_, id_vector_temp_);
-    id_vector_temp_.clear();
-    id_vector_temp_.resize(4, builder_->makeFloatConstant(65504.0f));
-    spv::Id const_float4_float16_max =
-        builder_->makeCompositeConstant(type_float4_, id_vector_temp_);
-    // NaN to 0, not to -max.
-    spv::Id color_clamped = builder_->createTriBuiltinCall(
-        type_float4_, ext_inst_glsl_std_450_, GLSLstd450FClamp,
-        builder_->createTriOp(
-            spv::OpSelect, type_float4_,
-            builder_->createUnaryOp(spv::OpIsNan, type_bool4_, color_float4),
-            const_float4_0_, color_float4),
-        const_float4_minus_float16_max, const_float4_float16_max);
+    // NaN is flushed to 0 inside PackFloat16x2ExtendedRange.
     for (uint32_t i = 0; i < 2; ++i) {
       uint_vector_temp_.clear();
       uint_vector_temp_.push_back(2 * i);
       uint_vector_temp_.push_back(2 * i + 1);
-      packed_16_float[i] = builder_->createUnaryBuiltinCall(
-          type_uint_, ext_inst_glsl_std_450_, GLSLstd450PackHalf2x16,
-          builder_->createRvalueSwizzle(spv::NoPrecision, type_float2_,
-                                        color_clamped, uint_vector_temp_));
+      packed_16_float[i] =
+          PackFloat16x2ExtendedRange(builder_->createRvalueSwizzle(
+              spv::NoPrecision, type_float2_, color_float4, uint_vector_temp_));
     }
     builder_->createBranch(&block_format_merge);
   }
@@ -3290,11 +3399,9 @@ std::array<spv::Id, 4> SpirvShaderTranslator::FSI_UnpackColor(
     for (uint32_t i = 0; i < 2; ++i) {
       builder_->setBuildPoint(i ? &block_format_16_16_16_16_float
                                 : &block_format_16_16_float);
-      // TODO(Triang3l): Xenos extended-range float16.
       for (uint32_t j = 0; j <= i; ++j) {
-        spv::Id components_float2 = builder_->createUnaryBuiltinCall(
-            type_float2_, ext_inst_glsl_std_450_, GLSLstd450UnpackHalf2x16,
-            color_packed[j]);
+        spv::Id components_float2 =
+            UnpackFloat16x2ExtendedRange(color_packed[j]);
         for (uint32_t k = 0; k < 2; ++k) {
           unpacked_16_float[i][2 * j + k] = builder_->createCompositeExtract(
               components_float2, type_float_, k);

--- a/src/xenia/gpu/texture_cache.cc
+++ b/src/xenia/gpu/texture_cache.cc
@@ -1013,6 +1013,7 @@ void TextureCache::BindingInfoFromFetchConstant(
       uint32_t total_width = width_minus_1 + 1;
       uint32_t row_width = xenos::kTexture2DCubeMaxWidthHeight;
       uint32_t num_rows = (total_width + row_width - 1) / row_width;
+      num_rows = std::min(num_rows, xenos::kTexture1DWideMaxRows);
       width_minus_1 = row_width - 1;
       height_minus_1 = num_rows - 1;
       // Disable mipmaps for wide 1D textures. The shader's coordinate remapping

--- a/src/xenia/gpu/texture_cache.h
+++ b/src/xenia/gpu/texture_cache.h
@@ -638,6 +638,19 @@ class TextureCache {
   // implementation to update the internal dependencies of the binding.
   virtual void UpdateTextureBindingsImpl(uint32_t fetch_constant_mask) {}
 
+  // Checks if there are any pages that contain scaled resolve data within the
+  // range.
+  bool IsRangeScaledResolved(uint32_t start_unscaled, uint32_t length_unscaled);
+
+  // Whether the mips of a scaled resolve texture must be generated on the host
+  // (the guest did not resolve them into scaled memory itself).
+  bool ScaledResolveMipsNeedGeneration(const Texture& texture) {
+    const TextureKey& key = texture.key();
+    return key.scaled_resolve && key.mip_max_level != 0 &&
+           !IsRangeScaledResolved(key.mip_page << 12,
+                                  texture.GetGuestMipsSize());
+  }
+
  private:
   void UpdateTexturesTotalHostMemoryUsage(uint64_t add, uint64_t subtract);
 
@@ -646,9 +659,6 @@ class TextureCache {
                             void* context, void* data, uint64_t argument,
                             bool invalidated_by_gpu);
 
-  // Checks if there are any pages that contain scaled resolve data within the
-  // range.
-  bool IsRangeScaledResolved(uint32_t start_unscaled, uint32_t length_unscaled);
   // Global shared memory invalidation callback for invalidating scaled resolved
   // texture data.
   static void ScaledResolveGlobalWatchCallbackThunk(

--- a/src/xenia/gpu/vulkan/vulkan_command_processor.cc
+++ b/src/xenia/gpu/vulkan/vulkan_command_processor.cc
@@ -1402,6 +1402,17 @@ void VulkanCommandProcessor::WriteRegister(uint32_t index, uint32_t value) {
       texture_cache_->TextureFetchConstantWritten(
           (index - XE_GPU_REG_SHADER_CONSTANT_FETCH_00_0) / 6);
     }
+  } else if (index == XE_GPU_REG_VGT_MAX_VTX_INDX ||
+             index == XE_GPU_REG_VGT_MIN_VTX_INDX ||
+             index == XE_GPU_REG_VGT_INDX_OFFSET ||
+             index == XE_GPU_REG_VGT_DMA_SIZE ||
+             index == XE_GPU_REG_VGT_HOS_MAX_TESS_LEVEL ||
+             index == XE_GPU_REG_VGT_HOS_MIN_TESS_LEVEL) {
+    // Source registers for the tessellation constant buffer. Invalidate it so
+    // the factor range and index parameters are refreshed per draw instead of
+    // staying stale from the first draw of the submission.
+    current_constant_buffers_up_to_date_ &=
+        ~(UINT32_C(1) << SpirvShaderTranslator::kConstantBufferTessellation);
   }
 }
 void VulkanCommandProcessor::WriteRegistersFromMem(uint32_t start_index,
@@ -2748,6 +2759,18 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type,
       vgt_draw_initiator.index_size == xenos::IndexFormat::kInt32 &&
       primitive_processing_result.host_vertex_shader_type ==
           Shader::HostVertexShaderType::kVertex;
+
+  // The tessellation vertex index endian is a per-draw value from the
+  // primitive processor rather than a register, kNone for auto draws whose
+  // factors were already converted on the host. A change between draws must
+  // invalidate the tessellation constant buffer explicitly.
+  if (current_tessellation_index_endian_ !=
+      primitive_processing_result.host_shader_index_endian) {
+    current_tessellation_index_endian_ =
+        primitive_processing_result.host_shader_index_endian;
+    current_constant_buffers_up_to_date_ &=
+        ~(UINT32_C(1) << SpirvShaderTranslator::kConstantBufferTessellation);
+  }
 
   // Update system constants before uploading them.
   UpdateSystemConstantValues(
@@ -5490,10 +5513,13 @@ bool VulkanCommandProcessor::UpdateBindings(const VulkanShader* vertex_shader,
       tessellation_constants.tessellation_factor_range[1] = tess_factor_max;
       tessellation_constants.padding0[0] = 0.0f;
       tessellation_constants.padding0[1] = 0.0f;
-      // Vertex index processing parameters for tessellation shaders.
-      auto vgt_dma_size = regs.Get<reg::VGT_DMA_SIZE>();
+      // Vertex index processing parameters for tessellation shaders. The
+      // endian comes from the primitive processor, not raw
+      // VGT_DMA_SIZE.swap_mode. Auto draws read factors the host has already
+      // byte swapped, so swapping them again in the hull shader corrupted every
+      // adaptive factor.
       tessellation_constants.vertex_index_endian =
-          static_cast<uint32_t>(vgt_dma_size.swap_mode);
+          static_cast<uint32_t>(current_tessellation_index_endian_);
       tessellation_constants.vertex_index_offset =
           regs[XE_GPU_REG_VGT_INDX_OFFSET];
       tessellation_constants.vertex_index_min_max[0] =

--- a/src/xenia/gpu/vulkan/vulkan_command_processor.cc
+++ b/src/xenia/gpu/vulkan/vulkan_command_processor.cc
@@ -2392,6 +2392,13 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type,
     return IssueCopy();
   }
 
+  if (regs.Get<reg::RB_SURFACE_INFO>().surface_pitch == 0) {
+    // Doesn't actually draw. Matches the Direct3D 12 backend.
+    // TODO(Triang3l): Do something so memexport still works in this case maybe?
+    // Unlikely that zero would even really be legal though.
+    return true;
+  }
+
   const ui::vulkan::VulkanDevice::Properties& device_properties =
       GetVulkanDevice()->properties();
 

--- a/src/xenia/gpu/vulkan/vulkan_command_processor.cc
+++ b/src/xenia/gpu/vulkan/vulkan_command_processor.cc
@@ -4712,8 +4712,9 @@ void VulkanCommandProcessor::UpdateDynamicState(
           stencil_ref_mask_back_reg = XE_GPU_REG_RB_STENCILREFMASK_BF;
         } else {
           // Choose the back face values only if drawing only back faces.
+          auto pa_su_sc_mode_cntl = regs.Get<reg::PA_SU_SC_MODE_CNTL>();
           stencil_ref_mask_front_reg =
-              regs.Get<reg::PA_SU_SC_MODE_CNTL>().cull_front
+              (pa_su_sc_mode_cntl.cull_front && !pa_su_sc_mode_cntl.cull_back)
                   ? XE_GPU_REG_RB_STENCILREFMASK_BF
                   : XE_GPU_REG_RB_STENCILREFMASK;
           stencil_ref_mask_back_reg = stencil_ref_mask_front_reg;

--- a/src/xenia/gpu/vulkan/vulkan_command_processor.cc
+++ b/src/xenia/gpu/vulkan/vulkan_command_processor.cc
@@ -1413,6 +1413,11 @@ void VulkanCommandProcessor::WriteRegister(uint32_t index, uint32_t value) {
     // staying stale from the first draw of the submission.
     current_constant_buffers_up_to_date_ &=
         ~(UINT32_C(1) << SpirvShaderTranslator::kConstantBufferTessellation);
+  } else if ((index >= XE_GPU_REG_PA_CL_UCP_0_X &&
+              index <= XE_GPU_REG_PA_CL_UCP_5_W) ||
+             index == XE_GPU_REG_PA_CL_CLIP_CNTL) {
+    current_constant_buffers_up_to_date_ &=
+        ~(UINT32_C(1) << SpirvShaderTranslator::kConstantBufferClipPlanes);
   }
 }
 void VulkanCommandProcessor::WriteRegistersFromMem(uint32_t start_index,

--- a/src/xenia/gpu/vulkan/vulkan_command_processor.h
+++ b/src/xenia/gpu/vulkan/vulkan_command_processor.h
@@ -788,6 +788,10 @@ class VulkanCommandProcessor final : public CommandProcessor {
   // Whether up-to-date data has been written to constant (uniform) buffers, and
   // the buffer infos in current_constant_buffer_infos_ point to them.
   uint32_t current_constant_buffers_up_to_date_;
+  // The index endian the tessellation constant buffer was filled with, from the
+  // primitive processor for the current draw. Not a register, so changes
+  // between draws invalidate the buffer separately from WriteRegister.
+  xenos::Endian current_tessellation_index_endian_ = xenos::Endian::kNone;
   VkDescriptorSet current_graphics_descriptor_sets_
       [SpirvShaderTranslator::kDescriptorSetCount];
   // Whether descriptor sets in current_graphics_descriptor_sets_ point to

--- a/src/xenia/gpu/vulkan/vulkan_pipeline_cache.cc
+++ b/src/xenia/gpu/vulkan/vulkan_pipeline_cache.cc
@@ -83,8 +83,15 @@ bool VulkanPipelineCache::Initialize() {
       render_target_cache_.GetPath() ==
       RenderTargetCache::Path::kPixelShaderInterlock;
 
+  // Cache device float control features for geometry shader creation.
+  const SpirvShaderTranslator::Features features(vulkan_device);
+  signed_zero_inf_nan_preserve_float32_ =
+      features.signed_zero_inf_nan_preserve_float32;
+  denorm_flush_to_zero_float32_ = features.denorm_flush_to_zero_float32;
+  rounding_mode_rte_float32_ = features.rounding_mode_rte_float32;
+
   shader_translator_ = std::make_unique<SpirvShaderTranslator>(
-      SpirvShaderTranslator::Features(vulkan_device),
+      features,
       render_target_cache_.msaa_2x_attachments_supported(),
       render_target_cache_.msaa_2x_no_attachments_supported(),
       edram_fragment_shader_interlock,
@@ -1578,7 +1585,25 @@ VkShaderModule VulkanPipelineCache::GetGeometryShader(GeometryShaderKey key) {
   builder.setMemoryModel(spv::AddressingModelLogical, spv::MemoryModelGLSL450);
   builder.setSource(spv::SourceLanguageUnknown, 0);
 
-  // TODO(Triang3l): Shader float controls (NaN preservation most importantly).
+  // Match the vertex and pixel shaders' float controls. NaN preservation most
+  // importantly keeps the NaN-position primitive discard below (used for the
+  // vertex kill "or" operator and degenerate rectangles) from being folded
+  // away. The geometry shader is built as SPIR-V 1.0, where the float controls
+  // are an extension. The execution modes are added once the entry point
+  // exists.
+  if (denorm_flush_to_zero_float32_ || signed_zero_inf_nan_preserve_float32_ ||
+      rounding_mode_rte_float32_) {
+    builder.addExtension("SPV_KHR_float_controls");
+  }
+  if (denorm_flush_to_zero_float32_) {
+    builder.addCapability(spv::CapabilityDenormFlushToZero);
+  }
+  if (signed_zero_inf_nan_preserve_float32_) {
+    builder.addCapability(spv::CapabilitySignedZeroInfNanPreserve);
+  }
+  if (rounding_mode_rte_float32_) {
+    builder.addCapability(spv::CapabilityRoundingModeRTE);
+  }
 
   std::vector<spv::Id> main_interface;
 
@@ -1825,6 +1850,18 @@ VkShaderModule VulkanPipelineCache::GetGeometryShader(GeometryShaderKey key) {
   builder.addExecutionMode(main_function, output_primitive_execution_mode);
   builder.addExecutionMode(main_function, spv::ExecutionModeOutputVertices,
                            int(output_max_vertices));
+  if (denorm_flush_to_zero_float32_) {
+    builder.addExecutionMode(main_function, spv::ExecutionModeDenormFlushToZero,
+                             32);
+  }
+  if (signed_zero_inf_nan_preserve_float32_) {
+    builder.addExecutionMode(main_function,
+                             spv::ExecutionModeSignedZeroInfNanPreserve, 32);
+  }
+  if (rounding_mode_rte_float32_) {
+    builder.addExecutionMode(main_function, spv::ExecutionModeRoundingModeRTE,
+                             32);
+  }
 
   // Note that after every OpEmitVertex, all output variables are undefined.
 

--- a/src/xenia/gpu/vulkan/vulkan_pipeline_cache.cc
+++ b/src/xenia/gpu/vulkan/vulkan_pipeline_cache.cc
@@ -409,6 +409,12 @@ VulkanPipelineCache::GetCurrentVertexShaderModification(
 
   modification.vertex.interpolator_mask = interpolator_mask;
 
+  // Tessellation mode selects the domain shader spacing.
+  if (Shader::IsHostVertexShaderTypeDomain(host_vertex_shader_type)) {
+    modification.vertex.tessellation_mode =
+        regs.Get<reg::VGT_HOS_CNTL>().tess_mode;
+  }
+
   // User clip planes.
   auto pa_cl_clip_cntl = regs.Get<reg::PA_CL_CLIP_CNTL>();
   uint32_t user_clip_planes =

--- a/src/xenia/gpu/vulkan/vulkan_pipeline_cache.cc
+++ b/src/xenia/gpu/vulkan/vulkan_pipeline_cache.cc
@@ -1126,15 +1126,37 @@ void VulkanPipelineCache::WritePipelineRenderTargetDescription(
         /* 15 */ PipelineBlendFactor::kOneMinusConstantAlpha,
         /* 16 */ PipelineBlendFactor::kSrcAlphaSaturate,
     };
+    // Like kBlendFactorMap, but with the color factors changed to their alpha
+    // equivalents. Alpha is scalar, so hardware treats a _COLOR factor in the
+    // alpha slot as the matching _ALPHA factor.
+    static constexpr PipelineBlendFactor kBlendFactorAlphaMap[32] = {
+        /*  0 */ PipelineBlendFactor::kZero,
+        /*  1 */ PipelineBlendFactor::kOne,
+        /*  2 */ PipelineBlendFactor::kZero,  // ?
+        /*  3 */ PipelineBlendFactor::kZero,  // ?
+        /*  4 */ PipelineBlendFactor::kSrcAlpha,
+        /*  5 */ PipelineBlendFactor::kOneMinusSrcAlpha,
+        /*  6 */ PipelineBlendFactor::kSrcAlpha,
+        /*  7 */ PipelineBlendFactor::kOneMinusSrcAlpha,
+        /*  8 */ PipelineBlendFactor::kDstAlpha,
+        /*  9 */ PipelineBlendFactor::kOneMinusDstAlpha,
+        /* 10 */ PipelineBlendFactor::kDstAlpha,
+        /* 11 */ PipelineBlendFactor::kOneMinusDstAlpha,
+        /* 12 */ PipelineBlendFactor::kConstantAlpha,
+        /* 13 */ PipelineBlendFactor::kOneMinusConstantAlpha,
+        /* 14 */ PipelineBlendFactor::kConstantAlpha,
+        /* 15 */ PipelineBlendFactor::kOneMinusConstantAlpha,
+        /* 16 */ PipelineBlendFactor::kSrcAlphaSaturate,
+    };
     render_target_out.src_color_blend_factor =
         kBlendFactorMap[uint32_t(blend_control.color_srcblend)];
     render_target_out.dst_color_blend_factor =
         kBlendFactorMap[uint32_t(blend_control.color_destblend)];
     render_target_out.color_blend_op = blend_control.color_comb_fcn;
     render_target_out.src_alpha_blend_factor =
-        kBlendFactorMap[uint32_t(blend_control.alpha_srcblend)];
+        kBlendFactorAlphaMap[uint32_t(blend_control.alpha_srcblend)];
     render_target_out.dst_alpha_blend_factor =
-        kBlendFactorMap[uint32_t(blend_control.alpha_destblend)];
+        kBlendFactorAlphaMap[uint32_t(blend_control.alpha_destblend)];
     render_target_out.alpha_blend_op = blend_control.alpha_comb_fcn;
     if (!command_processor_.GetVulkanDevice()
              ->properties()

--- a/src/xenia/gpu/vulkan/vulkan_pipeline_cache.cc
+++ b/src/xenia/gpu/vulkan/vulkan_pipeline_cache.cc
@@ -59,6 +59,9 @@ DEFINE_int32(
     "the number of threads explicitly (up to the number of logical CPU cores), "
     "0 to disable multithreaded pipeline creation.",
     "Vulkan");
+
+DECLARE_bool(spirv_disable_rounding_mode_rte);
+
 namespace xe {
 namespace gpu {
 namespace vulkan {
@@ -88,11 +91,11 @@ bool VulkanPipelineCache::Initialize() {
   signed_zero_inf_nan_preserve_float32_ =
       features.signed_zero_inf_nan_preserve_float32;
   denorm_flush_to_zero_float32_ = features.denorm_flush_to_zero_float32;
-  rounding_mode_rte_float32_ = features.rounding_mode_rte_float32;
+  rounding_mode_rte_float32_ = features.rounding_mode_rte_float32 &&
+                               !cvars::spirv_disable_rounding_mode_rte;
 
   shader_translator_ = std::make_unique<SpirvShaderTranslator>(
-      features,
-      render_target_cache_.msaa_2x_attachments_supported(),
+      features, render_target_cache_.msaa_2x_attachments_supported(),
       render_target_cache_.msaa_2x_no_attachments_supported(),
       edram_fragment_shader_interlock,
       render_target_cache_.draw_resolution_scale_x(),

--- a/src/xenia/gpu/vulkan/vulkan_pipeline_cache.h
+++ b/src/xenia/gpu/vulkan/vulkan_pipeline_cache.h
@@ -400,6 +400,13 @@ class VulkanPipelineCache {
   VulkanRenderTargetCache& render_target_cache_;
   VkShaderStageFlags guest_shader_vertex_stages_;
 
+  // Cached device float control features for geometry shader creation, so the
+  // built-in geometry shaders run under the same float semantics as the guest
+  // vertex and pixel shaders.
+  bool signed_zero_inf_nan_preserve_float32_ = false;
+  bool denorm_flush_to_zero_float32_ = false;
+  bool rounding_mode_rte_float32_ = false;
+
   // Temporary storage for AnalyzeUcode calls on the processor thread.
   StringBuffer ucode_disasm_buffer_;
   // Reusable shader translator on the command processor thread.

--- a/src/xenia/gpu/vulkan/vulkan_render_target_cache.cc
+++ b/src/xenia/gpu/vulkan/vulkan_render_target_cache.cc
@@ -1184,12 +1184,22 @@ bool VulkanRenderTargetCache::Resolve(
       } else {
         // TODO(Triang3l): Switching between descriptors if exceeding
         // maxStorageBufferRange.
-        // TODO(Triang3l): Use a single 512 MB shared memory binding if
-        // possible.
+        // Bind the whole shared memory buffer persistently when possible
+        // (passing the destination byte offset via dest_base) instead of
+        // allocating and writing a per-resolve descriptor. Scaled resolves
+        // write to separate scaled buffers, so they use transient descriptors.
+        // Decided per resolve, as native copies write to shared memory even
+        // with resolution scaling on.
+        const bool use_persistent_dest =
+            texture_cache.shared_memory_persistent_descriptor_set() !=
+                VK_NULL_HANDLE &&
+            !copy_dest_scaled;
         VkDescriptorSet descriptor_set_dest =
-            command_processor_.AllocateSingleTransientDescriptor(
-                VulkanCommandProcessor::SingleTransientDescriptorLayout ::
-                    kStorageBufferCompute);
+            use_persistent_dest
+                ? texture_cache.shared_memory_persistent_descriptor_set()
+                : command_processor_.AllocateSingleTransientDescriptor(
+                      VulkanCommandProcessor::SingleTransientDescriptorLayout ::
+                          kStorageBufferCompute);
         if (descriptor_set_dest != VK_NULL_HANDLE) {
           // Write the destination descriptor.
           VkDescriptorBufferInfo write_descriptor_set_dest_buffer_info;
@@ -1256,7 +1266,7 @@ bool VulkanRenderTargetCache::Resolve(
             }
           }
 
-          if (!scaled_buffer_ready) {
+          if (!scaled_buffer_ready && !use_persistent_dest) {
             // Write unscaled or native resolves to shared memory.
             if (copy_dest_scaled) {
               XELOGW(
@@ -1273,22 +1283,24 @@ bool VulkanRenderTargetCache::Resolve(
                 resolve_info.copy_dest_base +
                 resolve_info.copy_dest_extent_length;
           }
-          VkWriteDescriptorSet write_descriptor_set_dest;
-          write_descriptor_set_dest.sType =
-              VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-          write_descriptor_set_dest.pNext = nullptr;
-          write_descriptor_set_dest.dstSet = descriptor_set_dest;
-          write_descriptor_set_dest.dstBinding = 0;
-          write_descriptor_set_dest.dstArrayElement = 0;
-          write_descriptor_set_dest.descriptorCount = 1;
-          write_descriptor_set_dest.descriptorType =
-              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-          write_descriptor_set_dest.pImageInfo = nullptr;
-          write_descriptor_set_dest.pBufferInfo =
-              &write_descriptor_set_dest_buffer_info;
-          write_descriptor_set_dest.pTexelBufferView = nullptr;
-          dfn.vkUpdateDescriptorSets(device, 1, &write_descriptor_set_dest, 0,
-                                     nullptr);
+          if (!use_persistent_dest) {
+            VkWriteDescriptorSet write_descriptor_set_dest;
+            write_descriptor_set_dest.sType =
+                VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            write_descriptor_set_dest.pNext = nullptr;
+            write_descriptor_set_dest.dstSet = descriptor_set_dest;
+            write_descriptor_set_dest.dstBinding = 0;
+            write_descriptor_set_dest.dstArrayElement = 0;
+            write_descriptor_set_dest.descriptorCount = 1;
+            write_descriptor_set_dest.descriptorType =
+                VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            write_descriptor_set_dest.pImageInfo = nullptr;
+            write_descriptor_set_dest.pBufferInfo =
+                &write_descriptor_set_dest_buffer_info;
+            write_descriptor_set_dest.pTexelBufferView = nullptr;
+            dfn.vkUpdateDescriptorSets(device, 1, &write_descriptor_set_dest, 0,
+                                       nullptr);
+          }
 
           // Submit the resolve.
           if (!scaled_buffer_ready) {
@@ -1345,11 +1357,15 @@ bool VulkanRenderTargetCache::Resolve(
                 sizeof(copy_shader_constants.dest_relative),
                 &copy_shader_constants.dest_relative);
           } else {
-            // TODO(Triang3l): Proper dest_base in case of one 512 MB shared
-            // memory binding, or multiple shared memory bindings in case of
+            // TODO(Triang3l): Multiple shared memory bindings in case of
             // splitting due to maxStorageBufferRange overflow.
-            copy_shader_constants.dest_base -=
-                uint32_t(write_descriptor_set_dest_buffer_info.offset);
+            if (!use_persistent_dest) {
+              // The descriptor is offset to the destination, so make dest_base
+              // relative to it. With the whole buffer bound persistently,
+              // dest_base stays the absolute byte offset.
+              copy_shader_constants.dest_base -=
+                  uint32_t(write_descriptor_set_dest_buffer_info.offset);
+            }
             command_buffer.CmdVkPushConstants(
                 copy_pipeline_layout, VK_SHADER_STAGE_COMPUTE_BIT, 0,
                 sizeof(copy_shader_constants), &copy_shader_constants);

--- a/src/xenia/gpu/vulkan/vulkan_texture_cache.cc
+++ b/src/xenia/gpu/vulkan/vulkan_texture_cache.cc
@@ -475,6 +475,10 @@ VulkanTextureCache::~VulkanTextureCache() {
   if (load_pipeline_layout_ != VK_NULL_HANDLE) {
     dfn.vkDestroyPipelineLayout(device, load_pipeline_layout_, nullptr);
   }
+  if (shared_memory_persistent_descriptor_pool_ != VK_NULL_HANDLE) {
+    dfn.vkDestroyDescriptorPool(
+        device, shared_memory_persistent_descriptor_pool_, nullptr);
+  }
 
   // Textures memory is allocated using the Vulkan Memory Allocator, destroy all
   // textures before destroying VMA.
@@ -1345,6 +1349,13 @@ bool VulkanTextureCache::LoadTextureDataFromResidentMemoryImpl(Texture& texture,
   const VkDevice device = vulkan_device->device();
   VulkanSharedMemory& vulkan_shared_memory =
       static_cast<VulkanSharedMemory&>(shared_memory());
+  // Bind the whole shared memory buffer persistently when possible (passing the
+  // texture's byte offset via guest_offset) instead of allocating and writing
+  // per-load source descriptors. Scaled resolve textures read from separate
+  // scaled buffers, so they always use transient descriptors.
+  const bool use_persistent_source =
+      shared_memory_persistent_descriptor_set_ != VK_NULL_HANDLE &&
+      !texture_key.scaled_resolve;
   std::array<VkWriteDescriptorSet, 3> write_descriptor_sets;
   uint32_t write_descriptor_set_count = 0;
   VkDescriptorSet descriptor_set_dest =
@@ -1380,12 +1391,16 @@ bool VulkanTextureCache::LoadTextureDataFromResidentMemoryImpl(Texture& texture,
   VkDescriptorBufferInfo write_descriptor_set_source_base_buffer_info;
   VkDescriptorBufferInfo write_descriptor_set_source_mips_buffer_info;
   if (level_first == 0) {
-    descriptor_set_source_base =
-        command_processor_.AllocateSingleTransientDescriptor(
-            VulkanCommandProcessor::SingleTransientDescriptorLayout ::
-                kStorageBufferCompute);
-    if (!descriptor_set_source_base) {
-      return false;
+    if (use_persistent_source) {
+      descriptor_set_source_base = shared_memory_persistent_descriptor_set_;
+    } else {
+      descriptor_set_source_base =
+          command_processor_.AllocateSingleTransientDescriptor(
+              VulkanCommandProcessor::SingleTransientDescriptorLayout ::
+                  kStorageBufferCompute);
+      if (!descriptor_set_source_base) {
+        return false;
+      }
     }
     if (texture_key.scaled_resolve) {
       // For scaled textures, read from scaled resolve buffers
@@ -1434,7 +1449,7 @@ bool VulkanTextureCache::LoadTextureDataFromResidentMemoryImpl(Texture& texture,
             guest_address);
         return false;
       }
-    } else {
+    } else if (!use_persistent_source) {
       // Regular unscaled texture - use shared memory
       write_descriptor_set_source_base_buffer_info.buffer =
           vulkan_shared_memory.buffer();
@@ -1445,57 +1460,96 @@ bool VulkanTextureCache::LoadTextureDataFromResidentMemoryImpl(Texture& texture,
       write_descriptor_set_source_base_buffer_info.range =
           xe::align(vulkan_texture.GetGuestBaseSize(), uint32_t(16));
     }
-    VkWriteDescriptorSet& write_descriptor_set_source_base =
-        write_descriptor_sets[write_descriptor_set_count++];
-    write_descriptor_set_source_base.sType =
-        VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-    write_descriptor_set_source_base.pNext = nullptr;
-    write_descriptor_set_source_base.dstSet = descriptor_set_source_base;
-    write_descriptor_set_source_base.dstBinding = 0;
-    write_descriptor_set_source_base.dstArrayElement = 0;
-    write_descriptor_set_source_base.descriptorCount = 1;
-    write_descriptor_set_source_base.descriptorType =
-        VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    write_descriptor_set_source_base.pImageInfo = nullptr;
-    write_descriptor_set_source_base.pBufferInfo =
-        &write_descriptor_set_source_base_buffer_info;
-    write_descriptor_set_source_base.pTexelBufferView = nullptr;
-  }
-  // For scaled resolve textures, we don't load mips from buffers - they will
-  // be generated via blit from the base level. For unscaled textures, load
-  // mips from shared memory as usual.
-  if (level_last != 0 && !texture_key.scaled_resolve) {
-    descriptor_set_source_mips =
-        command_processor_.AllocateSingleTransientDescriptor(
-            VulkanCommandProcessor::SingleTransientDescriptorLayout ::
-                kStorageBufferCompute);
-    if (!descriptor_set_source_mips) {
-      return false;
+    if (!use_persistent_source) {
+      VkWriteDescriptorSet& write_descriptor_set_source_base =
+          write_descriptor_sets[write_descriptor_set_count++];
+      write_descriptor_set_source_base.sType =
+          VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+      write_descriptor_set_source_base.pNext = nullptr;
+      write_descriptor_set_source_base.dstSet = descriptor_set_source_base;
+      write_descriptor_set_source_base.dstBinding = 0;
+      write_descriptor_set_source_base.dstArrayElement = 0;
+      write_descriptor_set_source_base.descriptorCount = 1;
+      write_descriptor_set_source_base.descriptorType =
+          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+      write_descriptor_set_source_base.pImageInfo = nullptr;
+      write_descriptor_set_source_base.pBufferInfo =
+          &write_descriptor_set_source_base_buffer_info;
+      write_descriptor_set_source_base.pTexelBufferView = nullptr;
     }
-    // Regular unscaled texture - use shared memory
-    write_descriptor_set_source_mips_buffer_info.buffer =
-        vulkan_shared_memory.buffer();
-    write_descriptor_set_source_mips_buffer_info.offset = texture_key.mip_page
-                                                          << 12;
-    // Align (primarily the last row of a linear packed mip tail) because
-    // shaders use up to 16-byte loads for multiple blocks at once.
-    write_descriptor_set_source_mips_buffer_info.range =
-        xe::align(vulkan_texture.GetGuestMipsSize(), uint32_t(16));
-    VkWriteDescriptorSet& write_descriptor_set_source_mips =
-        write_descriptor_sets[write_descriptor_set_count++];
-    write_descriptor_set_source_mips.sType =
-        VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-    write_descriptor_set_source_mips.pNext = nullptr;
-    write_descriptor_set_source_mips.dstSet = descriptor_set_source_mips;
-    write_descriptor_set_source_mips.dstBinding = 0;
-    write_descriptor_set_source_mips.dstArrayElement = 0;
-    write_descriptor_set_source_mips.descriptorCount = 1;
-    write_descriptor_set_source_mips.descriptorType =
-        VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    write_descriptor_set_source_mips.pImageInfo = nullptr;
-    write_descriptor_set_source_mips.pBufferInfo =
-        &write_descriptor_set_source_mips_buffer_info;
-    write_descriptor_set_source_mips.pTexelBufferView = nullptr;
+  }
+  // Set up the mips source: scaled resolve buffer or shared memory.
+  if (level_last != 0) {
+    if (use_persistent_source) {
+      descriptor_set_source_mips = shared_memory_persistent_descriptor_set_;
+    } else {
+      descriptor_set_source_mips =
+          command_processor_.AllocateSingleTransientDescriptor(
+              VulkanCommandProcessor::SingleTransientDescriptorLayout ::
+                  kStorageBufferCompute);
+      if (!descriptor_set_source_mips) {
+        return false;
+      }
+      if (texture_key.scaled_resolve) {
+        // Scaled resolved mips live in the scaled buffer, like the base.
+        uint32_t guest_address = texture_key.mip_page << 12;
+        uint32_t guest_size = vulkan_texture.GetGuestMipsSize();
+        if (EnsureScaledResolveMemoryCommitted(guest_address, guest_size) &&
+            MakeScaledResolveRangeCurrent(guest_address, guest_size)) {
+          VkBuffer scaled_buffer = GetCurrentScaledResolveBuffer();
+          if (scaled_buffer != VK_NULL_HANDLE) {
+            uint32_t draw_resolution_scale_area =
+                draw_resolution_scale_x() * draw_resolution_scale_y();
+            uint64_t scaled_offset =
+                uint64_t(guest_address) * draw_resolution_scale_area;
+            uint64_t buffer_relative_offset =
+                scaled_offset - GetCurrentScaledResolveBufferBaseOffset();
+            write_descriptor_set_source_mips_buffer_info.buffer = scaled_buffer;
+            write_descriptor_set_source_mips_buffer_info.offset =
+                buffer_relative_offset;
+            write_descriptor_set_source_mips_buffer_info.range = xe::align(
+                guest_size * draw_resolution_scale_area, uint32_t(16));
+          } else {
+            XELOGE(
+                "Scaled resolve texture load: Failed to get current scaled "
+                "buffer for mips at 0x{:08X}",
+                guest_address);
+            return false;
+          }
+        } else {
+          XELOGE(
+              "Scaled resolve texture load: Failed to make range current for "
+              "mips at 0x{:08X}",
+              guest_address);
+          return false;
+        }
+      } else {
+        // Regular unscaled texture - use shared memory
+        write_descriptor_set_source_mips_buffer_info.buffer =
+            vulkan_shared_memory.buffer();
+        write_descriptor_set_source_mips_buffer_info.offset =
+            texture_key.mip_page << 12;
+        // Align (primarily the last row of a linear packed mip tail) because
+        // shaders use up to 16-byte loads for multiple blocks at once.
+        write_descriptor_set_source_mips_buffer_info.range =
+            xe::align(vulkan_texture.GetGuestMipsSize(), uint32_t(16));
+      }
+      VkWriteDescriptorSet& write_descriptor_set_source_mips =
+          write_descriptor_sets[write_descriptor_set_count++];
+      write_descriptor_set_source_mips.sType =
+          VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+      write_descriptor_set_source_mips.pNext = nullptr;
+      write_descriptor_set_source_mips.dstSet = descriptor_set_source_mips;
+      write_descriptor_set_source_mips.dstBinding = 0;
+      write_descriptor_set_source_mips.dstArrayElement = 0;
+      write_descriptor_set_source_mips.descriptorCount = 1;
+      write_descriptor_set_source_mips.descriptorType =
+          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+      write_descriptor_set_source_mips.pImageInfo = nullptr;
+      write_descriptor_set_source_mips.pBufferInfo =
+          &write_descriptor_set_source_mips_buffer_info;
+      write_descriptor_set_source_mips.pTexelBufferView = nullptr;
+    }
   }
   if (write_descriptor_set_count) {
     dfn.vkUpdateDescriptorSets(device, write_descriptor_set_count,
@@ -1541,8 +1595,13 @@ bool VulkanTextureCache::LoadTextureDataFromResidentMemoryImpl(Texture& texture,
           kLoadDescriptorSetIndexSource, 1, &descriptor_set_source, 0, nullptr);
     }
 
-    // TODO(Triang3l): guest_offset relative to the storage buffer origin.
-    load_constants.guest_offset = 0;
+    // With the whole buffer bound persistently, guest_offset is relative to the
+    // buffer origin. With a per-load source descriptor, it's already offset to
+    // the texture's base or mip page, so it stays relative to that.
+    load_constants.guest_offset =
+        use_persistent_source
+            ? ((is_base ? texture_key.base_page : texture_key.mip_page) << 12)
+            : 0;
     if (!is_base) {
       load_constants.guest_offset +=
           guest_layout.mip_offsets_bytes[level] *
@@ -2519,6 +2578,71 @@ bool VulkanTextureCache::Initialize() {
                                  nullptr, &load_pipeline_layout_)) {
     XELOGE("VulkanTexture: Failed to create the texture load pipeline layout");
     return false;
+  }
+
+  // If the whole shared memory buffer fits within maxStorageBufferRange, create
+  // a persistent descriptor set binding it for texture load sources, so
+  // per-load transient source descriptors don't need to be allocated and
+  // written. The texture's byte offset is passed via guest_offset instead, as
+  // on Direct3D 12. When the buffer doesn't fit, the per-load sub-range
+  // descriptors are used.
+  if (device_properties.maxStorageBufferRange >= SharedMemory::kBufferSize) {
+    VkDescriptorPoolSize shared_memory_persistent_pool_size;
+    shared_memory_persistent_pool_size.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    shared_memory_persistent_pool_size.descriptorCount = 1;
+    VkDescriptorPoolCreateInfo shared_memory_persistent_pool_create_info;
+    shared_memory_persistent_pool_create_info.sType =
+        VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+    shared_memory_persistent_pool_create_info.pNext = nullptr;
+    shared_memory_persistent_pool_create_info.flags = 0;
+    shared_memory_persistent_pool_create_info.maxSets = 1;
+    shared_memory_persistent_pool_create_info.poolSizeCount = 1;
+    shared_memory_persistent_pool_create_info.pPoolSizes =
+        &shared_memory_persistent_pool_size;
+    if (dfn.vkCreateDescriptorPool(
+            device, &shared_memory_persistent_pool_create_info, nullptr,
+            &shared_memory_persistent_descriptor_pool_) == VK_SUCCESS) {
+      VkDescriptorSetAllocateInfo shared_memory_persistent_set_allocate_info;
+      shared_memory_persistent_set_allocate_info.sType =
+          VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+      shared_memory_persistent_set_allocate_info.pNext = nullptr;
+      shared_memory_persistent_set_allocate_info.descriptorPool =
+          shared_memory_persistent_descriptor_pool_;
+      shared_memory_persistent_set_allocate_info.descriptorSetCount = 1;
+      shared_memory_persistent_set_allocate_info.pSetLayouts =
+          &load_descriptor_set_layout_storage_buffer;
+      if (dfn.vkAllocateDescriptorSets(
+              device, &shared_memory_persistent_set_allocate_info,
+              &shared_memory_persistent_descriptor_set_) == VK_SUCCESS) {
+        VkDescriptorBufferInfo shared_memory_persistent_buffer_info;
+        shared_memory_persistent_buffer_info.buffer =
+            static_cast<VulkanSharedMemory&>(shared_memory()).buffer();
+        shared_memory_persistent_buffer_info.offset = 0;
+        shared_memory_persistent_buffer_info.range = SharedMemory::kBufferSize;
+        VkWriteDescriptorSet shared_memory_persistent_write;
+        shared_memory_persistent_write.sType =
+            VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        shared_memory_persistent_write.pNext = nullptr;
+        shared_memory_persistent_write.dstSet =
+            shared_memory_persistent_descriptor_set_;
+        shared_memory_persistent_write.dstBinding = 0;
+        shared_memory_persistent_write.dstArrayElement = 0;
+        shared_memory_persistent_write.descriptorCount = 1;
+        shared_memory_persistent_write.descriptorType =
+            VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        shared_memory_persistent_write.pImageInfo = nullptr;
+        shared_memory_persistent_write.pBufferInfo =
+            &shared_memory_persistent_buffer_info;
+        shared_memory_persistent_write.pTexelBufferView = nullptr;
+        dfn.vkUpdateDescriptorSets(device, 1, &shared_memory_persistent_write,
+                                   0, nullptr);
+      } else {
+        dfn.vkDestroyDescriptorPool(
+            device, shared_memory_persistent_descriptor_pool_, nullptr);
+        shared_memory_persistent_descriptor_pool_ = VK_NULL_HANDLE;
+        shared_memory_persistent_descriptor_set_ = VK_NULL_HANDLE;
+      }
+    }
   }
 
   // Load pipelines, only the ones needed for the formats that will be used.

--- a/src/xenia/gpu/vulkan/vulkan_texture_cache.cc
+++ b/src/xenia/gpu/vulkan/vulkan_texture_cache.cc
@@ -1233,10 +1233,9 @@ bool VulkanTextureCache::LoadTextureDataFromResidentMemoryImpl(Texture& texture,
   uint32_t bytes_per_block = guest_format_info->bytes_per_block();
   uint32_t level_first = load_base ? 0 : 1;
   uint32_t level_last = load_mips ? texture_key.mip_max_level : 0;
-  // For scaled resolve textures, we only load level 0 from the scaled buffer -
-  // mips will be generated via blit.
+  // Load the guest's resolved mips from the scaled buffer, else generate them.
   uint32_t level_last_for_blit_gen = 0;
-  if (texture_key.scaled_resolve && level_last > 0) {
+  if (level_last > 0 && ScaledResolveMipsNeedGeneration(texture)) {
     level_last_for_blit_gen = level_last;
     level_last = 0;  // Only load base level from buffer
   }
@@ -1755,10 +1754,17 @@ bool VulkanTextureCache::LoadTextureDataFromResidentMemoryImpl(Texture& texture,
     copy_region.imageOffset.x = 0;
     copy_region.imageOffset.y = 0;
     copy_region.imageOffset.z = 0;
-    copy_region.imageExtent.width =
-        std::max((width * texture_resolution_scale_x) >> level, UINT32_C(1));
-    copy_region.imageExtent.height =
-        std::max((height * texture_resolution_scale_y) >> level, UINT32_C(1));
+    // The image mip is scale-then-reduce (max((dim*scale)>>level,1)) while the
+    // buffer footprint (bufferRowLength/bufferImageHeight) is
+    // reduce-then-scale, so for the deepest mips of scaled textures the mip can
+    // be a row or column larger than the buffer holds. Clamp the copy extent to
+    // the footprint so the GPU never reads past the buffer.
+    copy_region.imageExtent.width = std::min(
+        std::max((width * texture_resolution_scale_x) >> level, UINT32_C(1)),
+        copy_region.bufferRowLength);
+    copy_region.imageExtent.height = std::min(
+        std::max((height * texture_resolution_scale_y) >> level, UINT32_C(1)),
+        copy_region.bufferImageHeight);
     copy_region.imageExtent.depth = std::max(depth >> level, UINT32_C(1));
   }
 
@@ -2054,6 +2060,12 @@ VkImageView VulkanTextureCache::VulkanTexture::GetOrCreate3DAs2DImageView(
     image_create_info.format = format;
     image_create_info.extent.width = key().GetWidth();
     image_create_info.extent.height = key().GetHeight();
+    if (key().scaled_resolve) {
+      image_create_info.extent.width *=
+          vulkan_texture_cache.draw_resolution_scale_x();
+      image_create_info.extent.height *=
+          vulkan_texture_cache.draw_resolution_scale_y();
+    }
     image_create_info.extent.depth = 1;
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;

--- a/src/xenia/gpu/vulkan/vulkan_texture_cache.h
+++ b/src/xenia/gpu/vulkan/vulkan_texture_cache.h
@@ -97,6 +97,14 @@ class VulkanTextureCache final : public TextureCache {
                                               xenos::FetchOpDimension dimension,
                                               bool is_signed);
 
+  // Descriptor set (kStorageBufferCompute layout) binding the whole shared
+  // memory buffer for compute load/store, or VK_NULL_HANDLE if the buffer
+  // doesn't fit in maxStorageBufferRange. When valid, the byte offset into the
+  // buffer must be supplied via push constants. Shared with resolve.
+  VkDescriptorSet shared_memory_persistent_descriptor_set() const {
+    return shared_memory_persistent_descriptor_set_;
+  }
+
   SamplerParameters GetSamplerParameters(
       const VulkanShader::SamplerBinding& binding) const;
 
@@ -440,6 +448,16 @@ class VulkanTextureCache final : public TextureCache {
   VkPipelineLayout load_pipeline_layout_ = VK_NULL_HANDLE;
   std::array<VkPipeline, kLoadShaderCount> load_pipelines_{};
   std::array<VkPipeline, kLoadShaderCount> load_pipelines_scaled_{};
+
+  // Persistent descriptor binding the whole shared memory buffer
+  // (kStorageBufferCompute layout) for compute load/store, so per-operation
+  // transient descriptors don't need to be allocated and written. Only created
+  // when the buffer fits in maxStorageBufferRange. The byte offset into the
+  // buffer is passed via push constants instead. Used as the source of texture
+  // loads here, and shared as the destination of resolves in the render target
+  // cache.
+  VkDescriptorPool shared_memory_persistent_descriptor_pool_ = VK_NULL_HANDLE;
+  VkDescriptorSet shared_memory_persistent_descriptor_set_ = VK_NULL_HANDLE;
 
   // If both images can be placed in the same allocation, it's one allocation,
   // otherwise it's two separate.

--- a/src/xenia/gpu/xenos.h
+++ b/src/xenia/gpu/xenos.h
@@ -1185,6 +1185,9 @@ constexpr uint32_t kTextureSubresourceAlignmentBytes =
 // Texture fetch constant size field widths.
 constexpr uint32_t kTexture1DMaxWidthLog2 = 24;
 constexpr uint32_t kTexture1DMaxWidth = 1 << kTexture1DMaxWidthLog2;
+// Limit the number of rows materialized when wide 1D textures are mapped to
+// 2D. Some games use very large widths with much less data behind them.
+constexpr uint32_t kTexture1DWideMaxRows = 32;
 constexpr uint32_t kTexture2DCubeMaxWidthHeightLog2 = 13;
 constexpr uint32_t kTexture2DCubeMaxWidthHeight =
     1 << kTexture2DCubeMaxWidthHeightLog2;

--- a/src/xenia/memory.cc
+++ b/src/xenia/memory.cc
@@ -113,20 +113,6 @@ static inline bool ShouldSkipHostCommit(const BaseHeap& heap) {
   return false;
 }
 
-xe::memory::PageAccess ToPageAccess(uint32_t protect) {
-  // Write-combine memory is CPU-writable (for GPU uploads)
-  bool is_writable =
-      (protect & kMemoryProtectWrite) || (protect & kMemoryProtectWriteCombine);
-
-  if ((protect & kMemoryProtectRead) && !is_writable) {
-    return xe::memory::PageAccess::kReadOnly;
-  } else if ((protect & kMemoryProtectRead) && is_writable) {
-    return xe::memory::PageAccess::kReadWrite;
-  } else {
-    return xe::memory::PageAccess::kNoAccess;
-  }
-}
-
 void RandomizeMemory(void* range_start, uint32_t size) {
   if (!cvars::scribble_heap) {
     return;
@@ -667,6 +653,30 @@ void Memory::UnregisterPhysicalMemoryInvalidationCallback(
     assert_true(it != physical_memory_invalidation_callbacks_.end());
     if (it != physical_memory_invalidation_callbacks_.end()) {
       physical_memory_invalidation_callbacks_.erase(it);
+    }
+  }
+  delete entry;
+}
+
+void* Memory::RegisterPhysicalMemoryReadCallback(
+    PhysicalMemoryReadCallback callback, void* callback_context) {
+  auto entry = new std::pair<PhysicalMemoryReadCallback, void*>(
+      callback, callback_context);
+  auto lock = global_critical_region_.Acquire();
+  physical_memory_read_callbacks_.push_back(entry);
+  return entry;
+}
+
+void Memory::UnregisterPhysicalMemoryReadCallback(void* callback_handle) {
+  auto entry = reinterpret_cast<std::pair<PhysicalMemoryReadCallback, void*>*>(
+      callback_handle);
+  {
+    auto lock = global_critical_region_.Acquire();
+    auto it = std::find(physical_memory_read_callbacks_.begin(),
+                        physical_memory_read_callbacks_.end(), entry);
+    assert_true(it != physical_memory_read_callbacks_.end());
+    if (it != physical_memory_read_callbacks_.end()) {
+      physical_memory_read_callbacks_.erase(it);
     }
   }
   delete entry;
@@ -1940,7 +1950,8 @@ bool PhysicalHeap::Decommit(uint32_t address, uint32_t size) {
   }
 
   // Not caring about the contents anymore.
-  TriggerCallbacks(std::move(global_lock), address, size, true, true);
+  TriggerCallbacks(std::move(global_lock), address, size, true, true, true,
+                   true);
 
   return BaseHeap::Decommit(address, size);
 }
@@ -1965,7 +1976,7 @@ bool PhysicalHeap::Release(uint32_t base_address, uint32_t* out_region_size) {
   uint32_t region_size;
   if (QuerySize(base_address, &region_size)) {
     TriggerCallbacks(std::move(global_lock), base_address, region_size, true,
-                     true);
+                     true, true, true);
   }
 
   return BaseHeap::Release(base_address, out_region_size);
@@ -1976,9 +1987,14 @@ bool PhysicalHeap::Protect(uint32_t address, uint32_t size, uint32_t protect,
   auto global_lock = global_critical_region_.Acquire();
 
   // Only invalidate if making writable again, for simplicity - not when simply
-  // marking some range as immutable, for instance.
-  if (protect & kMemoryProtectWrite) {
-    TriggerCallbacks(std::move(global_lock), address, size, true, true, false);
+  // marking some range as immutable, for instance. The guest is announcing a
+  // write rather than reacting to a fault, so invalidate even with no watch
+  // armed: a range that was read-only when it was last uploaded never got one,
+  // and would otherwise stay stale for as long as the guest keeps it read-only
+  // outside of its own writes.
+  if (IsWritableProtect(protect)) {
+    TriggerCallbacks(std::move(global_lock), address, size, true, true, false,
+                     true);
   }
 
   if (!parent_heap_->Protect(GetPhysicalAddress(address), size, protect,
@@ -1994,8 +2010,6 @@ void PhysicalHeap::EnableAccessCallbacks(uint32_t physical_address,
                                          uint32_t length,
                                          bool enable_invalidation_notifications,
                                          bool enable_data_providers) {
-  // TODO(Triang3l): Implement data providers.
-  assert_false(enable_data_providers);
   if (!enable_invalidation_notifications && !enable_data_providers) {
     return;
   }
@@ -2033,15 +2047,20 @@ void PhysicalHeap::EnableAccessCallbacks(uint32_t physical_address,
 
   auto global_lock = global_critical_region_.Acquire();
   if (enable_invalidation_notifications) {
-    EnableAccessCallbacksInner<true>(system_page_first, system_page_last,
-                                     protect_access);
+    if (enable_data_providers) {
+      EnableAccessCallbacksInner<true, true>(system_page_first,
+                                             system_page_last, protect_access);
+    } else {
+      EnableAccessCallbacksInner<true, false>(system_page_first,
+                                              system_page_last, protect_access);
+    }
   } else {
-    EnableAccessCallbacksInner<false>(system_page_first, system_page_last,
-                                      protect_access);
+    EnableAccessCallbacksInner<false, true>(system_page_first, system_page_last,
+                                            protect_access);
   }
 }
 
-template <bool enable_invalidation_notifications>
+template <bool enable_invalidation_notifications, bool enable_data_providers>
 XE_NOINLINE void PhysicalHeap::EnableAccessCallbacksInner(
     const uint32_t system_page_first, const uint32_t system_page_last,
     xe::memory::PageAccess protect_access) XE_RESTRICT {
@@ -2049,19 +2068,11 @@ XE_NOINLINE void PhysicalHeap::EnableAccessCallbacksInner(
   uint32_t protect_system_page_first = UINT32_MAX;
 
   SystemPageFlagsBlock* XE_RESTRICT sys_page_flags = system_page_flags_.data();
-  PageEntry* XE_RESTRICT page_table_ptr = page_table_.data();
 
   // chrispy: a lot of time is spent in this loop, and i think some of the work
   // may be avoidable and repetitive profiling shows quite a bit of time spent
   // in this loop, but very little spent actually calling Protect
   uint32_t i = system_page_first;
-
-  uint32_t first_guest_page = SystemPagenumToGuestPagenum(system_page_first);
-  uint32_t last_guest_page = SystemPagenumToGuestPagenum(system_page_last);
-
-  uint32_t guest_one = SystemPagenumToGuestPagenum(1);
-
-  uint32_t system_one = GuestPagenumToSystemPagenum(1);
   for (; i <= system_page_last; ++i) {
     // Check if need to enable callbacks for the page and raise its protection.
     //
@@ -2093,24 +2104,30 @@ XE_NOINLINE void PhysicalHeap::EnableAccessCallbacksInner(
     uint64_t page_flags_bit = uint64_t(1) << (i & 63);
 #endif
 
-    uint32_t guest_page_number = SystemPagenumToGuestPagenum(i);
-    xe::memory::PageAccess current_page_access =
-        ToPageAccess(page_table_ptr[guest_page_number].current_protect);
+    xe::memory::PageAccess current_page_access = SystemPageGuestAccess(i);
     bool protect_system_page = false;
     // Don't do anything with inaccessible pages - don't protect, don't enable
     // callbacks - because real access violations are needed there. And don't
     // enable invalidation notifications for read-only pages for the same
     // reason.
     if (current_page_access != xe::memory::PageAccess::kNoAccess) {
-      // TODO(Triang3l): Enable data providers.
       if constexpr (enable_invalidation_notifications) {
         if (current_page_access != xe::memory::PageAccess::kReadOnly &&
             (page_flags_block.notify_on_invalidation & page_flags_bit) == 0) {
-          // TODO(Triang3l): Check if data providers are already enabled.
-          // If data providers are already enabled for the page, it has even
-          // stricter protection.
-          protect_system_page = true;
           page_flags_block.notify_on_invalidation |= page_flags_bit;
+          // A read-watched page is already protected no-access, stricter than
+          // read-only, so don't loosen it here.
+          if ((page_flags_block.notify_on_read & page_flags_bit) == 0) {
+            protect_system_page = true;
+          }
+        }
+      }
+      if constexpr (enable_data_providers) {
+        // Read watches protect the page no-access, so an accessible page not
+        // yet read-watched needs protecting.
+        if ((page_flags_block.notify_on_read & page_flags_bit) == 0) {
+          protect_system_page = true;
+          page_flags_block.notify_on_read |= page_flags_bit;
         }
       }
     }
@@ -2139,13 +2156,8 @@ XE_NOINLINE void PhysicalHeap::EnableAccessCallbacksInner(
 }
 bool PhysicalHeap::TriggerCallbacks(
     global_unique_lock_type global_lock_locked_once, uint32_t virtual_address,
-    uint32_t length, bool is_write, bool unwatch_exact_range, bool unprotect) {
-  // TODO(Triang3l): Support read watches.
-  assert_true(is_write);
-  if (!is_write) {
-    return false;
-  }
-
+    uint32_t length, bool is_write, bool unwatch_exact_range, bool unprotect,
+    bool invalidate_unwatched) {
   if (virtual_address < heap_base_) {
     if (heap_base_ - virtual_address >= length) {
       return false;
@@ -2172,10 +2184,90 @@ bool PhysicalHeap::TriggerCallbacks(
   uint32_t block_index_first = system_page_first >> 6;
   uint32_t block_index_last = system_page_last >> 6;
 
+  // Read watches: the first read of a no-access-armed page notifies the read
+  // callbacks, then the page is downgraded and unwatched so the access
+  // proceeds. A write to such a page is handled by the write path below, which
+  // also clears the read watch.
+  if (!is_write) {
+    bool any_read_watched = false;
+    for (uint32_t i = block_index_first; i <= block_index_last; ++i) {
+      uint64_t block = system_page_flags_[i].notify_on_read;
+      if (i == block_index_first) {
+        block &= ~((uint64_t(1) << (system_page_first & 63)) - 1);
+      }
+      if (i == block_index_last && (system_page_last & 63) != 63) {
+        block &= (uint64_t(1) << ((system_page_last & 63) + 1)) - 1;
+      }
+      if (block) {
+        any_read_watched = true;
+        break;
+      }
+    }
+    if (!any_read_watched) {
+      // No read watch here. If the guest mapping is accessible this is a race
+      // with another thread that cleared the watch, so retry. If it is
+      // no-access it is a genuine access violation, so propagate. Checked via
+      // the page table to stay signal safe.
+      return SystemPageGuestAccess(system_page_first) !=
+             xe::memory::PageAccess::kNoAccess;
+    }
+    uint32_t physical_address_offset = GetPhysicalAddress(heap_base_);
+    uint32_t physical_address_start =
+        xe::sat_sub(system_page_first << system_page_shift_,
+                    host_address_offset()) +
+        physical_address_offset;
+    uint32_t physical_length = std::min(
+        xe::sat_sub(
+            (system_page_last << system_page_shift_) + system_page_size_,
+            host_address_offset()) +
+            physical_address_offset - physical_address_start,
+        heap_size_ - (physical_address_start - physical_address_offset));
+    for (auto read_callback : memory_->physical_memory_read_callbacks_) {
+      read_callback->first(read_callback->second, physical_address_start,
+                           physical_length);
+    }
+    // Downgrade each read-watched page so the access proceeds. Keep it
+    // read-only if it also has a write watch, otherwise restore the guest
+    // protection. Then clear the read watch.
+    if (unprotect) {
+      uint8_t* protect_base = membase_ + heap_base_;
+      for (uint32_t i = system_page_first; i <= system_page_last; ++i) {
+        uint64_t bit = uint64_t(1) << (i & 63);
+        SystemPageFlagsBlock& flags = system_page_flags_[i >> 6];
+        if (!(flags.notify_on_read & bit)) {
+          continue;
+        }
+        xe::memory::PageAccess guest_access = SystemPageGuestAccess(i);
+        xe::memory::PageAccess target;
+        if (guest_access == xe::memory::PageAccess::kNoAccess) {
+          target = xe::memory::PageAccess::kNoAccess;
+        } else if (flags.notify_on_invalidation & bit) {
+          target = xe::memory::PageAccess::kReadOnly;
+        } else {
+          target = guest_access;
+        }
+        xe::memory::Protect(protect_base + (i << system_page_shift_),
+                            system_page_size_, target);
+      }
+    }
+    for (uint32_t i = block_index_first; i <= block_index_last; ++i) {
+      uint64_t mask = 0;
+      if (i == block_index_first) {
+        mask |= (uint64_t(1) << (system_page_first & 63)) - 1;
+      }
+      if (i == block_index_last && (system_page_last & 63) != 63) {
+        mask |= ~((uint64_t(1) << ((system_page_last & 63) + 1)) - 1);
+      }
+      system_page_flags_[i].notify_on_read &= mask;
+    }
+    return true;
+  }
+
   // Check if watching any page, whether need to call the callback at all.
   bool any_watched = false;
   for (uint32_t i = block_index_first; i <= block_index_last; ++i) {
-    uint64_t block = system_page_flags_[i].notify_on_invalidation;
+    uint64_t block = system_page_flags_[i].notify_on_invalidation |
+                     system_page_flags_[i].notify_on_read;
     if (i == block_index_first) {
       block &= ~((uint64_t(1) << (system_page_first & 63)) - 1);
     }
@@ -2187,14 +2279,17 @@ bool PhysicalHeap::TriggerCallbacks(
       break;
     }
   }
-  if (!any_watched) {
+  if (!any_watched && !invalidate_unwatched) {
     // No watches on this page — another thread already cleared them (race
     // condition between the fault firing and acquiring the lock). Return true
     // so the faulting instruction retries; the page is now unprotected and the
     // access will succeed. This is the signal-safe equivalent of the
     // QueryProtect check in the non-Linux path of
-    // MMIOHandler::ExceptionCallback.
-    return true;
+    // MMIOHandler::ExceptionCallback. If the guest doesn't permit the write
+    // either, retrying it faults forever, so report it unhandled and let the
+    // violation surface.
+    return SystemPageGuestAccess(system_page_first) ==
+           xe::memory::PageAccess::kReadWrite;
   }
 
   // Trigger callbacks.
@@ -2264,15 +2359,14 @@ bool PhysicalHeap::TriggerCallbacks(
     uint8_t* protect_base = membase_ + heap_base_;
     uint32_t unprotect_system_page_first = UINT32_MAX;
     for (uint32_t i = system_page_first; i <= system_page_last; ++i) {
-      // Check if need to allow writing to this page.
-      bool unprotect_page = (system_page_flags_[i >> 6].notify_on_invalidation &
-                             (uint64_t(1) << (i & 63))) != 0;
+      // Check if need to allow writing to this page. Read-watched pages are
+      // unprotected here too so a write to one doesn't re-fault.
+      bool unprotect_page =
+          ((system_page_flags_[i >> 6].notify_on_invalidation |
+            system_page_flags_[i >> 6].notify_on_read) &
+           (uint64_t(1) << (i & 63))) != 0;
       if (unprotect_page) {
-        uint32_t guest_page_number =
-            xe::sat_sub(i << system_page_shift_, host_address_offset()) >>
-            page_size_shift_;
-        if (ToPageAccess(page_table_[guest_page_number].current_protect) !=
-            xe::memory::PageAccess::kReadWrite) {
+        if (SystemPageGuestAccess(i) != xe::memory::PageAccess::kReadWrite) {
           unprotect_page = false;
         }
       }
@@ -2300,7 +2394,8 @@ bool PhysicalHeap::TriggerCallbacks(
     }
   }
 
-  // Mark pages as not write-watched.
+  // Mark pages as not write-watched. Unprotected pages are readable and
+  // writable now, so clear the read watch too.
   for (uint32_t i = block_index_first; i <= block_index_last; ++i) {
     uint64_t mask = 0;
     if (i == block_index_first) {
@@ -2310,6 +2405,7 @@ bool PhysicalHeap::TriggerCallbacks(
       mask |= ~((uint64_t(1) << ((system_page_last & 63) + 1)) - 1);
     }
     system_page_flags_[i].notify_on_invalidation &= mask;
+    system_page_flags_[i].notify_on_read &= mask;
   }
 
   return true;

--- a/src/xenia/memory.h
+++ b/src/xenia/memory.h
@@ -58,6 +58,25 @@ enum MemoryProtectFlag : uint32_t {
   kMemoryProtectNoAccess = 0,
 };
 
+// Write-combine memory is CPU-writable for GPU uploads, so treat it as writable
+// alongside the regular write flag.
+inline bool IsWritableProtect(uint32_t protect) {
+  return (protect & kMemoryProtectWrite) ||
+         (protect & kMemoryProtectWriteCombine);
+}
+
+inline xe::memory::PageAccess ToPageAccess(uint32_t protect) {
+  bool is_writable = IsWritableProtect(protect);
+
+  if ((protect & kMemoryProtectRead) && !is_writable) {
+    return xe::memory::PageAccess::kReadOnly;
+  } else if ((protect & kMemoryProtectRead) && is_writable) {
+    return xe::memory::PageAccess::kReadWrite;
+  } else {
+    return xe::memory::PageAccess::kNoAccess;
+  }
+}
+
 // Equivalent to the Win32 MEMORY_BASIC_INFORMATION struct.
 struct HeapAllocationInfo {
   // A pointer to the base address of the region of pages.
@@ -285,16 +304,20 @@ class PhysicalHeap : public BaseHeap {
   void EnableAccessCallbacks(uint32_t physical_address, uint32_t length,
                              bool enable_invalidation_notifications,
                              bool enable_data_providers);
-  template <bool enable_invalidation_notifications>
+  template <bool enable_invalidation_notifications, bool enable_data_providers>
   XE_NOINLINE void EnableAccessCallbacksInner(
       const uint32_t system_page_first, const uint32_t system_page_last,
       xe::memory::PageAccess protect_access) XE_RESTRICT;
 
-  // Returns true if any page in the range was watched.
+  // Returns true if any page in the range was watched. With
+  // invalidate_unwatched the callbacks are raised even when no watch is armed
+  // for a caller that knows the range is about to change rather than one
+  // reacting to a fault.
   bool TriggerCallbacks(global_unique_lock_type global_lock_locked_once,
                         uint32_t virtual_address, uint32_t length,
                         bool is_write, bool unwatch_exact_range,
-                        bool unprotect = true);
+                        bool unprotect = true,
+                        bool invalidate_unwatched = false);
 
   uint32_t GetPhysicalAddress(uint32_t address) const;
 
@@ -303,11 +326,41 @@ class PhysicalHeap : public BaseHeap {
            page_size_shift_;
   }
 
-  uint32_t GuestPagenumToSystemPagenum(uint32_t num) {
-    num <<= page_size_shift_;
-    num += host_address_offset();
-    num >>= system_page_shift_;
-    return num;
+  // The most permissive guest access of the guest pages a system page covers.
+  // Protection has system page granularity and BaseHeap::Protect resolves a
+  // system page the same way, so anything deciding on protection has to agree
+  // with it - the host page can be larger than the guest page. Inline, called
+  // per page in the arming loop.
+  xe::memory::PageAccess SystemPageGuestAccess(
+      uint32_t system_page_number) const {
+    uint32_t offset = host_address_offset();
+    uint32_t system_base = system_page_number << system_page_shift_;
+    uint32_t system_last = system_base + (system_page_size_ - 1);
+    if (system_last < offset) {
+      return xe::memory::PageAccess::kNoAccess;
+    }
+    uint32_t guest_page_first =
+        system_base > offset ? (system_base - offset) >> page_size_shift_ : 0;
+    uint32_t guest_page_count = uint32_t(page_table_.size());
+    if (guest_page_first >= guest_page_count) {
+      return xe::memory::PageAccess::kNoAccess;
+    }
+    uint32_t guest_page_last = (system_last - offset) >> page_size_shift_;
+    if (guest_page_last >= guest_page_count) {
+      guest_page_last = guest_page_count - 1;
+    }
+    xe::memory::PageAccess access = xe::memory::PageAccess::kNoAccess;
+    for (uint32_t i = guest_page_first; i <= guest_page_last; ++i) {
+      xe::memory::PageAccess page_access =
+          ToPageAccess(page_table_[i].current_protect);
+      if (page_access == xe::memory::PageAccess::kReadWrite) {
+        return xe::memory::PageAccess::kReadWrite;
+      }
+      if (page_access == xe::memory::PageAccess::kReadOnly) {
+        access = xe::memory::PageAccess::kReadOnly;
+      }
+    }
+    return access;
   }
 
  protected:
@@ -321,7 +374,10 @@ class PhysicalHeap : public BaseHeap {
   struct SystemPageFlagsBlock {
     // Whether writing to each page should result trigger invalidation
     // callbacks.
-    uint64_t notify_on_invalidation;
+    uint64_t notify_on_invalidation = 0;
+    // Whether the first access of each page triggers read callbacks. These
+    // pages are protected no-access. The watch is one-shot, cleared on access.
+    uint64_t notify_on_read = 0;
   };
   // Protected by global_critical_region. Flags for each 64 system pages,
   // interleaved as blocks, so bit scan can be used to quickly extract ranges.
@@ -501,6 +557,18 @@ class Memory {
   // RegisterPhysicalMemoryInvalidationCallback.
   void UnregisterPhysicalMemoryInvalidationCallback(void* callback_handle);
 
+  // Called on the first CPU access of a page armed as a read watch (via
+  // EnablePhysicalMemoryAccessCallbacks with data providers). The page is
+  // downgraded and unwatched right after, so it fires once per arm. Must be
+  // lightweight and non-blocking. It runs in the fault handler under the global
+  // critical region.
+  typedef void (*PhysicalMemoryReadCallback)(void* context_ptr,
+                                             uint32_t physical_address_start,
+                                             uint32_t length);
+  void* RegisterPhysicalMemoryReadCallback(PhysicalMemoryReadCallback callback,
+                                           void* callback_context);
+  void UnregisterPhysicalMemoryReadCallback(void* callback_handle);
+
   // Enables physical memory access callbacks for the specified memory range,
   // snapped to system page boundaries.
   void EnablePhysicalMemoryAccessCallbacks(
@@ -510,8 +578,7 @@ class Memory {
   // Forces triggering of watch callbacks for a virtual address range if pages
   // are watched there and unwatching them. Returns whether any page was
   // watched. Must be called with global critical region locking depth of 1.
-  // TODO(Triang3l): Implement data providers - this is why locking depth of 1
-  // will be required in the future.
+  // The invalidation and read callbacks run under that single lock hold.
   bool TriggerPhysicalMemoryCallbacks(
       global_unique_lock_type global_lock_locked_once, uint32_t virtual_address,
       uint32_t length, bool is_write, bool unwatch_exact_range,
@@ -613,6 +680,8 @@ class Memory {
   xe::global_critical_region global_critical_region_;
   std::vector<std::pair<PhysicalMemoryInvalidationCallback, void*>*>
       physical_memory_invalidation_callbacks_;
+  std::vector<std::pair<PhysicalMemoryReadCallback, void*>*>
+      physical_memory_read_callbacks_;
 };
 
 }  // namespace xe


### PR DESCRIPTION
Again, the intent here isn't to make Canary a carbon copy of Edge, just to pull over the generally useful fixes.

The two biggest ports here are the Vulkan tessellation fixes and changes to memory invalidation (clear_memory_page_state is mostly obsolete now). The rest is Vulkan parity work and smaller correctness fixes that seem safe and useful.

The out-of-bounds clamping and float16 changes have DXBC counterparts from me.

This also brings over the read watches work. For now, it's a no-op, but if we'd like to port Edge's host buffer resolve and memexport rewrite, it's a must.

Was AI used for this PR: No.