### PR TITLE
[APU] Fix 5.1 channel order in native ALSA audio driver

### DIFF
--- a/src/xenia/apu/alsa/alsa_audio_driver.cc
+++ b/src/xenia/apu/alsa/alsa_audio_driver.cc
@@ -12,6 +12,7 @@
 #include <pthread.h>
 #include <cerrno>
 #include <cstring>
+#include <utility>
 
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || \
     defined(_M_IX86)
@@ -232,6 +233,32 @@ bool ALSAAudioDriver::SetupAlsaDevice() {
     return false;
   }
 
+  // Xenia produces 5.1 frames in the Xbox 360/XAudio2 channel order:
+  //   FL, FR, FC, LFE, BL, BR
+  // Most ALSA devices (including PipeWire's ALSA compatibility layer) use
+  // the POSIX/ALSA convention instead:
+  //   FL, FR, RL, RR, FC, LFE
+  // Without correcting for this, center and LFE end up swapped with the
+  // rear channels. Query the device's channel map and only skip the
+  // correction if it already matches the Xbox 360/XAudio2 order, mirroring
+  // the equivalent check in Xenia's bundled SDL2 fork
+  // (third_party/SDL2/src/audio/alsa/SDL_alsa_audio.c).
+  swizzle_channels_ = false;
+  if (output_channels_ == 6) {
+    swizzle_channels_ = true;
+    snd_pcm_chmap_t* chmap = snd_pcm_get_chmap(pcm_handle_);
+    if (chmap) {
+      char chmap_str[64];
+      if (snd_pcm_chmap_print(chmap, sizeof(chmap_str), chmap_str) > 0) {
+        if (std::strcmp("FL FR FC LFE RL RR", chmap_str) == 0 ||
+            std::strcmp("FL FR FC LFE SL SR", chmap_str) == 0) {
+          swizzle_channels_ = false;
+        }
+      }
+      free(chmap);
+    }
+  }
+
   // Setup software parameters
   err = snd_pcm_sw_params_current(pcm_handle_, sw_params_);
   if (err < 0) {
@@ -381,6 +408,10 @@ void ALSAAudioDriver::WorkerThread() {
         // in correct format (This matches XAudio2 behavior where memcpy is
         // used)
         output = frame;
+      }
+
+      if (swizzle_channels_) {
+        ApplyChannelSwizzle(output, channel_samples_);
       }
 
       // Apply volume using SIMD-optimized function
@@ -576,6 +607,17 @@ void ALSAAudioDriver::ApplyVolume(float* buffer, size_t sample_count,
     buffer[i] *= volume;
   }
 #endif
+}
+
+void ALSAAudioDriver::ApplyChannelSwizzle(float* buffer,
+                                          size_t channel_samples) {
+  // Swap FC/LFE (indices 2/3) with BL/BR (indices 4/5) in each interleaved
+  // 6-channel frame to go from Xbox 360/XAudio2 order to ALSA order.
+  for (size_t sample = 0; sample < channel_samples; sample++) {
+    float* channel = &buffer[sample * 6];
+    std::swap(channel[2], channel[4]);
+    std::swap(channel[3], channel[5]);
+  }
 }
 
 void ALSAAudioDriver::Pause() {

--- a/src/xenia/apu/alsa/alsa_audio_driver.h
+++ b/src/xenia/apu/alsa/alsa_audio_driver.h
@@ -47,6 +47,7 @@ class ALSAAudioDriver : public AudioDriver {
                        size_t input_frame_count, size_t output_capacity_frames,
                        float frequency_ratio, uint32_t channels);
   void ApplyVolume(float* buffer, size_t sample_count, float volume);
+  void ApplyChannelSwizzle(float* buffer, size_t channel_samples);
 
   xe::threading::Semaphore* semaphore_ = nullptr;
 
@@ -66,6 +67,11 @@ class ALSAAudioDriver : public AudioDriver {
   uint32_t output_channels_ = 0;
   snd_pcm_uframes_t period_size_ = 0;
   snd_pcm_uframes_t buffer_size_ = 0;
+
+  // True if the opened device's channel map doesn't already match Xenia's
+  // Xbox 360/XAudio2 channel order (FL, FR, FC, LFE, BL, BR), and channels
+  // 3/5 need to be swapped with 5/6 (indices 2/3 with 4/5) before writing.
+  bool swizzle_channels_ = false;
 
   // Threading
   std::unique_ptr<std::thread> worker_thread_;


### PR DESCRIPTION
## Summary

`ALSAAudioDriver` (`src/xenia/apu/alsa/alsa_audio_driver.cc`) writes 6-channel
frames straight through to the opened ALSA PCM device without accounting for
the fact that Xenia produces samples in the Xbox 360/XAudio2 channel order
(FL, FR, FC, LFE, BL, BR), while ALSA devices conventionally expose the
POSIX/ALSA channel order instead (FL, FR, RL, RR, FC, LFE). Since nothing
reorders between the two, center-channel and LFE content is written to the
rear-channel positions and vice versa.

Confirmed via `snd_pcm_get_chmap()` on a real 5.1 setup (PipeWire's ALSA
compatibility layer) that the opened device's channel map is
`FL FR RL RR FC LFE`, not the Xbox 360/XAudio2 order Xenia assumes. This
means, for a 6-channel stream:

| Xenia buffer position | Xenia's data | Lands on ALSA port |
|---|---|---|
| 2 | Center (FC) | Rear-Left |
| 3 | LFE | Rear-Right |
| 4 | Rear-Left | Center |
| 5 | Rear-Right | LFE/Sub |

Reproduced on real 5.1 hardware across titles from different eras (including
title ID `454107D9`), which rules out a game-specific or launch-era-specific
cause — the driver has no channel reordering logic at all.

## Fix

Query the device's channel map via `snd_pcm_get_chmap()` after hardware
parameters are applied, and swap channels 3/4 (center/LFE) with 5/6
(rear-left/rear-right) before writing, unless the map already matches the
Xbox 360/XAudio2 order. This mirrors the equivalent, already-working check in
Xenia's own bundled SDL2 fork
(`third_party/SDL2/src/audio/alsa/SDL_alsa_audio.c`), which correctly handles
this exact case in its own ALSA backend — `ALSAAudioDriver` is a separate,
newer native ALSA implementation that didn't have the equivalent logic.

Only engages for 6-channel output (`swizzle_channels_` is only ever set when
`output_channels_ == 6`); stereo output is untouched.

## Test plan

- [x] Builds clean (`xb build --config=release`), `xb format` / `xb lint --origin` report no issues
- [x] Confirmed the bug's existence and mechanism via `snd_pcm_get_chmap()` against the real device Xenia opens
- [x] Verified the fix resolves the issue on real 5.1 hardware: center-channel dialogue/audio now correctly comes from the center speaker instead of rear-left
- [x] Reproduced on two titles from different console-generation eras before the fix, confirming it isn't game-specific