### PR TITLE
[GPU] Match normalized depth resolve texture precision

### DIFF
--- a/src/xenia/gpu/d3d12/d3d12_command_processor.cc
+++ b/src/xenia/gpu/d3d12/d3d12_command_processor.cc
@@ -4330,13 +4330,13 @@ XE_NOINLINE void D3D12CommandProcessor::UpdateSystemConstantValues_Impl(
     texture_signs_uint =
         (texture_signs_uint & ~texture_signs_mask) | texture_signs_shifted;
     // cache misses here, we're accessing the texture bindings out of order
-    uint32_t texture_integer_scale_bits =
-        texture_cache_->GetActiveIntegerScaleBits(texture_index);
+    uint32_t texture_fixed_point_info =
+        texture_cache_->GetActiveTextureFixedPointInfo(texture_index);
     update_dirty_uint32_cmp(
-        system_constants_.texture_integer_scale_bits[texture_index],
-        texture_integer_scale_bits);
-    system_constants_.texture_integer_scale_bits[texture_index] =
-        texture_integer_scale_bits;
+        system_constants_.texture_fixed_point_info[texture_index],
+        texture_fixed_point_info);
+    system_constants_.texture_fixed_point_info[texture_index] =
+        texture_fixed_point_info;
     textures_resolution_scaled |=
         uint32_t(texture_cache_->IsActiveTextureResolutionScaled(texture_index))
         << texture_index;

--- a/src/xenia/gpu/d3d12/d3d12_render_target_cache.cc
+++ b/src/xenia/gpu/d3d12/d3d12_render_target_cache.cc
@@ -1483,7 +1483,8 @@ bool D3D12RenderTargetCache::Resolve(const Memory& memory,
         // Invalidate textures and mark the range as scaled if needed.
         texture_cache.MarkRangeAsResolved(resolve_info.copy_dest_extent_start,
                                           resolve_info.copy_dest_extent_length,
-                                          copy_dest_scaled);
+                                          copy_dest_scaled,
+                                          resolve_info.IsCopyingDepth());
         written_address_out = resolve_info.copy_dest_extent_start;
         written_length_out = resolve_info.copy_dest_extent_length;
         if (written_scaled_out) {

--- a/src/xenia/gpu/dxbc_shader_translator.cc
+++ b/src/xenia/gpu/dxbc_shader_translator.cc
@@ -2195,7 +2195,7 @@ constexpr DxbcShaderTranslator::SystemConstantRdef
         {"xe_edram_blend_constant", ShaderRdefTypeIndex::kFloat4,
          sizeof(float) * 4},
 
-        {"xe_texture_integer_scale_bits", ShaderRdefTypeIndex::kUint4Array8,
+        {"xe_texture_fixed_point_info", ShaderRdefTypeIndex::kUint4Array8,
          sizeof(uint32_t) * 32},
 };
 

--- a/src/xenia/gpu/dxbc_shader_translator.h
+++ b/src/xenia/gpu/dxbc_shader_translator.h
@@ -114,7 +114,7 @@ class DxbcShaderTranslator : public ShaderTranslator {
     // If anything in this is structure is changed in a way not compatible with
     // the previous layout, invalidate the pipeline storages by increasing this
     // version number (0xYYYYMMDD)!
-    static constexpr uint32_t kVersion = 0x20260803;
+    static constexpr uint32_t kVersion = 0x20260816;
 
     enum class DepthStencilMode : uint32_t {
       kNoModifiers,
@@ -413,13 +413,14 @@ class DxbcShaderTranslator : public ShaderTranslator {
     // The constant blend factor for the respective modes.
     float edram_blend_constant[4];
 
-    // Integer num_format on fixed textures. Each dword packs the scale needed
-    // to turn normalized host samples back into guest integer values.
+    // Fixed-point texture fetch conversion information. Each dword packs the
+    // scale needed to turn normalized host samples back into guest integer
+    // values, plus flags for normalized depth/stencil resolve samples.
     // bits 0:3 = component_bits - 1
     // bit 4 = signed
     // bit 5 = unsigned-biased
     // Zero means no scale.
-    uint32_t texture_integer_scale_bits[32];
+    uint32_t texture_fixed_point_info[32];
 
    private:
     friend class DxbcShaderTranslator;
@@ -474,7 +475,7 @@ class DxbcShaderTranslator : public ShaderTranslator {
 
       kEdramBlendConstant,
 
-      kTextureIntegerScaleBits,
+      kTextureFixedPointInfo,
 
       kCount,
     };

--- a/src/xenia/gpu/dxbc_shader_translator_fetch.cc
+++ b/src/xenia/gpu/dxbc_shader_translator_fetch.cc
@@ -16,6 +16,7 @@
 #include "xenia/gpu/dxbc_shader_translator.h"
 #include "xenia/gpu/gpu_flags.h"
 #include "xenia/gpu/render_target_cache.h"
+#include "xenia/gpu/texture_cache.h"
 
 namespace xe {
 namespace gpu {
@@ -2239,9 +2240,8 @@ void DxbcShaderTranslator::ProcessTextureFetchInstruction(
         a_.OpBreak();
         a_.OpEndSwitch();
       }
-      // num_format is applied after signedness. A fixed-point format's host
-      // view returns normalized values, so for an integer num_format restore
-      // the guest integer range here.
+      // num_format is applied after signedness. Convert the host sample to the
+      // precision and range of the guest fixed-point fetch result.
       uint32_t integer_scale_bits_temp = PushSystemTemp();
       uint32_t integer_scale_temp = PushSystemTemp();
       uint32_t integer_scale_flags_temp = PushSystemTemp();
@@ -2254,11 +2254,41 @@ void DxbcShaderTranslator::ProcessTextureFetchInstruction(
       dxbc::Dest integer_scale_flags_dest(dxbc::Dest::R(
           integer_scale_flags_temp, used_result_nonzero_components));
       dxbc::Src integer_scale_flags_src(dxbc::Src::R(integer_scale_flags_temp));
-      dxbc::Src integer_scale_bits_packed = LoadSystemConstant(
-          SystemConstants::Index::kTextureIntegerScaleBits,
-          offsetof(SystemConstants, texture_integer_scale_bits) +
+      dxbc::Src fixed_point_info = LoadSystemConstant(
+          SystemConstants::Index::kTextureFixedPointInfo,
+          offsetof(SystemConstants, texture_fixed_point_info) +
               sizeof(uint32_t) * tfetch_index,
           dxbc::Src::kXXXX);
+      // The tested shaders use explicit point filter overrides. kUseFetchConst
+      // is intentionally excluded because its runtime sampler state has not
+      // been validated for this observed behavior.
+      if (instr.attributes.mag_filter == xenos::TextureFilter::kPoint &&
+          instr.attributes.min_filter == xenos::TextureFilter::kPoint &&
+          instr.attributes.mip_filter == xenos::TextureFilter::kPoint &&
+          instr.attributes.aniso_filter == xenos::AnisoFilter::kDisabled) {
+        // Observed guest behavior in 4D5309C9, 4D530AA4, and 4D530AB5:
+        // normalized fixed-point samples from depth/stencil resolves behave as
+        // if rounded to 16 fractional bits. Keep threshold comparisons against
+        // values such as 128 / 255 on the expected side of the boundary.
+        a_.OpAnd(
+            dxbc::Dest::R(integer_scale_bits_temp, 0b0001), fixed_point_info,
+            dxbc::Src::LU(kTextureFixedPointInfoDepthResolveNormalizedFlag));
+        a_.OpIf(true, integer_scale_bits_src.SelectFromSwizzled(0));
+        a_.OpMul(
+            dxbc::Dest::R(system_temp_result_, used_result_nonzero_components),
+            dxbc::Src::R(system_temp_result_), dxbc::Src::LF(65536.0f));
+        a_.OpRoundNE(
+            dxbc::Dest::R(system_temp_result_, used_result_nonzero_components),
+            dxbc::Src::R(system_temp_result_));
+        a_.OpMul(
+            dxbc::Dest::R(system_temp_result_, used_result_nonzero_components),
+            dxbc::Src::R(system_temp_result_), dxbc::Src::LF(1.0f / 65536.0f));
+        a_.OpEndIf();
+      }
+      a_.OpAnd(dxbc::Dest::R(integer_scale_bits_temp, 0b0001), fixed_point_info,
+               dxbc::Src::LU(kTextureFixedPointInfoIntegerScaleMask));
+      dxbc::Src integer_scale_bits_packed =
+          integer_scale_bits_src.SelectFromSwizzled(0);
       // Uniform early out. Zero means leave the sample alone. Only integer
       // num_format on fixed textures has scale bits.
       a_.OpIf(true, integer_scale_bits_packed);

--- a/src/xenia/gpu/shaders/xenos_draw.hlsli
+++ b/src/xenia/gpu/shaders/xenos_draw.hlsli
@@ -50,7 +50,7 @@ cbuffer xe_system_cbuffer : register(b0) {
 
   float4 xe_edram_blend_constant;
 
-  uint4 xe_texture_integer_scale_bits[8];
+  uint4 xe_texture_fixed_point_info[8];
 };
 
 struct XeHSControlPointInputIndexed {

--- a/src/xenia/gpu/spirv_shader_translator.cc
+++ b/src/xenia/gpu/spirv_shader_translator.cc
@@ -333,9 +333,8 @@ void SpirvShaderTranslator::StartTranslation() {
        type_float4_array_4},
       {"edram_blend_constant", offsetof(SystemConstants, edram_blend_constant),
        type_float4_},
-      {"texture_integer_scale_bits",
-       offsetof(SystemConstants, texture_integer_scale_bits),
-       type_uint4_array_8},
+      {"texture_fixed_point_info",
+       offsetof(SystemConstants, texture_fixed_point_info), type_uint4_array_8},
   };
   id_vector_temp_.clear();
   id_vector_temp_.reserve(xe::countof(system_constants));

--- a/src/xenia/gpu/spirv_shader_translator.h
+++ b/src/xenia/gpu/spirv_shader_translator.h
@@ -34,7 +34,7 @@ class SpirvShaderTranslator : public ShaderTranslator {
     // TODO(Triang3l): Change to 0xYYYYMMDD once it's out of the rapid
     // prototyping stage (easier to do small granular updates with an
     // incremental counter).
-    static constexpr uint32_t kVersion = 18;
+    static constexpr uint32_t kVersion = 19;
 
     enum class DepthStencilMode : uint32_t {
       kNoModifiers,
@@ -307,13 +307,14 @@ class SpirvShaderTranslator : public ShaderTranslator {
     // The constant blend factor for the respective modes.
     float edram_blend_constant[4];
 
-    // Integer num_format on fixed textures. Each dword packs the scale needed
-    // to turn normalized host samples back into guest integer values.
+    // Fixed-point texture fetch conversion information. Each dword packs the
+    // scale needed to turn normalized host samples back into guest integer
+    // values, plus flags for normalized depth/stencil resolve samples.
     // bits 0:3 = component_bits - 1
     // bit 4 = signed
     // bit 5 = unsigned-biased
     // Zero means no scale.
-    uint32_t texture_integer_scale_bits[32];
+    uint32_t texture_fixed_point_info[32];
   };
 
   // Separate constant buffer for user clip planes
@@ -1012,7 +1013,7 @@ class SpirvShaderTranslator : public ShaderTranslator {
     kSystemConstantEdramRTKeepMask,
     kSystemConstantEdramRTClamp,
     kSystemConstantEdramBlendConstant,
-    kSystemConstantTextureIntegerScaleBits,
+    kSystemConstantTextureFixedPointInfo,
   };
   spv::Id uniform_system_constants_;
   spv::Id uniform_clip_plane_constants_;

--- a/src/xenia/gpu/spirv_shader_translator_fetch.cc
+++ b/src/xenia/gpu/spirv_shader_translator_fetch.cc
@@ -19,6 +19,7 @@
 #include "xenia/gpu/gpu_flags.h"
 #include "xenia/gpu/render_target_cache.h"
 #include "xenia/gpu/spirv_compatibility.h"
+#include "xenia/gpu/texture_cache.h"
 
 namespace xe {
 namespace gpu {
@@ -2543,21 +2544,80 @@ void SpirvShaderTranslator::ProcessTextureFetchInstruction(
           }
         }
 
-        // num_format is applied after signs/gamma. Fixed textures sample as
-        // normalized host values, so integer num_format scales them back to
-        // guest integer units here.
+        // num_format is applied after signs/gamma. Convert the host sample to
+        // the precision and range of the guest fixed-point fetch result.
         id_vector_temp_.clear();
         id_vector_temp_.push_back(
-            builder_->makeIntConstant(kSystemConstantTextureIntegerScaleBits));
+            builder_->makeIntConstant(kSystemConstantTextureFixedPointInfo));
         id_vector_temp_.push_back(
             builder_->makeIntConstant(int32_t(fetch_constant_index >> 2)));
         id_vector_temp_.push_back(
             builder_->makeIntConstant(int32_t(fetch_constant_index & 3)));
-        spv::Id integer_scale_bits_packed = builder_->createLoad(
+        spv::Id fixed_point_info = builder_->createLoad(
             builder_->createAccessChain(spv::StorageClassUniform,
                                         uniform_system_constants_,
                                         id_vector_temp_),
             spv::NoPrecision);
+        // The tested shaders use explicit point filter overrides.
+        // kUseFetchConst is intentionally excluded because its runtime sampler
+        // state has not been validated for this observed behavior.
+        if (instr.attributes.mag_filter == xenos::TextureFilter::kPoint &&
+            instr.attributes.min_filter == xenos::TextureFilter::kPoint &&
+            instr.attributes.mip_filter == xenos::TextureFilter::kPoint &&
+            instr.attributes.aniso_filter == xenos::AnisoFilter::kDisabled) {
+          // Observed guest behavior in 4D5309C9, 4D530AA4, and 4D530AB5:
+          // normalized fixed-point samples from depth/stencil resolves behave
+          // as if rounded to 16 fractional bits. Keep threshold comparisons
+          // against values such as 128 / 255 on the expected side of the
+          // boundary.
+          spv::Id depth_resolve_normalized = builder_->createBinOp(
+              spv::OpINotEqual, type_bool_,
+              builder_->createBinOp(
+                  spv::OpBitwiseAnd, type_uint_, fixed_point_info,
+                  builder_->makeUintConstant(
+                      kTextureFixedPointInfoDepthResolveNormalizedFlag)),
+              const_uint_0_);
+          SpirvBuilder::IfBuilder if_depth_resolve_normalized(
+              depth_resolve_normalized, spv::SelectionControlMaskNone,
+              *builder_);
+          spv::Id rounded_result[4] = {};
+          {
+            uint32_t result_remaining_components =
+                used_result_nonzero_components;
+            uint32_t result_component_index;
+            while (xe::bit_scan_forward(result_remaining_components,
+                                        &result_component_index)) {
+              result_remaining_components &=
+                  ~(UINT32_C(1) << result_component_index);
+              rounded_result[result_component_index] =
+                  builder_->createNoContractionBinOp(
+                      spv::OpFMul, type_float_,
+                      builder_->createUnaryBuiltinCall(
+                          type_float_, ext_inst_glsl_std_450_,
+                          GLSLstd450RoundEven,
+                          builder_->createNoContractionBinOp(
+                              spv::OpFMul, type_float_,
+                              result[result_component_index],
+                              builder_->makeFloatConstant(65536.0f))),
+                      builder_->makeFloatConstant(1.0f / 65536.0f));
+            }
+          }
+          if_depth_resolve_normalized.makeEndIf();
+          uint32_t result_remaining_components = used_result_nonzero_components;
+          uint32_t result_component_index;
+          while (xe::bit_scan_forward(result_remaining_components,
+                                      &result_component_index)) {
+            result_remaining_components &=
+                ~(UINT32_C(1) << result_component_index);
+            result[result_component_index] =
+                if_depth_resolve_normalized.createMergePhi(
+                    rounded_result[result_component_index],
+                    result[result_component_index]);
+          }
+        }
+        spv::Id integer_scale_bits_packed = builder_->createBinOp(
+            spv::OpBitwiseAnd, type_uint_, fixed_point_info,
+            builder_->makeUintConstant(kTextureFixedPointInfoIntegerScaleMask));
         {
           // Uniform early out. Zero means leave the sample alone. Only integer
           // num_format on fixed textures has scale bits.

--- a/src/xenia/gpu/texture_cache.cc
+++ b/src/xenia/gpu/texture_cache.cc
@@ -123,17 +123,24 @@ TextureCache::TextureCache(const RegisterFile& register_file,
   assert_true(draw_resolution_scale_y >= 1);
   assert_true(draw_resolution_scale_y <= kMaxDrawResolutionScaleAlongAxis);
 
+  constexpr uint32_t kResolvePageDwordCount =
+      SharedMemory::kBufferSize / 4096 / 32;
   if (draw_resolution_scale_x > 1 || draw_resolution_scale_y > 1) {
-    constexpr uint32_t kScaledResolvePageDwordCount =
-        SharedMemory::kBufferSize / 4096 / 32;
     scaled_resolve_pages_ =
-        std::unique_ptr<uint32_t[]>(new uint32_t[kScaledResolvePageDwordCount]);
+        std::unique_ptr<uint32_t[]>(new uint32_t[kResolvePageDwordCount]);
     std::memset(scaled_resolve_pages_.get(), 0,
-                kScaledResolvePageDwordCount * sizeof(uint32_t));
+                kResolvePageDwordCount * sizeof(uint32_t));
     std::memset(scaled_resolve_pages_l2_, 0, sizeof(scaled_resolve_pages_l2_));
     scaled_resolve_global_watch_handle_ = shared_memory.RegisterGlobalWatch(
         ScaledResolveGlobalWatchCallbackThunk, this);
   }
+  depth_resolve_pages_ =
+      std::unique_ptr<uint32_t[]>(new uint32_t[kResolvePageDwordCount]);
+  std::memset(depth_resolve_pages_.get(), 0,
+              kResolvePageDwordCount * sizeof(uint32_t));
+  std::memset(depth_resolve_pages_l2_, 0, sizeof(depth_resolve_pages_l2_));
+  depth_resolve_global_watch_handle_ = shared_memory.RegisterGlobalWatch(
+      DepthResolveGlobalWatchCallbackThunk, this);
 }
 
 TextureCache::~TextureCache() {
@@ -141,6 +148,9 @@ TextureCache::~TextureCache() {
 
   if (scaled_resolve_global_watch_handle_) {
     shared_memory().UnregisterGlobalWatch(scaled_resolve_global_watch_handle_);
+  }
+  if (depth_resolve_global_watch_handle_) {
+    shared_memory().UnregisterGlobalWatch(depth_resolve_global_watch_handle_);
   }
 }
 
@@ -267,27 +277,31 @@ void TextureCache::BeginFrame() {
 
 void TextureCache::MarkRangeAsResolved(uint32_t start_unscaled,
                                        uint32_t length_unscaled,
-                                       bool resolution_scaled) {
+                                       bool resolution_scaled, bool is_depth) {
   if (length_unscaled == 0) {
     return;
   }
   start_unscaled &= 0x1FFFFFFF;
   length_unscaled = std::min(length_unscaled, 0x20000000 - start_unscaled);
 
-  if (IsDrawResolutionScaled()) {
-    uint32_t page_first = start_unscaled >> 12;
-    uint32_t page_last = (start_unscaled + length_unscaled - 1) >> 12;
-    uint32_t block_first = page_first >> 5;
-    uint32_t block_last = page_last >> 5;
-    auto global_lock = global_critical_region_.Acquire();
-    for (uint32_t i = block_first; i <= block_last; ++i) {
-      uint32_t add_bits = UINT32_MAX;
-      if (i == block_first) {
-        add_bits &= ~((UINT32_C(1) << (page_first & 31)) - 1);
-      }
-      if (i == block_last && (page_last & 31) != 31) {
-        add_bits &= (UINT32_C(1) << ((page_last & 31) + 1)) - 1;
-      }
+  // Invalidate textures and clear provenance left by previous writes before
+  // recording the provenance of this resolve.
+  shared_memory().RangeWrittenByGpu(start_unscaled, length_unscaled);
+
+  uint32_t page_first = start_unscaled >> 12;
+  uint32_t page_last = (start_unscaled + length_unscaled - 1) >> 12;
+  uint32_t block_first = page_first >> 5;
+  uint32_t block_last = page_last >> 5;
+  auto global_lock = global_critical_region_.Acquire();
+  for (uint32_t i = block_first; i <= block_last; ++i) {
+    uint32_t add_bits = UINT32_MAX;
+    if (i == block_first) {
+      add_bits &= ~((UINT32_C(1) << (page_first & 31)) - 1);
+    }
+    if (i == block_last && (page_last & 31) != 31) {
+      add_bits &= (UINT32_C(1) << ((page_last & 31) + 1)) - 1;
+    }
+    if (IsDrawResolutionScaled()) {
       if (resolution_scaled) {
         scaled_resolve_pages_[i] |= add_bits;
         scaled_resolve_pages_l2_[i >> 6] |= UINT64_C(1) << (i & 63);
@@ -300,11 +314,16 @@ void TextureCache::MarkRangeAsResolved(uint32_t start_unscaled,
         }
       }
     }
+    if (is_depth) {
+      depth_resolve_pages_[i] |= add_bits;
+      depth_resolve_pages_l2_[i >> 6] |= UINT64_C(1) << (i & 63);
+    } else {
+      depth_resolve_pages_[i] &= ~add_bits;
+      if (!depth_resolve_pages_[i]) {
+        depth_resolve_pages_l2_[i >> 6] &= ~(UINT64_C(1) << (i & 63));
+      }
+    }
   }
-
-  // Invalidate textures. Toggling individual textures between scaled and
-  // unscaled also relies on invalidation through shared memory.
-  shared_memory().RangeWrittenByGpu(start_unscaled, length_unscaled);
 }
 
 uint32_t TextureCache::GuestToHostSwizzle(uint32_t guest_swizzle,
@@ -366,6 +385,8 @@ void TextureCache::RequestTextures(uint32_t used_texture_mask) {
         GuestToHostSwizzle(fetch.swizzle, GetHostFormatSwizzle(binding.key));
     binding.integer_scale_bits = GetIntegerScaleBits(
         fetch.format, fetch.num_format, fetch.swizzle, binding.swizzled_signs);
+    binding.normalized_fixed_point =
+        !fetch.num_format && FormatInfo::Get(fetch.format)->fixed;
 
     // Check if need to load the unsigned and the signed versions of the texture
     // (if the format is emulated with different host bit representations for
@@ -624,21 +645,35 @@ void TextureCache::DestroyAllTextures(bool from_destructor) {
 }
 
 TextureCache::Texture* TextureCache::FindOrCreateTexture(TextureKey key) {
+  texture_util::TextureGuestLayout resolve_guest_layout = key.GetGuestLayout();
+
   // Check if the texture is a scaled resolve texture.
   if (IsDrawResolutionScaled() && key.tiled &&
       IsScaledResolveSupportedForFormat(key)) {
-    texture_util::TextureGuestLayout scaled_resolve_guest_layout =
-        key.GetGuestLayout();
-    if ((scaled_resolve_guest_layout.base.level_data_extent_bytes &&
+    if ((resolve_guest_layout.base.level_data_extent_bytes &&
          IsRangeScaledResolved(
              key.base_page << 12,
-             scaled_resolve_guest_layout.base.level_data_extent_bytes)) ||
-        (scaled_resolve_guest_layout.mips_total_extent_bytes &&
-         IsRangeScaledResolved(
-             key.mip_page << 12,
-             scaled_resolve_guest_layout.mips_total_extent_bytes))) {
+             resolve_guest_layout.base.level_data_extent_bytes)) ||
+        (resolve_guest_layout.mips_total_extent_bytes &&
+         IsRangeScaledResolved(key.mip_page << 12,
+                               resolve_guest_layout.mips_total_extent_bytes))) {
       key.scaled_resolve = 1;
     }
+  }
+  bool has_depth_resolve_range = false;
+  bool fully_depth_resolved = true;
+  if (resolve_guest_layout.base.level_data_extent_bytes) {
+    has_depth_resolve_range = true;
+    fully_depth_resolved &= IsRangeFullyDepthResolved(
+        key.base_page << 12, resolve_guest_layout.base.level_data_extent_bytes);
+  }
+  if (resolve_guest_layout.mips_total_extent_bytes) {
+    has_depth_resolve_range = true;
+    fully_depth_resolved &= IsRangeFullyDepthResolved(
+        key.mip_page << 12, resolve_guest_layout.mips_total_extent_bytes);
+  }
+  if (has_depth_resolve_range && fully_depth_resolved) {
+    key.depth_resolve = 1;
   }
 
   uint32_t host_width = key.GetWidth();
@@ -1146,6 +1181,35 @@ bool TextureCache::IsRangeScaledResolved(uint32_t start_unscaled,
   return false;
 }
 
+bool TextureCache::IsRangeFullyDepthResolved(uint32_t start_unscaled,
+                                             uint32_t length_unscaled) {
+  start_unscaled = std::min(start_unscaled, SharedMemory::kBufferSize);
+  length_unscaled =
+      std::min(length_unscaled, SharedMemory::kBufferSize - start_unscaled);
+  if (!length_unscaled) {
+    return false;
+  }
+
+  uint32_t page_first = start_unscaled >> 12;
+  uint32_t page_last = (start_unscaled + length_unscaled - 1) >> 12;
+  uint32_t block_first = page_first >> 5;
+  uint32_t block_last = page_last >> 5;
+  auto global_lock = global_critical_region_.Acquire();
+  for (uint32_t i = block_first; i <= block_last; ++i) {
+    uint32_t check_bits = UINT32_MAX;
+    if (i == block_first) {
+      check_bits &= ~((UINT32_C(1) << (page_first & 31)) - 1);
+    }
+    if (i == block_last && (page_last & 31) != 31) {
+      check_bits &= (UINT32_C(1) << ((page_last & 31) + 1)) - 1;
+    }
+    if ((depth_resolve_pages_[i] & check_bits) != check_bits) {
+      return false;
+    }
+  }
+  return true;
+}
+
 void TextureCache::ScaledResolveGlobalWatchCallbackThunk(
     const global_unique_lock_type& global_lock, void* context,
     uint32_t address_first, uint32_t address_last, bool invalidated_by_gpu) {
@@ -1196,6 +1260,54 @@ void TextureCache::ScaledResolveGlobalWatchCallback(
       scaled_resolve_pages_[resolve_block_index] &= resolve_keep_bits;
       if (scaled_resolve_pages_[resolve_block_index] == 0) {
         scaled_resolve_pages_l2_[i] &=
+            ~(UINT64_C(1) << resolve_block_relative_index);
+      }
+    }
+  }
+}
+
+void TextureCache::DepthResolveGlobalWatchCallbackThunk(
+    const global_unique_lock_type& global_lock, void* context,
+    uint32_t address_first, uint32_t address_last, bool invalidated_by_gpu) {
+  TextureCache* texture_cache = reinterpret_cast<TextureCache*>(context);
+  texture_cache->DepthResolveGlobalWatchCallback(
+      global_lock, address_first, address_last, invalidated_by_gpu);
+}
+
+void TextureCache::DepthResolveGlobalWatchCallback(
+    const global_unique_lock_type& global_lock, uint32_t address_first,
+    uint32_t address_last, [[maybe_unused]] bool invalidated_by_gpu) {
+  uint32_t resolve_page_first = address_first >> 12;
+  uint32_t resolve_page_last = address_last >> 12;
+  uint32_t resolve_block_first = resolve_page_first >> 5;
+  uint32_t resolve_block_last = resolve_page_last >> 5;
+  uint32_t resolve_l2_block_first = resolve_block_first >> 6;
+  uint32_t resolve_l2_block_last = resolve_block_last >> 6;
+  for (uint32_t i = resolve_l2_block_first; i <= resolve_l2_block_last; ++i) {
+    uint64_t resolve_l2_block = depth_resolve_pages_l2_[i];
+    if (i == resolve_l2_block_first) {
+      resolve_l2_block &= ~((UINT64_C(1) << (resolve_block_first & 63)) - 1);
+    }
+    if (i == resolve_l2_block_last && (resolve_block_last & 63) != 63) {
+      resolve_l2_block &= (UINT64_C(1) << ((resolve_block_last & 63) + 1)) - 1;
+    }
+    uint32_t resolve_block_relative_index;
+    while (
+        xe::bit_scan_forward(resolve_l2_block, &resolve_block_relative_index)) {
+      resolve_l2_block &= ~(UINT64_C(1) << resolve_block_relative_index);
+      uint32_t resolve_block_index = (i << 6) + resolve_block_relative_index;
+      uint32_t resolve_keep_bits = 0;
+      if (resolve_block_index == resolve_block_first) {
+        resolve_keep_bits |= (UINT32_C(1) << (resolve_page_first & 31)) - 1;
+      }
+      if (resolve_block_index == resolve_block_last &&
+          (resolve_page_last & 31) != 31) {
+        resolve_keep_bits |=
+            ~((UINT32_C(1) << ((resolve_page_last & 31) + 1)) - 1);
+      }
+      depth_resolve_pages_[resolve_block_index] &= resolve_keep_bits;
+      if (depth_resolve_pages_[resolve_block_index] == 0) {
+        depth_resolve_pages_l2_[i] &=
             ~(UINT64_C(1) << resolve_block_relative_index);
       }
     }

--- a/src/xenia/gpu/texture_cache.h
+++ b/src/xenia/gpu/texture_cache.h
@@ -29,6 +29,15 @@
 namespace xe {
 namespace gpu {
 
+// Per-texture fixed-point fetch conversion information.
+// Bits 0:23 contain four 6-bit integer scale descriptions.
+// Bit 24 requests 16-fractional-bit rounding of normalized samples from a
+// depth/stencil resolve.
+constexpr uint32_t kTextureFixedPointInfoIntegerScaleMask =
+    (UINT32_C(1) << 24) - 1;
+constexpr uint32_t kTextureFixedPointInfoDepthResolveNormalizedFlag =
+    UINT32_C(1) << 24;
+
 // Manages host copies of guest textures, performing untiling, format and endian
 // conversion of textures stored in the shared memory, and also handling
 // invalidation.
@@ -101,9 +110,10 @@ class TextureCache {
   // overlapping it. resolution_scaled is whether the data went to the scaled
   // resolve address space, or to shared memory, such as resolves done at
   // native resolution when a scale threshold is set. The latter clears the
-  // scaled state of the range.
+  // scaled state of the range. is_depth is whether the resolved source is a
+  // depth/stencil render target.
   void MarkRangeAsResolved(uint32_t start_unscaled, uint32_t length_unscaled,
-                           bool resolution_scaled);
+                           bool resolution_scaled, bool is_depth);
   // Ensures the memory backing the range in the scaled resolve address space is
   // allocated and returns whether it is.
   virtual bool EnsureScaledResolveMemoryCommitted(
@@ -143,10 +153,20 @@ class TextureCache {
         GetValidTextureBinding(fetch_constant_index);
     return binding ? binding->swizzled_signs : kSwizzledSignsUnsigned;
   }
-  uint32_t GetActiveIntegerScaleBits(uint32_t fetch_constant_index) const {
+  uint32_t GetActiveTextureFixedPointInfo(uint32_t fetch_constant_index) const {
     const TextureBinding* binding =
         GetValidTextureBinding(fetch_constant_index);
-    return binding ? binding->integer_scale_bits : 0;
+    if (!binding) {
+      return 0;
+    }
+    uint32_t fixed_point_info = binding->integer_scale_bits;
+    if (binding->normalized_fixed_point &&
+        ((binding->texture && binding->texture->key().depth_resolve) ||
+         (binding->texture_signed &&
+          binding->texture_signed->key().depth_resolve))) {
+      fixed_point_info |= kTextureFixedPointInfoDepthResolveNormalizedFlag;
+    }
+    return fixed_point_info;
   }
   bool IsActiveTextureResolutionScaled(uint32_t fetch_constant_index) const {
     const TextureBinding* binding =
@@ -201,8 +221,10 @@ class TextureCache {
 
     // Whether this texture is a resolution-scaled resolve target.
     uint32_t scaled_resolve : 1;  // 97
+    // Whether all the texture data was written by depth/stencil resolves.
+    uint32_t depth_resolve : 1;  // 98
     // Least important in ==, so placed last.
-    uint32_t is_valid : 1;  // 98
+    uint32_t is_valid : 1;  // 99
 
     TextureKey() { MakeInvalid(); }
     TextureKey(const TextureKey& key) {
@@ -529,6 +551,8 @@ class TextureCache {
     // Packed TextureSign values, 2 bit per each component, with guest-side
     // destination swizzle from the fetch constant applied to them.
     uint8_t swizzled_signs;
+    // Whether the texture fetch uses a normalized fixed-point format.
+    bool normalized_fixed_point;
     // Unsigned version of the texture (or signed if they have the same data).
     Texture* texture;
     // Signed version of the texture if the data in the signed version is
@@ -641,6 +665,9 @@ class TextureCache {
   // Checks if there are any pages that contain scaled resolve data within the
   // range.
   bool IsRangeScaledResolved(uint32_t start_unscaled, uint32_t length_unscaled);
+  // Checks if every page in the range contains depth/stencil resolve data.
+  bool IsRangeFullyDepthResolved(uint32_t start_unscaled,
+                                 uint32_t length_unscaled);
 
   // Whether the mips of a scaled resolve texture must be generated on the host
   // (the guest did not resolve them into scaled memory itself).
@@ -667,6 +694,14 @@ class TextureCache {
   void ScaledResolveGlobalWatchCallback(
       const global_unique_lock_type& global_lock, uint32_t address_first,
       uint32_t address_last, bool invalidated_by_gpu);
+  // Global shared memory invalidation callback for depth/stencil resolve
+  // provenance.
+  static void DepthResolveGlobalWatchCallbackThunk(
+      const global_unique_lock_type& global_lock, void* context,
+      uint32_t address_first, uint32_t address_last, bool invalidated_by_gpu);
+  void DepthResolveGlobalWatchCallback(
+      const global_unique_lock_type& global_lock, uint32_t address_first,
+      uint32_t address_last, bool invalidated_by_gpu);
 
   const RegisterFile& register_file_;
   SharedMemory& shared_memory_;
@@ -686,8 +721,14 @@ class TextureCache {
   // level 2 bits.
   uint64_t scaled_resolve_pages_l2_[SharedMemory::kBufferSize >> (12 + 5 + 6)];
 
+  // Bit vector storing whether each 4 KB physical memory page contains data
+  // written by a depth/stencil resolve, and its second-level rejection vector.
+  std::unique_ptr<uint32_t[]> depth_resolve_pages_;
+  uint64_t depth_resolve_pages_l2_[SharedMemory::kBufferSize >> (12 + 5 + 6)];
+
   // Global watch for scaled resolve data invalidation.
   SharedMemory::GlobalWatchHandle scaled_resolve_global_watch_handle_ = nullptr;
+  SharedMemory::GlobalWatchHandle depth_resolve_global_watch_handle_ = nullptr;
 
   uint64_t current_submission_index_ = 0;
   uint64_t current_submission_time_ = 0;

--- a/src/xenia/gpu/vulkan/vulkan_command_processor.cc
+++ b/src/xenia/gpu/vulkan/vulkan_command_processor.cc
@@ -5100,12 +5100,12 @@ void VulkanCommandProcessor::UpdateSystemConstantValues(
           (texture_signs_uint & texture_signs_mask) != texture_signs_shifted;
       texture_signs_uint =
           (texture_signs_uint & ~texture_signs_mask) | texture_signs_shifted;
-      uint32_t texture_integer_scale_bits =
-          texture_cache_->GetActiveIntegerScaleBits(texture_index);
-      dirty |= system_constants_.texture_integer_scale_bits[texture_index] !=
-               texture_integer_scale_bits;
-      system_constants_.texture_integer_scale_bits[texture_index] =
-          texture_integer_scale_bits;
+      uint32_t texture_fixed_point_info =
+          texture_cache_->GetActiveTextureFixedPointInfo(texture_index);
+      dirty |= system_constants_.texture_fixed_point_info[texture_index] !=
+               texture_fixed_point_info;
+      system_constants_.texture_fixed_point_info[texture_index] =
+          texture_fixed_point_info;
     }
   }
 

--- a/src/xenia/gpu/vulkan/vulkan_render_target_cache.cc
+++ b/src/xenia/gpu/vulkan/vulkan_render_target_cache.cc
@@ -1400,7 +1400,8 @@ bool VulkanRenderTargetCache::Resolve(
           // went.
           texture_cache.MarkRangeAsResolved(
               resolve_info.copy_dest_extent_start,
-              resolve_info.copy_dest_extent_length, scaled_buffer_ready);
+              resolve_info.copy_dest_extent_length, scaled_buffer_ready,
+              resolve_info.IsCopyingDepth());
           written_address_out = resolve_info.copy_dest_extent_start;
           written_length_out = resolve_info.copy_dest_extent_length;
           if (written_scaled_out) {


### PR DESCRIPTION
This fixes incorrect motion blur around cars in Forza Horizon 2. Xenia sampled a normalized value from a resolved depth/stencil texture with more precision than the game expects. The game compares this value against a 16-bit fractional constant. For example, `128 / 255` needs to become `32897 / 65536`, but the host sample was slightly below that value. This caused the motion blur mask to leave a sharp rectangle around each car.

The texture cache now tracks when texture data comes from a depth/stencil resolve. The D3D12 and Vulkan shader translators round normalized point samples from these textures to 16 fractional bits. Other normalized textures are not changed.

https://github.com/xenia-canary/game-compatibility/issues/30
https://github.com/xenia-canary/game-compatibility/issues/111

