### PR TITLE
[Base] Proper support for non ANSI characters in launch argument

### DIFF
--- a/src/xenia/base/cvar.h
+++ b/src/xenia/base/cvar.h
@@ -146,7 +146,7 @@ template <>
 inline void CommandVar<std::filesystem::path>::LoadFromLaunchOptions(
     cxxopts::ParseResult* result) {
   std::string value = (*result)[name_].template as<std::string>();
-  SetCommandLineValue(value);
+  SetCommandLineValue(xe::to_path(value));
 }
 template <class T>
 void ConfigVar<T>::LoadConfigValue(const toml::node* result) {
@@ -164,8 +164,8 @@ void ConfigVar<T>::LoadConfigValue(const toml::node* result) {
 template <>
 inline void ConfigVar<std::filesystem::path>::LoadConfigValue(
     const toml::node* result) {
-  SetConfigValue(
-      xe::utf8::fix_path_separators(result->as_string()->value_or("")));
+  SetConfigValue(xe::to_path(
+      xe::utf8::fix_path_separators(result->as_string()->value_or(""))));
 }
 template <class T>
 void ConfigVar<T>::LoadGameConfigValue(const toml::node* result) {
@@ -183,8 +183,8 @@ void ConfigVar<T>::LoadGameConfigValue(const toml::node* result) {
 template <>
 inline void ConfigVar<std::filesystem::path>::LoadGameConfigValue(
     const toml::node* result) {
-  SetGameConfigValue(
-      xe::utf8::fix_path_separators(result->as_string()->value_or("")));
+  SetGameConfigValue(xe::to_path(
+      xe::utf8::fix_path_separators(result->as_string()->value_or(""))));
 }
 template <class T>
 CommandVar<T>::CommandVar(const char* name, T* default_value,

--- a/src/xenia/base/main_win.cc
+++ b/src/xenia/base/main_win.cc
@@ -90,12 +90,16 @@ bool ParseWin32LaunchArguments(
   }
 
   // Convert all args to narrow, as cxxopts doesn't support wchar.
+  // Use WideCharToMultiByte with CP_UTF8 to support non-ANSI characters
+  // (e.g. CJK paths), unlike locale-dependent wcstombs.
   int argc = wargc;
   char** argv = reinterpret_cast<char**>(alloca(sizeof(char*) * argc));
   for (int n = 0; n < argc; n++) {
-    size_t len = std::wcstombs(nullptr, wargv[n], 0);
-    argv[n] = reinterpret_cast<char*>(alloca(sizeof(char) * (len + 1)));
-    std::wcstombs(argv[n], wargv[n], len + 1);
+    int len = WideCharToMultiByte(CP_UTF8, 0, wargv[n], -1, nullptr, 0, nullptr,
+                                  nullptr);
+    argv[n] = reinterpret_cast<char*>(alloca(sizeof(char) * len));
+    WideCharToMultiByte(CP_UTF8, 0, wargv[n], -1, argv[n], len, nullptr,
+                        nullptr);
   }
 
   LocalFree(wargv);


### PR DESCRIPTION
Launch arguments on Windows were converted from wide chars using locale-dependent `std::wcstombs`, which mangles non-ANSI characters (e.g. CJK). Games launched from paths containing such characters could not be loaded ([example](https://github.com/xenia-manager/xenia-manager/issues/580))
- Convert wide command-line arguments with `WideCharToMultiByte(CP_UTF8)` instead of `wcstombs` (src/xenia/base/main_win.cc)
- Convert path cvar values from UTF-8 via `xe::to_path` for command line, config, and game config sources (src/xenia/base/cvar.h)

Tested by launching a game from a path containing CJK characters and Cyrillic letters.
NOTE: I made this fix couple of months ago so I quickly built the Xenia, tested it and shipped it.