### PR TITLE
[GPU] Kill the resolve num_format and gamma cvars

### DIFF
--- a/src/xenia/gpu/draw_util.cc
+++ b/src/xenia/gpu/draw_util.cc
@@ -29,26 +29,6 @@ DEFINE_bool(
     "GPU");
 
 DEFINE_bool(
-    resolve_check_number_format, true,
-    "Require the destination number format to match before using fast color "
-    "resolves.\n"
-    "Fast resolves copy the exact EDRAM bits. If a title resolves unsigned "
-    "color data to a signed or integer destination, enabling this forces full "
-    "resolves in the shader so the destination gets repacked instead.",
-    "GPU");
-
-DEFINE_bool(
-    gamma_decode_pwl_resolve, true,
-    "During 8_8_8_8_GAMMA MSAA color resolves, average the samples in linear "
-    "space instead of averaging the encoded PWL gamma values directly.\n"
-    "This is separate from gamma_render_target_as_unorm16. It only applies "
-    "when a full shader resolve reads an 8_8_8_8_GAMMA EDRAM color source. "
-    "Compatible 8_8_8_8 destinations are written back as PWL gamma.\n"
-    "Leave enabled for games that otherwise look overexposed after gamma "
-    "MSAA resolves. Disable only if it causes a title-specific regression.",
-    "GPU");
-
-DEFINE_bool(
     depth_bias_shader_offset, false,
     "Route decal host render target draws with polygon offset through shader "
     "depth. This avoids Z-fighting in games that rely on tiny depth bias "
@@ -1349,8 +1329,7 @@ bool GetResolveInfo(const RegisterFile& regs, const Memory& memory,
     color_edram_info.format = uint32_t(color_info.color_format);
     color_edram_info.format_is_64bpp = is_64bpp;
     color_edram_info.fill_half_pixel_offset = uint32_t(fill_half_pixel_offset);
-    color_edram_info.decode_pwl_gamma =
-        cvars::gamma_decode_pwl_resolve ? 1u : 0u;
+    color_edram_info.decode_pwl_gamma = 1;
     if ((fixed_rg16_truncated_to_minus_1_to_1 &&
          color_info.color_format == xenos::ColorRenderTargetFormat::k_16_16) ||
         (fixed_rgba16_truncated_to_minus_1_to_1 &&
@@ -1433,9 +1412,8 @@ ResolveCopyShaderIndex ResolveInfo::GetCopyShader(
   // full shader conversion. Any title keeping the encoding will re-alias as
   // 8_8_8_8 before resolving, so any gamma source is always being decoded.
   bool gamma_decoded_source =
-      !is_depth && color_edram_info.decode_pwl_gamma &&
-      xenos::ColorRenderTargetFormat(color_edram_info.format) ==
-          xenos::ColorRenderTargetFormat::k_8_8_8_8_GAMMA;
+      !is_depth && xenos::ColorRenderTargetFormat(color_edram_info.format) ==
+                       xenos::ColorRenderTargetFormat::k_8_8_8_8_GAMMA;
   if (is_depth ||
       (!gamma_decoded_source && !copy_dest_info.copy_dest_exp_bias &&
        xenos::IsSingleCopySampleSelected(
@@ -1443,10 +1421,9 @@ ResolveCopyShaderIndex ResolveInfo::GetCopyShader(
        xenos::IsColorResolveFormatBitwiseEquivalent(
            xenos::ColorRenderTargetFormat(color_edram_info.format),
            xenos::ColorFormat(copy_dest_info.copy_dest_format)) &&
-       (!cvars::resolve_check_number_format ||
-        ColorResolveNumberFormatMatches(
-            xenos::ColorFormat(copy_dest_info.copy_dest_format),
-            copy_dest_info.copy_dest_number)))) {
+       ColorResolveNumberFormatMatches(
+           xenos::ColorFormat(copy_dest_info.copy_dest_format),
+           copy_dest_info.copy_dest_number))) {
     if (edram_info.msaa_samples >= xenos::MsaaSamples::k4X) {
       shader = source_is_64bpp ? ResolveCopyShaderIndex::kFast64bpp4xMSAA
                                : ResolveCopyShaderIndex::kFast32bpp4xMSAA;

--- a/src/xenia/gpu/draw_util.h
+++ b/src/xenia/gpu/draw_util.h
@@ -532,10 +532,9 @@ union ResolveEdramInfo {
     // of the resolve region with the contents of the first surely covered
     // column / row with resolution scaling.
     uint32_t fill_half_pixel_offset : 1;
-    // Flag from gamma_decode_pwl_resolve in resolve shader. Some games appear
-    // overexposed unless full 8_8_8_8_GAMMA resolves decode PWL gamma to
-    // linear before MSAA averaging / conversion, then write gamma bytes again
-    // for gamma dests. Off keeps the old byte averaging.
+    // Some games appear overexposed unless full 8_8_8_8_GAMMA resolves decode
+    // PWL gamma to linear before MSAA averaging / conversion, then write gamma
+    // bytes again for gamma dests. Kept as a constant in the resolve shader.
     uint32_t decode_pwl_gamma : 1;
   };
   ResolveEdramInfo() : packed(0) { static_assert_size(*this, sizeof(packed)); }

--- a/src/xenia/gpu/shaders/resolve.xesli
+++ b/src/xenia/gpu/shaders/resolve.xesli
@@ -726,28 +726,6 @@ uint XeResolveEdramPixelStrideBytes(XeResolveInfo resolve_info) {
                  kXenosColorRenderTargetFormat_8_8_8_8_GAMMA;
     }
 
-    bool XeResolveDestStoresPWLGamma(XeResolveInfo resolve_info) {
-      // Resolve constants don't carry a destination gamma bit. Treat an
-      // unsigned 8_8_8_8 destination as PWL gamma storage.
-      bool dest_number_is_unorm =
-          resolve_info.dest_num_format ==
-          kXenosSurfaceNumberFormat_UnsignedRepeatingFraction;
-      bool dest_is_8888 =
-          resolve_info.dest_format == kXenosFormat_8_8_8_8 ||
-          resolve_info.dest_format == kXenosFormat_8_8_8_8_A ||
-          resolve_info.dest_format ==
-              kXenosFormat_8_8_8_8_AS_16_16_16_16;
-      return dest_number_is_unorm && dest_is_8888;
-    }
-
-    void XeResolvePWLGammaToLinearRGB(inout_param_xe(float4_xe, pixel)) {
-      pixel.rgb = XePWLGammaToLinear3(pixel.rgb);
-    }
-
-    void XeResolveLinearToPWLGammaRGB(inout_param_xe(float4_xe, pixel)) {
-      pixel.rgb = XeLinearToPWLGamma3(pixel.rgb);
-    }
-
     void XeResolveDecodePWLGammaSource(
         XeResolveInfo resolve_info, inout_param_xe(float4_xe, pixel)) {
       // Source gamma is RGB only. 8_8_8_8_GAMMA still stores alpha as ordinary
@@ -759,7 +737,7 @@ uint XeResolveEdramPixelStrideBytes(XeResolveInfo resolve_info) {
       // the same model that maintains float 2_10_10_10 bits, which makes it
       // not a gamma source here either.
       dont_flatten_xe if (XeResolveSourceUsesPWLGamma(resolve_info)) {
-        XeResolvePWLGammaToLinearRGB(pixel);
+        pixel.rgb = XePWLGammaToLinear3(pixel.rgb);
       }
     }
 


### PR DESCRIPTION
I'm keeping the gamma resolve as a bit in the resolve shader. Otherwise, I think both of these cvars can be retired.

Update: Cleaned up some dead code in the resolve shader that should've been caught in [PR 1119](https://github.com/xenia-canary/xenia-canary/pull/1119)