### PR TITLE
[GPU] Convert depth-only stencil tests to float24 precision

### DIFF
--- a/src/xenia/gpu/d3d12/pipeline_cache.cc
+++ b/src/xenia/gpu/d3d12/pipeline_cache.cc
@@ -1520,6 +1520,21 @@ bool PipelineCache::GetCurrentStateDescription(
             bound_depth_and_color_render_target_formats[0]);
         depth_stencil_bound_and_used = true;
       }
+      const bool depth_only_stencil_test =
+          !pixel_shader &&
+          regs.Get<reg::RB_MODECONTROL>().edram_mode ==
+              xenos::EdramMode::kDepthOnly &&
+          normalized_depth_control.stencil_enable &&
+          !normalized_depth_control.z_write_enable;
+      // Depth-only stencil passes may use the depth result only to update a
+      // mask. Compare D24FS8 at the guest's float24 precision so host float32
+      // precision doesn't change which stencil samples pass.
+      description_out.depth_float24_convert =
+          !pixel_shader && normalized_depth_control.z_enable &&
+          regs.Get<reg::RB_DEPTH_INFO>().depth_format ==
+              xenos::DepthRenderTargetFormat::kD24FS8 &&
+          (render_target_cache_.depth_float24_convert_in_pixel_shader() ||
+           depth_only_stencil_test);
     } else {
       description_out.depth_func = xenos::CompareFunction::kAlways;
     }
@@ -3010,7 +3025,7 @@ ID3D12PipelineState* PipelineCache::CreateD3D12Pipeline(
     state_desc.PS.pShaderBytecode = depth_only_pixel_shader_.data();
     state_desc.PS.BytecodeLength = depth_only_pixel_shader_.size();
   } else {
-    if (render_target_cache_.depth_float24_convert_in_pixel_shader() &&
+    if (description.depth_float24_convert &&
         (description.depth_func != xenos::CompareFunction::kAlways ||
          description.depth_write) &&
         description.depth_format == xenos::DepthRenderTargetFormat::kD24FS8) {

--- a/src/xenia/gpu/d3d12/pipeline_cache.h
+++ b/src/xenia/gpu/d3d12/pipeline_cache.h
@@ -223,6 +223,8 @@ class PipelineCache {
     uint32_t stencil_read_mask : 8;                   // 27
     // Native draw (scale threshold), keeps slope-scale unscaled.
     uint32_t resolution_scale_native : 1;  // 28
+    // Whether the depth-only pixel shader converts D24FS8 depth to float24.
+    uint32_t depth_float24_convert : 1;  // 29
 
     uint32_t stencil_write_mask : 8;                   // 8
     xenos::StencilOp stencil_front_fail_op : 3;        // 11
@@ -237,7 +239,7 @@ class PipelineCache {
     PipelineRenderTarget render_targets[xenos::kMaxColorRenderTargets];
 
     inline bool operator==(const PipelineDescription& other) const;
-    static constexpr uint32_t kVersion = 0x20260716;
+    static constexpr uint32_t kVersion = 0x20260815;
   });
 
   XEPACKEDSTRUCT(PipelineStoredDescription, {


### PR DESCRIPTION
Resolves an issue where the road inside a rectangle behind the player car is not blurred in Forza Horizon 1 and 2.

https://github.com/xenia-canary/game-compatibility/issues/30
https://github.com/xenia-canary/game-compatibility/issues/111

The game builds part of its motion blur mask with D24FS8 depth-only draws. These draws do not use a pixel shader or write depth. They only use the depth result to update stencil. On D3D12, Xenia compared this depth at the host's float32 precision. A small difference from the Xbox 360 float24 depth changed which samples updated stencil and left an incorrect blur exclusion area behind the car.

This change uses Xenia's existing float24 depth-only pixel shader for the specific case where depth and stencil are enabled, the format is D24FS8, and depth writes are disabled. The new state is included in the D3D12 pipeline key, and the pipeline cache version is updated so old pipelines are rebuilt. The conversion is not enabled for every draw because doing that also affects normal depth rendering and can cause missing shadows or incorrect geometry. This currently changes only the D3D12 path.

Tested in Forza Horizon 2 with the D3D12 RTV path. The rectangle was removed while car shadows and normal depth ordering remained correct.

Before:
<img width="2560" height="1440" alt="4D530AA4 - 2026-08-15T09-21-43" src="https://github.com/user-attachments/assets/8bf06681-d7f7-4016-abbd-3d3120105f3c" />

After:
<img width="2560" height="1440" alt="4D530AA4 - 2026-08-15T09-23-11" src="https://github.com/user-attachments/assets/3b2ed311-8796-4002-9814-0b75e5ef8443" />

