### PR TITLE
[HID] Fix support for Xbox 360 Skylanders Traptanium Portal

### DIFF
--- a/src/xenia/hid/portal/hardware_portal.cc
+++ b/src/xenia/hid/portal/hardware_portal.cc
@@ -8,6 +8,9 @@
  */
 
 #include "xenia/hid/portal/hardware_portal.h"
+
+#include <algorithm>
+
 #include "xenia/base/logging.h"
 
 namespace xe {
@@ -16,6 +19,7 @@ namespace hid {
 HardwarePortal::HardwarePortal() : Portal() {
   libusb_init(&context_);
   OpenDevice();
+  StartReaderThread();
 }
 
 HardwarePortal::~HardwarePortal() {
@@ -28,6 +32,98 @@ HardwarePortal::~HardwarePortal() {
 
 bool HardwarePortal::IsConnected() { return handle_ != nullptr; }
 
+void HardwarePortal::StartReaderThread() {
+  if (!handle_ || reader_thread_.joinable()) {
+    return;
+  }
+
+  stop_reader_.store(false, std::memory_order_release);
+  reader_thread_ = std::thread(&HardwarePortal::ReaderThreadMain, this);
+}
+
+void HardwarePortal::StopReaderThread() {
+  if (!reader_thread_.joinable()) {
+    return;
+  }
+
+  stop_reader_.store(true, std::memory_order_release);
+  reader_thread_.join();
+  stop_reader_.store(false, std::memory_order_release);
+}
+
+void HardwarePortal::ReaderThreadMain() {
+  while (!stop_reader_.load(std::memory_order_acquire)) {
+    libusb_device_handle* handle = handle_;
+    if (!handle) {
+      break;
+    }
+
+    std::array<uint8_t, kPortalBufferSize> buffer{};
+    int32_t packet_length = 0;
+
+    const int result = libusb_interrupt_transfer(
+        handle, read_endpoint, buffer.data(), static_cast<int>(buffer.size()),
+        &packet_length, timeout);
+
+    if (stop_reader_.load(std::memory_order_acquire)) {
+      break;
+    }
+
+    switch (result) {
+      case LIBUSB_ERROR_TIMEOUT:
+        continue;
+      case LIBUSB_ERROR_NO_DEVICE:
+        stop_reader_.store(true, std::memory_order_release);
+        return;
+      case LIBUSB_ERROR_PIPE:
+        libusb_clear_halt(handle, read_endpoint);
+        continue;
+      default:
+        break;
+    }
+
+    if (result < 0) {
+      XELOGW("Portal[Read] returned error: {:08X}", result);
+      continue;
+    }
+
+    if (packet_length > 0 &&
+        packet_length <= static_cast<int32_t>(kPortalBufferSize)) {
+      QueuePacket(std::move(buffer), packet_length);
+    }
+  }
+}
+
+void HardwarePortal::QueuePacket(
+    std::array<uint8_t, kPortalBufferSize>&& packet, int32_t length) {
+  std::lock_guard<std::mutex> guard(read_queue_mutex_);
+
+  // Keep recent input bounded if the guest temporarily stops polling.
+  if (read_queue_.size() >= kMaxQueuedPackets) {
+    read_queue_.pop();
+  }
+
+  read_queue_.push(QueuedPacket{std::move(packet), length});
+}
+
+bool HardwarePortal::DequeuePacket(std::span<uint8_t> data, int32_t& read_count) {
+  std::lock_guard<std::mutex> guard(read_queue_mutex_);
+  if (read_queue_.empty()) {
+    read_count = 0;
+    return false;
+  }
+
+  QueuedPacket packet = std::move(read_queue_.front());
+  read_queue_.pop();
+
+  const size_t copied =
+      std::min(data.size(), static_cast<size_t>(packet.length));
+  std::copy_n(packet.data.begin(), copied, data.begin());
+  read_count = static_cast<int32_t>(copied);
+
+  return true;
+}
+
 void HardwarePortal::OpenDevice() {
   if (!context_ || handle_) {
     return;
@@ -38,7 +134,12 @@ void HardwarePortal::OpenDevice() {
     handle_ =
         libusb_open_device_with_vid_pid(context_, entry.first, entry.second);
     if (handle_) {
-      libusb_claim_interface(handle_, 0);
+      const int claim_result = libusb_claim_interface(handle_, 0);
+      if (claim_result != LIBUSB_SUCCESS) {
+        libusb_close(handle_);
+        handle_ = nullptr;
+        continue;
+      }
       break;
     }
   }
@@ -49,50 +150,64 @@ void HardwarePortal::CloseDevice() {
     return;
   }
 
+  StopReaderThread();
+
   libusb_release_interface(handle_, 0);
   libusb_close(handle_);
   handle_ = nullptr;
+
+  std::lock_guard<std::mutex> guard(read_queue_mutex_);
+  while (!read_queue_.empty()) {
+    read_queue_.pop();
+  }
 }
 
 X_STATUS HardwarePortal::ReadInternal(std::span<uint8_t> data,
                                       int32_t& read_count) {
-  const int result = libusb_interrupt_transfer(
-      handle_, read_endpoint, data.data(), static_cast<int>(data.size()),
-      &read_count, timeout);
-
-  switch (result) {
-    case LIBUSB_ERROR_NO_DEVICE:
-      return X_ERROR_DEVICE_NOT_CONNECTED;
-      break;
-    case LIBUSB_ERROR_TIMEOUT:
-      return X_ERROR_SUCCESS;
-    default:
-      break;
+  if (DequeuePacket(data, read_count)) {
+    return X_ERROR_SUCCESS;
   }
 
-  if (result < 0) {
-    XELOGW("Portal[Read] returned error: {:08X}", result);
-    return X_ERROR_FUNCTION_FAILED;
-  }
+  read_count = 0;
   return X_ERROR_SUCCESS;
 }
 
 X_STATUS HardwarePortal::WriteInternal(std::span<uint8_t> data) {
+  // Physical portal output uses fixed-size USB reports. Zero-pad shorter
+  // guest writes to the report size before submitting the transfer.
+  std::array<uint8_t, kPortalBufferSize> buffer{};
+  const size_t copied = std::min<size_t>(data.size(), buffer.size());
+  std::copy_n(data.begin(), copied, buffer.begin());
+
+  int bytes_transferred = 0;
   const int result = libusb_interrupt_transfer(
-      handle_, write_endpoint, data.data(), static_cast<int>(data.size()),
-      nullptr, timeout);
+      handle_, write_endpoint, buffer.data(), static_cast<int>(buffer.size()),
+      &bytes_transferred, timeout);
 
   if (result < 0) {
     XELOGW("Portal[Write] returned error: {:08X}", result);
     return X_ERROR_DEVICE_NOT_CONNECTED;
   }
 
+  if (bytes_transferred != static_cast<int>(buffer.size())) {
+    XELOGW("Portal[Write] incomplete transfer: {} of {} bytes",
+           bytes_transferred, buffer.size());
+    return X_ERROR_FUNCTION_FAILED;
+  }
+
   return X_ERROR_SUCCESS;
 };
 
-void HardwarePortal::OnDeviceArrival() { OpenDevice(); };
+void HardwarePortal::OnDeviceArrival() {
+  std::lock_guard<xe_mutex> guard(lock_);
+  OpenDevice();
+  StartReaderThread();
+}
 
-void HardwarePortal::OnDeviceRemoval() { CloseDevice(); };
+void HardwarePortal::OnDeviceRemoval() {
+  std::lock_guard<xe_mutex> guard(lock_);
+  CloseDevice();
+}
 
 }  // namespace hid
 }  // namespace xe

--- a/src/xenia/hid/portal/hardware_portal.cc
+++ b/src/xenia/hid/portal/hardware_portal.cc
@@ -32,8 +32,12 @@ HardwarePortal::~HardwarePortal() {
 
 bool HardwarePortal::IsConnected() { return handle_ != nullptr; }
 
+bool HardwarePortal::UsesAsyncReads() const {
+  return hid_mode_.load(std::memory_order_acquire) != PortalHidMode::kLegacy;
+}
+
 void HardwarePortal::StartReaderThread() {
-  if (!handle_ || reader_thread_.joinable()) {
+  if (!handle_ || !UsesAsyncReads() || reader_thread_.joinable()) {
     return;
   }
 
@@ -63,7 +67,7 @@ void HardwarePortal::ReaderThreadMain() {
 
     const int result = libusb_interrupt_transfer(
         handle, read_endpoint, buffer.data(), static_cast<int>(buffer.size()),
-        &packet_length, timeout);
+        &packet_length, kAsyncTransferTimeout);
 
     if (stop_reader_.load(std::memory_order_acquire)) {
       break;
@@ -89,9 +93,76 @@ void HardwarePortal::ReaderThreadMain() {
 
     if (packet_length > 0 &&
         packet_length <= static_cast<int32_t>(kPortalBufferSize)) {
+      const bool use_legacy_hid = IdentifyPortalFromPacket(
+          std::span<const uint8_t>(buffer.data(), packet_length));
       QueuePacket(std::move(buffer), packet_length);
+      if (use_legacy_hid) {
+        // The identifying packet is queued for the guest. All later reads use
+        // the original synchronous HID path for this physical portal.
+        return;
+      }
     }
   }
+}
+
+bool HardwarePortal::IdentifyPortalFromPacket(std::span<const uint8_t> packet) {
+  if (hid_mode_.load(std::memory_order_acquire) != PortalHidMode::kUnknown) {
+    return false;
+  }
+
+  size_t id_offset = 0;
+  if (packet.size() >= 5 && packet[0] == 0x0B && packet[1] == 0x14 &&
+      packet[2] == 0x52) {
+    // Xbox 360 portals wrap the standard 'R' identification response.
+    id_offset = 3;
+  } else if (packet.size() >= 3 && packet[0] == 0x52) {
+    id_offset = 1;
+  } else {
+    return false;
+  }
+
+  const uint8_t id_major = packet[id_offset];
+  const uint8_t id_minor = packet[id_offset + 1];
+  const bool is_traptanium =
+      id_major == 0x02 &&
+      ((id_minor >= 0x18 && id_minor <= 0x1B) || id_minor == 0x27);
+  const PortalHidMode detected_mode =
+      is_traptanium ? PortalHidMode::kTraptaniumAsync : PortalHidMode::kLegacy;
+  hid_mode_.store(detected_mode, std::memory_order_release);
+
+  XELOGI("Portal identified as {} (ID {:02X} {:02X})",
+         is_traptanium ? "Traptanium" : "legacy", id_major, id_minor);
+  return detected_mode == PortalHidMode::kLegacy;
+}
+
+bool HardwarePortal::IsActiveDevicePresent() const {
+  if (!context_ || !handle_) {
+    return false;
+  }
+
+  libusb_device* active_device = libusb_get_device(handle_);
+  if (!active_device) {
+    return false;
+  }
+
+  libusb_device** device_list = nullptr;
+  const ssize_t device_count = libusb_get_device_list(context_, &device_list);
+  if (device_count < 0) {
+    // A failed rescan is not proof that the portal was removed. Keep the
+    // current handle and let the USB transfer path report a real disconnect.
+    return true;
+  }
+
+  bool is_present = false;
+  for (ssize_t i = 0; i < device_count; ++i) {
+    if (device_list[i] == active_device) {
+      is_present = true;
+      break;
+    }
+  }
+
+  libusb_free_device_list(device_list, 1);
+  return is_present;
 }
 
 void HardwarePortal::QueuePacket(
@@ -130,9 +201,9 @@ void HardwarePortal::OpenDevice() {
   }
 
   // Allow only one portal device at the time.
-  for (const auto& entry : kPortalVendorProductIdList) {
-    handle_ =
-        libusb_open_device_with_vid_pid(context_, entry.first, entry.second);
+  for (const auto& entry : kSupportedPortalDevices) {
+    handle_ = libusb_open_device_with_vid_pid(context_, entry.vendor_id,
+                                              entry.product_id);
     if (handle_) {
       const int claim_result = libusb_claim_interface(handle_, 0);
       if (claim_result != LIBUSB_SUCCESS) {
@@ -140,6 +211,7 @@ void HardwarePortal::OpenDevice() {
         handle_ = nullptr;
         continue;
       }
+      hid_mode_.store(entry.initial_mode, std::memory_order_release);
       break;
     }
   }
@@ -155,6 +227,7 @@ void HardwarePortal::CloseDevice() {
   libusb_release_interface(handle_, 0);
   libusb_close(handle_);
   handle_ = nullptr;
+  hid_mode_.store(PortalHidMode::kUnknown, std::memory_order_release);
 
   std::lock_guard<std::mutex> guard(read_queue_mutex_);
   while (!read_queue_.empty()) {
@@ -164,15 +237,52 @@ void HardwarePortal::CloseDevice() {
 
 X_STATUS HardwarePortal::ReadInternal(std::span<uint8_t> data,
                                       int32_t& read_count) {
+  // Drain any packet queued before a portal identified itself as legacy.
   if (DequeuePacket(data, read_count)) {
     return X_ERROR_SUCCESS;
   }
 
-  read_count = 0;
+  if (UsesAsyncReads()) {
+    read_count = 0;
+    return X_ERROR_SUCCESS;
+  }
+
+  // Original HID behavior used by older Skylanders portals and other bases.
+  const int result = libusb_interrupt_transfer(
+      handle_, read_endpoint, data.data(), static_cast<int>(data.size()),
+      &read_count, kLegacyTransferTimeout);
+
+  switch (result) {
+    case LIBUSB_ERROR_NO_DEVICE:
+      return X_ERROR_DEVICE_NOT_CONNECTED;
+    case LIBUSB_ERROR_TIMEOUT:
+      return X_ERROR_SUCCESS;
+    default:
+      break;
+  }
+
+  if (result < 0) {
+    XELOGW("Portal[Read] returned error: {:08X}", result);
+    return X_ERROR_FUNCTION_FAILED;
+  }
   return X_ERROR_SUCCESS;
 }
 
 X_STATUS HardwarePortal::WriteInternal(std::span<uint8_t> data) {
+  if (!UsesAsyncReads()) {
+    // Preserve the original report length and timeout for legacy hardware.
+    const int result = libusb_interrupt_transfer(
+        handle_, write_endpoint, data.data(), static_cast<int>(data.size()),
+        nullptr, kLegacyTransferTimeout);
+
+    if (result < 0) {
+      XELOGW("Portal[Write] returned error: {:08X}", result);
+      return X_ERROR_DEVICE_NOT_CONNECTED;
+    }
+
+    return X_ERROR_SUCCESS;
+  }
+
   // Physical portal output uses fixed-size USB reports. Zero-pad shorter
   // guest writes to the report size before submitting the transfer.
   std::array<uint8_t, kPortalBufferSize> buffer{};
@@ -182,7 +292,7 @@ X_STATUS HardwarePortal::WriteInternal(std::span<uint8_t> data) {
   int bytes_transferred = 0;
   const int result = libusb_interrupt_transfer(
       handle_, write_endpoint, buffer.data(), static_cast<int>(buffer.size()),
-      &bytes_transferred, timeout);
+      &bytes_transferred, kAsyncTransferTimeout);
 
   if (result < 0) {
     XELOGW("Portal[Write] returned error: {:08X}", result);
@@ -206,6 +316,11 @@ void HardwarePortal::OnDeviceArrival() {
 
 void HardwarePortal::OnDeviceRemoval() {
   std::lock_guard<xe_mutex> guard(lock_);
+  if (IsActiveDevicePresent()) {
+    // Windows reports removal for every USB device, including controllers.
+    // Do not reset a portal that is still physically connected.
+    return;
+  }
   CloseDevice();
 }
 

--- a/src/xenia/hid/portal/hardware_portal.h
+++ b/src/xenia/hid/portal/hardware_portal.h
@@ -11,9 +11,18 @@
 #define XENIA_HID_PORTAL_HARDWARE_PORTAL_H_
 
 #include <array>
+#include <atomic>
+#include <mutex>
+#include <queue>
+#include <thread>
+
 #include "xenia/hid/portal/portal.h"
 
 #include "third_party/libusb/libusb/libusb.h"
+
+#ifdef Portal
+#undef Portal
+#endif
 
 namespace xe {
 namespace hid {
@@ -22,6 +31,11 @@ constexpr std::array<std::pair<uint16_t, uint16_t>, 2>
     kPortalVendorProductIdList = {
         std::pair<uint16_t, uint16_t>{0x1430, 0x1F17},
         std::pair<uint16_t, uint16_t>{0x24C6, 0xFA00}};
+
+struct QueuedPacket {
+  std::array<uint8_t, kPortalBufferSize> data{};
+  int32_t length = 0;
+};
 
 class HardwarePortal final : public Portal {
  public:
@@ -34,6 +48,15 @@ class HardwarePortal final : public Portal {
   virtual void OnDeviceRemoval() override;
 
  private:
+  static constexpr size_t kMaxQueuedPackets = 64;
+
+  void StartReaderThread();
+  void StopReaderThread();
+  void ReaderThreadMain();
+  void QueuePacket(std::array<uint8_t, kPortalBufferSize>&& packet,
+                   int32_t length);
+  bool DequeuePacket(std::span<uint8_t> data, int32_t& read_count);
+
   virtual void OpenDevice() override;
   virtual void CloseDevice() override;
   virtual X_STATUS ReadInternal(std::span<uint8_t> data,
@@ -42,10 +65,14 @@ class HardwarePortal final : public Portal {
 
   const uint8_t read_endpoint = 0x81;
   const uint8_t write_endpoint = 0x02;
-  const uint16_t timeout = 100;
+  const uint16_t timeout = 30;
 
   libusb_context* context_ = nullptr;
   libusb_device_handle* handle_ = nullptr;
+  std::atomic_bool stop_reader_{false};
+  std::thread reader_thread_;
+  std::mutex read_queue_mutex_;
+  std::queue<QueuedPacket> read_queue_;
 };
 
 }  // namespace hid

--- a/src/xenia/hid/portal/hardware_portal.h
+++ b/src/xenia/hid/portal/hardware_portal.h
@@ -27,10 +27,22 @@
 namespace xe {
 namespace hid {
 
-constexpr std::array<std::pair<uint16_t, uint16_t>, 2>
-    kPortalVendorProductIdList = {
-        std::pair<uint16_t, uint16_t>{0x1430, 0x1F17},
-        std::pair<uint16_t, uint16_t>{0x24C6, 0xFA00}};
+enum class PortalHidMode : uint8_t {
+  kUnknown,
+  kLegacy,
+  kTraptaniumAsync,
+};
+
+struct SupportedPortalDevice {
+  uint16_t vendor_id;
+  uint16_t product_id;
+  PortalHidMode initial_mode;
+};
+
+constexpr std::array<SupportedPortalDevice, 2> kSupportedPortalDevices = {{
+    {0x1430, 0x1F17, PortalHidMode::kUnknown},
+    {0x24C6, 0xFA00, PortalHidMode::kLegacy},
+}};
 
 struct QueuedPacket {
   std::array<uint8_t, kPortalBufferSize> data{};
@@ -49,26 +61,31 @@ class HardwarePortal final : public Portal {
 
  private:
   static constexpr size_t kMaxQueuedPackets = 64;
+  static constexpr uint16_t kAsyncTransferTimeout = 30;
+  static constexpr uint16_t kLegacyTransferTimeout = 100;
 
   void StartReaderThread();
   void StopReaderThread();
   void ReaderThreadMain();
+  bool IdentifyPortalFromPacket(std::span<const uint8_t> packet);
+  bool IsActiveDevicePresent() const;
   void QueuePacket(std::array<uint8_t, kPortalBufferSize>&& packet,
                    int32_t length);
   bool DequeuePacket(std::span<uint8_t> data, int32_t& read_count);
 
   virtual void OpenDevice() override;
   virtual void CloseDevice() override;
+  virtual bool UsesAsyncReads() const override;
   virtual X_STATUS ReadInternal(std::span<uint8_t> data,
                                 int32_t& read_count) override;
   virtual X_STATUS WriteInternal(std::span<uint8_t> data) override;
 
   const uint8_t read_endpoint = 0x81;
   const uint8_t write_endpoint = 0x02;
-  const uint16_t timeout = 30;
 
   libusb_context* context_ = nullptr;
   libusb_device_handle* handle_ = nullptr;
+  std::atomic<PortalHidMode> hid_mode_{PortalHidMode::kUnknown};
   std::atomic_bool stop_reader_{false};
   std::thread reader_thread_;
   std::mutex read_queue_mutex_;

--- a/src/xenia/hid/portal/portal.cc
+++ b/src/xenia/hid/portal/portal.cc
@@ -31,14 +31,11 @@ X_STATUS Portal::Read(std::span<uint8_t> data, uint32_t& bytes_read,
   X_STATUS status = ReadInternal(data, read_count);
 
   if (XSUCCEEDED(status)) {
-    // According to XAM decompilation logic here is reversed. Difference in
-    // status should return 1, but these values are taken from internal parts of
-    // xinput raw implementation, so it might be completely opposite.
-    state = previous_status_ == status;
+    // Empty asynchronous polls complete successfully with no data. Signal
+    // state only when a packet was actually returned to the guest.
+    state = read_count > 0 ? 1 : 0;
     bytes_read = read_count;
   }
-
-  previous_status_ = status;
 
   if (status == X_ERROR_DEVICE_NOT_CONNECTED) {
     CloseDevice();

--- a/src/xenia/hid/portal/portal.cc
+++ b/src/xenia/hid/portal/portal.cc
@@ -31,11 +31,18 @@ X_STATUS Portal::Read(std::span<uint8_t> data, uint32_t& bytes_read,
   X_STATUS status = ReadInternal(data, read_count);
 
   if (XSUCCEEDED(status)) {
-    // Empty asynchronous polls complete successfully with no data. Signal
-    // state only when a packet was actually returned to the guest.
-    state = read_count > 0 ? 1 : 0;
+    if (UsesAsyncReads()) {
+      // Empty asynchronous polls complete successfully with no data. Signal
+      // state only when a packet was actually returned to the guest.
+      state = read_count > 0 ? 1 : 0;
+    } else {
+      // Preserve the original HID state behavior for legacy portals.
+      state = previous_status_ == status;
+    }
     bytes_read = read_count;
   }
+
+  previous_status_ = status;
 
   if (status == X_ERROR_DEVICE_NOT_CONNECTED) {
     CloseDevice();

--- a/src/xenia/hid/portal/portal.h
+++ b/src/xenia/hid/portal/portal.h
@@ -44,10 +44,13 @@ class Portal {
  private:
   virtual void OpenDevice() = 0;
   virtual void CloseDevice() = 0;
+  virtual bool UsesAsyncReads() const = 0;
 
   virtual X_STATUS ReadInternal(std::span<uint8_t> data,
                                 int32_t& read_count) = 0;
   virtual X_STATUS WriteInternal(std::span<uint8_t> data) = 0;
+
+  X_STATUS previous_status_ = 0;
 };
 
 }  // namespace hid

--- a/src/xenia/hid/portal/portal.h
+++ b/src/xenia/hid/portal/portal.h
@@ -15,6 +15,10 @@
 #include "xenia/base/mutex.h"
 #include "xenia/xbox.h"
 
+#ifdef Portal
+#undef Portal
+#endif
+
 namespace xe {
 namespace hid {
 
@@ -34,6 +38,9 @@ class Portal {
   virtual void OnDeviceArrival() = 0;
   virtual void OnDeviceRemoval() = 0;
 
+ protected:
+  xe_mutex lock_;
+
  private:
   virtual void OpenDevice() = 0;
   virtual void CloseDevice() = 0;
@@ -41,9 +48,6 @@ class Portal {
   virtual X_STATUS ReadInternal(std::span<uint8_t> data,
                                 int32_t& read_count) = 0;
   virtual X_STATUS WriteInternal(std::span<uint8_t> data) = 0;
-
-  xe_mutex lock_;
-  X_STATUS previous_status_ = 0;
 };
 
 }  // namespace hid


### PR DESCRIPTION
Fixes communication with physical Xbox 360 Traptanium Portal hardware used by Skylanders: Trap Team.

### Problem

Skylanders: Trap Team (Title ID `41560911`) would freeze or stall when a physical Xbox 360 Traptanium Portal was connected.

The physical USB read was occurring directly on the guest polling path, so waiting for data from the portal could block the game. Unplugging the portal allowed execution to continue.

The existing read state handling also could not reliably distinguish between an empty poll and actual portal data being received.

### Changes

- Add asynchronous physical USB reads.
- Queue received packets with their actual transfer length.
- Bound the receive queue to prevent unbounded growth.
- Report state based on whether packet data was actually returned.
- Send physical portal output as fixed-size, zero-padded USB reports.
- Synchronize device arrival/removal with portal I/O.
- Validate interface claiming before using the device.
- Stop and join the reader thread before closing the USB handle.
- Detect incomplete USB writes.

### Testing

Tested with Skylanders: Trap Team (`41560911`) using an original Xbox 360 Traptanium Portal with the WinUSB driver.

Verified:
- Portal detection
- Figure detection and swapping
- Trap functionality
- Portal lighting
- Device unplug/replug
- No portal-related freezing

### Before

With the physical portal connected, the game would freeze or stall while attempting to communicate with it.

<img width="1266" height="760" alt="Screenshot 2026-08-16 012138" src="https://github.com/user-attachments/assets/7a905f2d-34ba-4ff1-87a7-ac6bb0d4ac2e" />


### After

The physical portal is detected and remains functional during gameplay without the previous freezing.

<img width="1264" height="758" alt="image" src="https://github.com/user-attachments/assets/3edfa2f2-8e02-4159-b407-2d24a0b78efc" />
