### PR TITLE
[GPU] Round normalized unsigned fixed fetches

### DIFF
--- a/src/xenia/gpu/dxbc_shader_translator.h
+++ b/src/xenia/gpu/dxbc_shader_translator.h
@@ -418,6 +418,7 @@ class DxbcShaderTranslator : public ShaderTranslator {
     // bits 0:3 = component_bits - 1
     // bit 4 = signed
     // bit 5 = unsigned-biased
+    // bit 24 = normalized
     // Zero means no scale.
     uint32_t texture_integer_scale_bits[32];
 

--- a/src/xenia/gpu/dxbc_shader_translator_fetch.cc
+++ b/src/xenia/gpu/dxbc_shader_translator_fetch.cc
@@ -2241,19 +2241,15 @@ void DxbcShaderTranslator::ProcessTextureFetchInstruction(
       }
       // num_format is applied after signedness. A fixed-point format's host
       // view returns normalized values, so for an integer num_format restore
-      // the guest integer range here.
-      uint32_t integer_scale_bits_temp = PushSystemTemp();
+      // the guest integer range here. Bit 24 requests rounding for normalized
+      // unsigned values.
       uint32_t integer_scale_temp = PushSystemTemp();
-      uint32_t integer_scale_flags_temp = PushSystemTemp();
-      dxbc::Dest integer_scale_bits_dest(dxbc::Dest::R(
-          integer_scale_bits_temp, used_result_nonzero_components));
-      dxbc::Src integer_scale_bits_src(dxbc::Src::R(integer_scale_bits_temp));
       dxbc::Dest integer_scale_dest(
           dxbc::Dest::R(integer_scale_temp, used_result_nonzero_components));
       dxbc::Src integer_scale_src(dxbc::Src::R(integer_scale_temp));
-      dxbc::Dest integer_scale_flags_dest(dxbc::Dest::R(
-          integer_scale_flags_temp, used_result_nonzero_components));
-      dxbc::Src integer_scale_flags_src(dxbc::Src::R(integer_scale_flags_temp));
+      dxbc::Dest integer_scale_flags_dest(
+          dxbc::Dest::R(signs_temp, used_result_nonzero_components));
+      dxbc::Src integer_scale_flags_src(dxbc::Src::R(signs_temp));
       dxbc::Src integer_scale_bits_packed = LoadSystemConstant(
           SystemConstants::Index::kTextureIntegerScaleBits,
           offsetof(SystemConstants, texture_integer_scale_bits) +
@@ -2262,12 +2258,25 @@ void DxbcShaderTranslator::ProcessTextureFetchInstruction(
       // Uniform early out. Zero means leave the sample alone. Only integer
       // num_format on fixed textures has scale bits.
       a_.OpIf(true, integer_scale_bits_packed);
-      a_.OpUBFE(integer_scale_bits_dest, dxbc::Src::LU(6),
+      a_.OpAnd(dxbc::Dest::R(signs_temp, 0b0001), integer_scale_bits_packed,
+               dxbc::Src::LU(UINT32_C(1) << 24));
+      a_.OpIf(true, dxbc::Src::R(signs_temp, dxbc::Src::kXXXX));
+      // Round normalized results to 16 fractional bits.
+      a_.OpMul(
+          dxbc::Dest::R(system_temp_result_, used_result_nonzero_components),
+          dxbc::Src::R(system_temp_result_), dxbc::Src::LF(65536.0f));
+      a_.OpRoundNE(
+          dxbc::Dest::R(system_temp_result_, used_result_nonzero_components),
+          dxbc::Src::R(system_temp_result_));
+      a_.OpMul(
+          dxbc::Dest::R(system_temp_result_, used_result_nonzero_components),
+          dxbc::Src::R(system_temp_result_), dxbc::Src::LF(1.0f / 65536.0f));
+      a_.OpElse();
+      a_.OpUBFE(integer_scale_dest, dxbc::Src::LU(4),
                 dxbc::Src::LU(0, 6, 12, 18), integer_scale_bits_packed);
-      a_.OpAnd(integer_scale_dest, integer_scale_bits_src, dxbc::Src::LU(0xF));
       a_.OpIAdd(integer_scale_dest, integer_scale_src, dxbc::Src::LU(1));
-      a_.OpUBFE(integer_scale_flags_dest, dxbc::Src::LU(1), dxbc::Src::LU(4),
-                integer_scale_bits_src);
+      a_.OpUBFE(integer_scale_flags_dest, dxbc::Src::LU(1),
+                dxbc::Src::LU(4, 10, 16, 22), integer_scale_bits_packed);
       a_.OpIAdd(integer_scale_dest, integer_scale_src,
                 -integer_scale_flags_src);
       a_.OpIShL(integer_scale_dest, dxbc::Src::LU(1), integer_scale_src);
@@ -2276,19 +2285,20 @@ void DxbcShaderTranslator::ProcessTextureFetchInstruction(
       // Unsigned biased samples are already mapped from [0, 1] to [-1, 1], so
       // use half of the unsigned scale and subtract 0.5 to restore the guest's
       // integer value.
-      a_.OpUBFE(integer_scale_bits_dest, dxbc::Src::LU(1), dxbc::Src::LU(5),
-                integer_scale_bits_src);
-      a_.OpMovC(integer_scale_flags_dest, integer_scale_bits_src,
+      a_.OpUBFE(integer_scale_flags_dest, dxbc::Src::LU(1),
+                dxbc::Src::LU(5, 11, 17, 23), integer_scale_bits_packed);
+      a_.OpMovC(integer_scale_flags_dest, integer_scale_flags_src,
                 dxbc::Src::LF(0.5f), dxbc::Src::LF(1.0f));
       a_.OpMul(integer_scale_dest, integer_scale_src, integer_scale_flags_src);
-      a_.OpMovC(integer_scale_flags_dest, integer_scale_bits_src,
-                dxbc::Src::LF(-0.5f), dxbc::Src::LF(0.0f));
+      a_.OpAdd(integer_scale_flags_dest, integer_scale_flags_src,
+               dxbc::Src::LF(-1.0f));
       a_.OpMAd(
           dxbc::Dest::R(system_temp_result_, used_result_nonzero_components),
           dxbc::Src::R(system_temp_result_), integer_scale_src,
           integer_scale_flags_src);
       a_.OpEndIf();
-      PopSystemTemp(3);
+      a_.OpEndIf();
+      PopSystemTemp();
     }
     if (signs_temp != UINT32_MAX) {
       PopSystemTemp();

--- a/src/xenia/gpu/spirv_shader_translator.h
+++ b/src/xenia/gpu/spirv_shader_translator.h
@@ -312,6 +312,7 @@ class SpirvShaderTranslator : public ShaderTranslator {
     // bits 0:3 = component_bits - 1
     // bit 4 = signed
     // bit 5 = unsigned-biased
+    // bit 24 = normalized
     // Zero means no scale.
     uint32_t texture_integer_scale_bits[32];
   };

--- a/src/xenia/gpu/spirv_shader_translator_fetch.cc
+++ b/src/xenia/gpu/spirv_shader_translator_fetch.cc
@@ -2545,7 +2545,8 @@ void SpirvShaderTranslator::ProcessTextureFetchInstruction(
 
         // num_format is applied after signs/gamma. Fixed textures sample as
         // normalized host values, so integer num_format scales them back to
-        // guest integer units here.
+        // guest integer units here. Bit 24 requests rounding for normalized
+        // unsigned values.
         id_vector_temp_.clear();
         id_vector_temp_.push_back(
             builder_->makeIntConstant(kSystemConstantTextureIntegerScaleBits));
@@ -2558,6 +2559,10 @@ void SpirvShaderTranslator::ProcessTextureFetchInstruction(
                                         uniform_system_constants_,
                                         id_vector_temp_),
             spv::NoPrecision);
+        id_vector_temp_.clear();
+        id_vector_temp_.insert(id_vector_temp_.cend(), result, result + 4);
+        spv::Id integer_scale_result =
+            builder_->createCompositeConstruct(type_float4_, id_vector_temp_);
         {
           // Uniform early out. Zero means leave the sample alone. Only integer
           // num_format on fixed textures has scale bits.
@@ -2566,78 +2571,114 @@ void SpirvShaderTranslator::ProcessTextureFetchInstruction(
               builder_->makeUintConstant(0));
           SpirvBuilder::IfBuilder if_integer_scale(
               integer_scale_active, spv::SelectionControlMaskNone, *builder_);
-          spv::Id scaled_result[4] = {};
+          spv::Id integer_scale_result_converted;
           {
+            spv::Id normalized = builder_->createBinOp(
+                spv::OpINotEqual, type_bool_,
+                builder_->createBinOp(
+                    spv::OpBitwiseAnd, type_uint_, integer_scale_bits_packed,
+                    builder_->makeUintConstant(UINT32_C(1) << 24)),
+                builder_->makeUintConstant(0));
+            SpirvBuilder::IfBuilder if_normalized(
+                normalized, spv::SelectionControlMaskNone, *builder_);
+            spv::Id normalized_result = builder_->createNoContractionBinOp(
+                spv::OpVectorTimesScalar, type_float4_, integer_scale_result,
+                builder_->makeFloatConstant(65536.0f));
+            normalized_result = builder_->createUnaryBuiltinCall(
+                type_float4_, ext_inst_glsl_std_450_, GLSLstd450RoundEven,
+                normalized_result);
+            normalized_result = builder_->createNoContractionBinOp(
+                spv::OpVectorTimesScalar, type_float4_, normalized_result,
+                builder_->makeFloatConstant(1.0f / 65536.0f));
+            if_normalized.makeBeginElse();
             spv::Id const_uint_1 = builder_->makeUintConstant(1);
-            uint32_t result_remaining_components =
-                used_result_nonzero_components;
-            uint32_t result_component_index;
-            while (xe::bit_scan_forward(result_remaining_components,
-                                        &result_component_index)) {
-              result_remaining_components &=
-                  ~(UINT32_C(1) << result_component_index);
-              spv::Id scale_bits = builder_->createTriOp(
-                  spv::OpBitFieldUExtract, type_uint_,
-                  integer_scale_bits_packed,
-                  builder_->makeUintConstant(result_component_index * 6),
-                  builder_->makeUintConstant(6));
-              spv::Id scale_shift = builder_->createBinOp(
-                  spv::OpIAdd, type_uint_,
-                  builder_->createBinOp(spv::OpBitwiseAnd, type_uint_,
-                                        scale_bits,
-                                        builder_->makeUintConstant(0xF)),
-                  const_uint_1);
-              scale_shift = builder_->createBinOp(
-                  spv::OpISub, type_uint_, scale_shift,
-                  builder_->createTriOp(spv::OpBitFieldUExtract, type_uint_,
-                                        scale_bits,
-                                        builder_->makeUintConstant(4),
-                                        builder_->makeUintConstant(1)));
-              spv::Id scale_uint = builder_->createBinOp(
-                  spv::OpISub, type_uint_,
-                  builder_->createBinOp(spv::OpShiftLeftLogical, type_uint_,
-                                        const_uint_1, scale_shift),
-                  const_uint_1);
-              // Unsigned biased samples are already mapped [0, 1] to [-1, 1],
-              // so use half of the unsigned scale and subtract 0.5 to restore
-              // the guest's integer value.
-              spv::Id biased = builder_->createBinOp(
-                  spv::OpINotEqual, type_bool_,
-                  builder_->createTriOp(spv::OpBitFieldUExtract, type_uint_,
-                                        scale_bits,
-                                        builder_->makeUintConstant(5),
-                                        builder_->makeUintConstant(1)),
-                  builder_->makeUintConstant(0));
-              spv::Id scale_float = builder_->createNoContractionBinOp(
-                  spv::OpFMul, type_float_,
-                  builder_->createUnaryOp(spv::OpConvertUToF, type_float_,
-                                          scale_uint),
-                  builder_->createTriOp(spv::OpSelect, type_float_, biased,
-                                        builder_->makeFloatConstant(0.5f),
-                                        builder_->makeFloatConstant(1.0f)));
-              scaled_result[result_component_index] =
-                  builder_->createNoContractionBinOp(
-                      spv::OpFAdd, type_float_,
-                      builder_->createNoContractionBinOp(
-                          spv::OpFMul, type_float_,
-                          result[result_component_index], scale_float),
-                      builder_->createTriOp(spv::OpSelect, type_float_, biased,
-                                            builder_->makeFloatConstant(-0.5f),
-                                            builder_->makeFloatConstant(0.0f)));
+            id_vector_temp_.clear();
+            for (uint32_t i = 0; i < 4; ++i) {
+              id_vector_temp_.push_back(builder_->makeUintConstant(i * 6));
             }
+            spv::Id scale_bits = builder_->createBinOp(
+                spv::OpShiftRightLogical, type_uint4_,
+                builder_->smearScalar(spv::NoPrecision,
+                                      integer_scale_bits_packed, type_uint4_),
+                builder_->makeCompositeConstant(type_uint4_, id_vector_temp_));
+            scale_bits = builder_->createBinOp(
+                spv::OpBitwiseAnd, type_uint4_, scale_bits,
+                builder_->smearScalar(spv::NoPrecision,
+                                      builder_->makeUintConstant(0x3F),
+                                      type_uint4_));
+            spv::Id const_uint4_1 = builder_->smearScalar(
+                spv::NoPrecision, const_uint_1, type_uint4_);
+            spv::Id scale_shift = builder_->createBinOp(
+                spv::OpIAdd, type_uint4_,
+                builder_->createBinOp(
+                    spv::OpBitwiseAnd, type_uint4_, scale_bits,
+                    builder_->smearScalar(spv::NoPrecision,
+                                          builder_->makeUintConstant(0xF),
+                                          type_uint4_)),
+                const_uint4_1);
+            scale_shift = builder_->createBinOp(
+                spv::OpISub, type_uint4_, scale_shift,
+                builder_->createBinOp(
+                    spv::OpBitwiseAnd, type_uint4_,
+                    builder_->createBinOp(
+                        spv::OpShiftRightLogical, type_uint4_, scale_bits,
+                        builder_->smearScalar(spv::NoPrecision,
+                                              builder_->makeUintConstant(4),
+                                              type_uint4_)),
+                    const_uint4_1));
+            spv::Id scale_uint = builder_->createBinOp(
+                spv::OpISub, type_uint4_,
+                builder_->createBinOp(spv::OpShiftLeftLogical, type_uint4_,
+                                      const_uint4_1, scale_shift),
+                const_uint4_1);
+            // Unsigned biased samples are already mapped [0, 1] to [-1, 1],
+            // so use half of the unsigned scale and subtract 0.5 to restore
+            // the guest's integer value.
+            spv::Id biased = builder_->createBinOp(
+                spv::OpINotEqual, type_bool4_,
+                builder_->createBinOp(
+                    spv::OpBitwiseAnd, type_uint4_,
+                    builder_->createBinOp(
+                        spv::OpShiftRightLogical, type_uint4_, scale_bits,
+                        builder_->smearScalar(spv::NoPrecision,
+                                              builder_->makeUintConstant(5),
+                                              type_uint4_)),
+                    const_uint4_1),
+                const_uint4_0_);
+            spv::Id scale_float = builder_->createTriOp(
+                spv::OpSelect, type_float4_, biased,
+                builder_->smearScalar(spv::NoPrecision,
+                                      builder_->makeFloatConstant(0.5f),
+                                      type_float4_),
+                const_float4_1_);
+            spv::Id scaled_result = builder_->createNoContractionBinOp(
+                spv::OpFAdd, type_float4_,
+                builder_->createNoContractionBinOp(
+                    spv::OpFMul, type_float4_, integer_scale_result,
+                    builder_->createNoContractionBinOp(
+                        spv::OpFMul, type_float4_,
+                        builder_->createUnaryOp(spv::OpConvertUToF,
+                                                type_float4_, scale_uint),
+                        scale_float)),
+                builder_->createNoContractionBinOp(
+                    spv::OpFSub, type_float4_, scale_float, const_float4_1_));
+            if_normalized.makeEndIf();
+            integer_scale_result_converted =
+                if_normalized.createMergePhi(normalized_result, scaled_result);
           }
           if_integer_scale.makeEndIf();
           // Keep the original result when the scale branch is skipped.
-          uint32_t result_remaining_components = used_result_nonzero_components;
-          uint32_t result_component_index;
-          while (xe::bit_scan_forward(result_remaining_components,
-                                      &result_component_index)) {
-            result_remaining_components &=
-                ~(UINT32_C(1) << result_component_index);
-            result[result_component_index] = if_integer_scale.createMergePhi(
-                scaled_result[result_component_index],
-                result[result_component_index]);
-          }
+          integer_scale_result = if_integer_scale.createMergePhi(
+              integer_scale_result_converted, integer_scale_result);
+        }
+        uint32_t result_remaining_components = used_result_nonzero_components;
+        uint32_t result_component_index;
+        while (xe::bit_scan_forward(result_remaining_components,
+                                    &result_component_index)) {
+          result_remaining_components &=
+              ~(UINT32_C(1) << result_component_index);
+          result[result_component_index] = builder_->createCompositeExtract(
+              integer_scale_result, type_float_, result_component_index);
         }
 
         // Apply the exponent bias from the bits 13:18 of the fetch constant

--- a/src/xenia/gpu/texture_cache.cc
+++ b/src/xenia/gpu/texture_cache.cc
@@ -694,17 +694,20 @@ TextureCache::Texture* TextureCache::FindOrCreateTexture(TextureKey key) {
 // last stored channel the same way the host swizzle expands the formats.
 // (k_16 has a 16 bit width in all four components, k_5_6_5 gives blue in W.)
 // Constant (0/1) lanes, gamma, and non-fixed formats have nothing to rescale
-// and stay 0.
+// and stay 0. Bit 24 for normalized fixed fetches.
 uint32_t TextureCache::GetIntegerScaleBits(xenos::TextureFormat guest_format,
                                            uint32_t num_format,
                                            uint32_t guest_swizzle,
                                            uint8_t swizzled_signs) {
-  // num_format 0 is the normalized/fractional fetch - nothing to rescale.
   const FormatInfo& format_info = *FormatInfo::Get(guest_format);
   uint32_t scale_bits = 0;
 
-  if (!num_format || !format_info.fixed) {
+  if (!format_info.fixed) {
     return 0;
+  }
+
+  if (!num_format) {
+    return swizzled_signs == kSwizzledSignsUnsigned ? UINT32_C(1) << 24 : 0;
   }
 
   uint32_t last_stored_component = 0;

--- a/src/xenia/gpu/texture_cache.h
+++ b/src/xenia/gpu/texture_cache.h
@@ -523,6 +523,7 @@ class TextureCache {
   struct TextureBinding {
     TextureKey key;
     // Packed integer scale, 6 bits per component.
+    // Bit 24 for normalized values.
     uint32_t integer_scale_bits;
     // Destination swizzle merged with guest to host format swizzle.
     uint32_t host_swizzle;


### PR DESCRIPTION
Proposed alternative to #1158, tackling the same broken AO mask blending in [4D5309C9](https://github.com/xenia-canary/game-compatibility/issues/30) & [4D530AA4](https://github.com/xenia-canary/game-compatibility/issues/111) as a pure fetch issue and building off of the existing fixed integer scales without introducing any tracking and watches.

Giving @michaeloliverx co-author credit.