### PR TITLE
[GPU] Fix scalar ALU swizzles with three-source vector ops

### DIFF
--- a/src/xenia/gpu/shader_interpreter.cc
+++ b/src/xenia/gpu/shader_interpreter.cc
@@ -620,7 +620,8 @@ void ShaderInterpreter::ExecuteAluInstruction(ucode::AluInstruction instr) {
   bool scalar_src_absolute = false;
   switch (scalar_opcode_info.operand_count) {
     case 1: {
-      // r#/c#.w or r#/c#.wx.
+      // r#/c#.w, or r#/c#.wx unless the paired vector opcode has three
+      // operands, in which case r#/c#.wz.
       const float* scalar_src_ptr;
       uint32_t scalar_src_register = instr.src_reg(3);
       std::array<float, 4> scalar_src_float_constant;
@@ -640,9 +641,11 @@ void ShaderInterpreter::ExecuteAluInstruction(ucode::AluInstruction instr) {
       scalar_operand_component_count =
           scalar_opcode_info.single_operand_is_two_component ? 2 : 1;
       for (uint32_t i = 0; i < scalar_operand_component_count; ++i) {
+        uint32_t source_component =
+            i == 0 ? 3 : (vector_opcode_info.GetOperandCount() == 3 ? 2 : 0);
         scalar_operands[i] =
             scalar_src_ptr[ucode::AluInstruction::GetSwizzledComponentIndex(
-                scalar_src_swizzle, (3 + i) & 3)];
+                scalar_src_swizzle, source_component)];
       }
     } break;
     case 2: {

--- a/src/xenia/gpu/shader_translator.cc
+++ b/src/xenia/gpu/shader_translator.cc
@@ -1213,7 +1213,8 @@ uint32_t ParsedTextureFetchInstruction::GetNonZeroResultComponents() const {
 
 static void ParseAluInstructionOperand(const AluInstruction& op, uint32_t i,
                                        uint32_t swizzle_component_count,
-                                       InstructionOperand& out_op) {
+                                       InstructionOperand& out_op,
+                                       uint32_t scalar_second_component = 0) {
   out_op.is_negated = op.src_negate(i);
   uint32_t reg = op.src_reg(i);
   if (op.src_is_temp(i)) {
@@ -1247,9 +1248,10 @@ static void ParseAluInstructionOperand(const AluInstruction& op, uint32_t i,
     // Scalar `a` (W).
     out_op.components[0] = GetSwizzledAluSourceComponent(swizzle, 3);
   } else if (swizzle_component_count == 2) {
-    // Scalar left-hand `a` (W) and right-hand `b` (X).
+    // Scalar left-hand `a` (W) and right-hand `b` (X or Z).
     out_op.components[0] = GetSwizzledAluSourceComponent(swizzle, 3);
-    out_op.components[1] = GetSwizzledAluSourceComponent(swizzle, 0);
+    out_op.components[1] =
+        GetSwizzledAluSourceComponent(swizzle, scalar_second_component);
   } else if (swizzle_component_count == 3) {
     assert_always();
   } else if (swizzle_component_count == 4) {
@@ -1421,9 +1423,13 @@ void ParseAluInstruction(const AluInstruction& op,
   instr.scalar_operand_count = scalar_opcode_info.operand_count;
   if (instr.scalar_operand_count) {
     if (instr.scalar_operand_count == 1) {
+      // The scalar operation shares source 3 with the vector operation. If the
+      // vector operation uses source 3, the scalar `b` component is Z;
+      // otherwise it is X.
       ParseAluInstructionOperand(
           op, 3, scalar_opcode_info.single_operand_is_two_component ? 2 : 1,
-          instr.scalar_operands[0]);
+          instr.scalar_operands[0],
+          vector_opcode_info.GetOperandCount() == 3 ? 2 : 0);
     } else {
       // Constant and temporary register.
 

--- a/src/xenia/gpu/ucode.h
+++ b/src/xenia/gpu/ucode.h
@@ -942,10 +942,13 @@ static_assert_size(FetchInstruction, sizeof(uint32_t) * 3);
 // - All temporary registers are vec4s.
 // - Most scalar ALU operations work with one or two components of the source
 //   register or the float constant passed as the third operand of the whole
-//   co-issued ALU operation, denoted by `a` (the left-hand operand) and `b`
-//   (the right-hand operand).
+//   ALU instruction, denoted by `a` (the left-hand operand) and `b` (the
+//   right-hand operand).
 //   `a` is the [(3 + src3_swizzle[6:7]) & 3] component (W - alpha).
-//   `b` is the [(0 + src3_swizzle[0:1]) & 3] component (X - red).
+//   For single-source two-component scalar operations, `b` is the
+//   [(0 + src3_swizzle[0:1]) & 3] component (X - red), or the
+//   [(2 + src3_swizzle[4:5]) & 3] component (Z - blue) if the vector operation
+//   uses source 3.
 // - mulsc, addsc, subsc scalar ALU operations accept two operands - a float
 //   constant with the `a` (W) swizzle (addressed by the third operand index and
 //   addressing mode) being the left-hand operand, and a temporary register with
@@ -1330,11 +1333,12 @@ enum class AluScalarOpcode : uint32_t {
 struct AluScalarOpcodeInfo {
   const char* name;
   // 0 - no operands.
-  // 1 - one single-component (W) or two-component (WX) r# or c#.
+  // 1 - one single-component (W) or two-component (WX, or WZ if the vector
+  //     operation uses source 3) r# or c#.
   // 2 - c#.w and r#.x.
   uint32_t operand_count;
-  // If operand_count is 1, whether both W and X of the operand are used rather
-  // than only W.
+  // If operand_count is 1, whether two components of the operand are used
+  // rather than only W.
   bool single_operand_is_two_component;
   // Note that all scalar instructions except for retain_prev modify the
   // previous scalar register, so they must be executed even if they don't write


### PR DESCRIPTION
Fixes scalar ALU source swizzle decoding. In Call of Duty 3 (`415607E1`), the bug caused procedural grass to stretch across the screen or map with both D3D12 and Vulkan. The [existing game patch](https://github.com/xenia-canary/game-patches/blob/84d6682caf1b75b2fdb7adcd197c6559c09b2ed4/patches/415607E1%20-%20Call%20Of%20Duty%203%20MP%20(TU3).patch.toml#L6-L14) works around this by disabling grass.

See https://github.com/xenia-canary/game-compatibility/issues/27

## Technical details

Some scalar ALU operations read two values from one source register. The first value uses the W-relative swizzle lane and the second uses the Z-relative lane. Xenia used W-relative for the first value but X-relative for the second. The shader interpreter used the same incorrect `W, X` order.

The affected grass vertex shader has ucode hash `4B4E6FDA02FB39C3`. One clear example is where it builds the X and Y parts of the same normalized vector:

```text
Before:
+ muls r7.x___, r6.xw
+ muls r7._y__, r6.yz

After:
+ muls r7.x___, r6.xw
+ muls r7._y__, r6.yw
```

`r6.w` contains the reciprocal length calculated just before these instructions, so both components need to use it. The same bug decoded `maxs r5._y__, c80.zx` instead of `maxs r5._y__, c80.zz`. Here, `c80.x` is the animated wind phase and `c80.z` is the grass tilt value. Allowing the increasing wind phase to control the tilt caused the worst stretching.

The fix reads the second value from the Z-relative swizzle lane in the common shader parser and uses the same `W, Z` order in the shader interpreter. It does not use a game-specific shader hash or workaround.

## Testing

- Tested Call of Duty 3 multiplayer with grass enabled. The grass is animated and no stretched blades or other visual problems were seen.

Before:
<img width="2080" height="1248" alt="415607E1 - 2026-08-11T13-14-37" src="https://github.com/user-attachments/assets/cfd50547-6eed-4ba2-a019-469bea506c40" />

After:

<img width="2080" height="1248" alt="415607E1 - 2026-08-11T13-18-13" src="https://github.com/user-attachments/assets/8116c73c-bd72-43fe-abea-e791c8b9a8aa" />


Since this fixes shared scalar ALU decoding, it should also resolve graphics issues in other games that use these instructions.



---


Was AI used? Yes of course



**EDIT:** Further testing showed that the first version of this fix was too broad. Reading W/Z for every two-component scalar operation fixed the Call of Duty 3 grass, but caused over-bright character lighting in Call of Duty: World at War.

The correct lane depends on the paired vector operation. The scalar operation reads W/X when the vector operation does not use source 3. It reads W/Z when the vector operation uses source 3, because both operations share that source encoding. The same scalar opcode can therefore use different lanes:

```text
/* Two-source vector operation: scalar reads W/X. */
mul r5.xyz_, r5.xxxx, c37.xzyy
+ muls r7.x___, r6.xw

/* Three-source vector operation: scalar reads W/Z. */
mad r3._y__, r0.yyyy, c34.xxxx, r6.zzwy
+ muls r7._y__, r6.yw

