### PR TITLE
[Memory] Fix large-alignment physical allocs through offset-translated heaps

### DIFF
--- a/src/xenia/base/testing/physical_heap_test.cc
+++ b/src/xenia/base/testing/physical_heap_test.cc
@@ -161,17 +161,21 @@ TEST_CASE("PhysicalHeap vE0000000 alignment", "[memory]") {
     REQUIRE(translation_offset % heap.page_size() == 0);
   }
 
-  SECTION("alloc with alignment larger than page_size is rejected") {
-    // vE0000000 has a 0x1000 physical translation offset, so a 64KB
-    // alignment request can't produce a 64KB-aligned guest address.
-    // PhysicalHeap::Alloc forces top-down, which here lands one stride
-    // past the end of the child heap and BaseHeap::AllocFixed rejects
-    // it as out of range.
+  SECTION("alloc with alignment larger than page_size succeeds aligned") {
+    // vE0000000 has a 0x1000 physical translation offset, so a naive
+    // 0-phase search of the parent heap can never land on a candidate that
+    // translates to a 64KB-aligned guest address (it's always short by
+    // exactly 0x1000, mod 0x10000). PhysicalHeap::Alloc passes an
+    // alignment_phase of physical_base % alignment through to the parent
+    // search to compensate, so this now succeeds with a correctly aligned
+    // address instead of failing.
     uint32_t alignment = 0x10000;  // 64KB
     uint32_t addr = 0;
     bool ok = heap.Alloc(0x10000, alignment, kMemoryAllocationReserve,
                          kMemoryProtectRead, false, &addr);
-    REQUIRE_FALSE(ok);
+    REQUIRE(ok);
+    REQUIRE(addr % alignment == 0);
+    REQUIRE(addr >= 0xE0000000);
   }
 }
 
@@ -193,12 +197,12 @@ TEST_CASE("PhysicalHeap vE0000000 AllocRange alignment", "[memory]") {
     REQUIRE(addr % 0x1000 == 0);
   }
 
-  SECTION("AllocRange with large alignment succeeds via bottom-up") {
-    // Bottom-up search picks a low parent address that translates to a
-    // guest address inside the child heap, so BaseHeap::AllocFixed accepts
-    // it. The PhysicalHeap alignment check is host-based
-    // ((addr + host_address_offset_) % alignment), so the misalignment of
-    // the guest address itself is not rejected here.
+  SECTION("AllocRange with large alignment succeeds correctly aligned") {
+    // PhysicalHeap::AllocRange passes physical_base % alignment through to
+    // the parent search as its alignment_phase, so both bottom-up and
+    // top-down now land on a parent address that translates back to a
+    // properly aligned child address instead of one that merely happens to
+    // fall inside heap bounds.
     uint32_t alignment = 0x10000;
     uint32_t addr = 0;
     bool ok = heap.AllocRange(0xE0000000, 0xFFFCFFFF, 0x10000, alignment,
@@ -206,6 +210,25 @@ TEST_CASE("PhysicalHeap vE0000000 AllocRange alignment", "[memory]") {
                               false, &addr);
     REQUIRE(ok);
     REQUIRE(addr >= 0xE0000000);
+    REQUIRE(addr % alignment == 0);
+  }
+
+  SECTION("32KB-aligned 2.5MB allocation through the 4KB-page vE0000000 heap") {
+    // Regression test for a guest MmAllocatePhysicalMemoryEx call observed
+    // in title 4D5307F1: a 0x280000-byte request at 0x8000 (32KB) alignment
+    // routed through the 4KB-page physical heap. Before the alignment_phase
+    // fix this failed deterministically (not as a rare collision) because
+    // the 0x1000 translation offset made a 0-phase parent search unable to
+    // produce any 32KB-aligned child address; the guest received a null
+    // pointer and faulted downstream on it.
+    uint32_t alignment = 0x8000;
+    uint32_t addr = 0;
+    bool ok = heap.AllocRange(0xE0000000, 0xFFFCFFFF, 0x280000, alignment,
+                              kMemoryAllocationReserve, kMemoryProtectRead,
+                              true, &addr);
+    REQUIRE(ok);
+    REQUIRE(addr >= 0xE0000000);
+    REQUIRE(addr % alignment == 0);
   }
 }
 

--- a/src/xenia/memory.cc
+++ b/src/xenia/memory.cc
@@ -1180,7 +1180,8 @@ static inline T QuickMod(T value, uint32_t modv) {
 bool BaseHeap::AllocRange(uint32_t low_address, uint32_t high_address,
                           uint32_t size, uint32_t alignment,
                           uint32_t allocation_type, uint32_t protect,
-                          bool top_down, uint32_t* out_address) {
+                          bool top_down, uint32_t* out_address,
+                          uint32_t alignment_phase) {
   *out_address = 0;
 
   alignment = xe::round_up(alignment, page_size_);
@@ -1203,10 +1204,18 @@ bool BaseHeap::AllocRange(uint32_t low_address, uint32_t high_address,
   auto global_lock = global_critical_region_.Acquire();
 
   // Find a free page range using the free block tracker.
-  // The base page must match the requested alignment.
+  // The base page must match the requested alignment, shifted by
+  // alignment_phase (see the declaration comment in memory.h).
   uint32_t start_page_number = UINT_MAX;
   uint32_t end_page_number = UINT_MAX;
   uint32_t page_scan_stride = alignment >> page_size_shift_;
+  uint32_t phase_pages = alignment_phase >> page_size_shift_;
+  // The phase-shifted stride math below assumes a power-of-two stride (it
+  // relies on QuickMod's mask path to fold the unsigned wraparound). Only
+  // PhysicalHeap passes a non-zero phase, and only ever with power-of-two
+  // alignments, so this holds there. When phase_pages == 0 the alignment
+  // search stays bit-for-bit identical to the unshifted original.
+  assert_true(phase_pages == 0 || xe::is_pow2(page_scan_stride));
 
   if (top_down) {
     // Search free blocks from high addresses downward.
@@ -1229,17 +1238,19 @@ bool BaseHeap::AllocRange(uint32_t low_address, uint32_t high_address,
       }
 
       // Compute the highest aligned start within this block and range.
-      // high_page_number is exclusive and rounded down to the stride, so
-      // the top stride of pages is never returned.
+      // high_page_number is exclusive and rounded down to a stride boundary
+      // (offset by phase_pages), so the top stride of pages is never
+      // returned. With phase_pages == 0 this is the plain round-down.
       uint32_t high_aligned =
-          high_page_number - QuickMod(high_page_number, page_scan_stride);
+          high_page_number -
+          QuickMod(high_page_number - phase_pages, page_scan_stride);
       uint32_t usable_end = std::min(block_end, high_aligned);
       if (usable_end < page_count) {
         continue;
       }
       uint32_t latest_start = usable_end - page_count;
-      // Align down to stride.
-      latest_start -= QuickMod(latest_start, page_scan_stride);
+      // Align down to stride (phase-shifted).
+      latest_start -= QuickMod(latest_start - phase_pages, page_scan_stride);
       uint32_t usable_start = std::max(block_start, low_page_number);
       if (latest_start >= usable_start &&
           latest_start + page_count <= block_end) {
@@ -1277,7 +1288,17 @@ bool BaseHeap::AllocRange(uint32_t low_address, uint32_t high_address,
       // high_page_number is treated as exclusive — the page at
       // high_page_number itself is never returned.
       uint32_t earliest = std::max(block_start, low_page_number);
-      uint32_t aligned_start = xe::round_up(earliest, page_scan_stride, false);
+      // Phase-shifted round-up: smallest x >= earliest with
+      // x % page_scan_stride == phase_pages. For the common phase_pages == 0
+      // case this is exactly xe::round_up(earliest, page_scan_stride), kept
+      // verbatim so non-PhysicalHeap callers (which may pass a non-power-of-
+      // two stride) are unaffected. The shifted form relies on QuickMod's
+      // mask path folding the unsigned wraparound in (phase_pages - earliest)
+      // and is only reached with power-of-two strides (see assert above).
+      uint32_t aligned_start =
+          phase_pages == 0
+              ? xe::round_up(earliest, page_scan_stride, false)
+              : earliest + QuickMod(phase_pages - earliest, page_scan_stride);
       if (aligned_start + page_count <= block_end &&
           aligned_start + page_count <= high_page_number) {
         start_page_number = aligned_start;
@@ -1800,9 +1821,16 @@ bool PhysicalHeap::Alloc(uint32_t size, uint32_t alignment,
   uint32_t parent_heap_start = GetPhysicalAddress(heap_base_);
   uint32_t parent_heap_end = GetPhysicalAddress(heap_base_ + (heap_size_ - 1));
   uint32_t parent_address;
-  if (!parent_heap_->AllocRange(parent_heap_start, parent_heap_end, size,
-                                alignment, allocation_type, protect, top_down,
-                                &parent_address)) {
+  // parent_heap_start (this heap's own physical base offset, e.g. 0x1000 for
+  // 0xE0000000) is the residue a parent-heap address must hit for the
+  // translation below to land back on an alignment-satisfying child address.
+  // Without this, the parent search returns addresses 0-mod-alignment, which
+  // translate to child addresses that are unconditionally
+  // (alignment - parent_heap_start)-mod-alignment instead -- never 0 for any
+  // alignment greater than parent_heap_start.
+  if (!parent_heap_->AllocRange(
+          parent_heap_start, parent_heap_end, size, alignment, allocation_type,
+          protect, top_down, &parent_address, parent_heap_start % alignment)) {
     XELOGE(
         "PhysicalHeap::Alloc unable to alloc physical memory in parent heap "
         "(requested {} bytes, parent free {}/{} pages)",
@@ -1882,7 +1910,11 @@ bool PhysicalHeap::AllocFixed(uint32_t base_address, uint32_t size,
 bool PhysicalHeap::AllocRange(uint32_t low_address, uint32_t high_address,
                               uint32_t size, uint32_t alignment,
                               uint32_t allocation_type, uint32_t protect,
-                              bool top_down, uint32_t* out_address) {
+                              bool top_down, uint32_t* out_address,
+                              uint32_t /* alignment_phase */) {
+  // An incoming alignment_phase is ignored: this override always allocates
+  // through the parent heap and derives the phase the translation requires
+  // itself (below), so a caller-supplied phase would have no coherent meaning.
   *out_address = 0;
 
   // Adjust alignment size our page size differs from the parent.
@@ -1897,9 +1929,14 @@ bool PhysicalHeap::AllocRange(uint32_t low_address, uint32_t high_address,
   uint32_t parent_low_address = GetPhysicalAddress(low_address);
   uint32_t parent_high_address = GetPhysicalAddress(high_address);
   uint32_t parent_address;
+  // See the matching comment in PhysicalHeap::Alloc: the parent search must
+  // target the phase this heap's physical base offset requires, not 0, or
+  // the translated child address below can never satisfy the alignment
+  // check for any alignment greater than that offset.
   if (!parent_heap_->AllocRange(parent_low_address, parent_high_address, size,
                                 alignment, allocation_type, protect, top_down,
-                                &parent_address)) {
+                                &parent_address,
+                                GetPhysicalAddress(heap_base_) % alignment)) {
     XELOGE(
         "PhysicalHeap::AllocRange unable to alloc physical memory in parent "
         "heap (requested {} bytes, parent free {}/{} pages)",

--- a/src/xenia/memory.h
+++ b/src/xenia/memory.h
@@ -180,10 +180,18 @@ class BaseHeap {
   // Allocates pages at an address within the given address range.
   // This can reserve and commit the pages as well as set protection modes.
   // This will fail if not enough contiguous pages can be found.
+  // alignment_phase shifts the alignment grid the search scans: the returned
+  // address satisfies (address - heap_base_) % alignment == alignment_phase
+  // instead of == 0. Used by PhysicalHeap to compensate for a heap-specific
+  // constant offset between its own addressing and its parent heap's, so
+  // the parent search lands on a page that translates back to a correctly
+  // aligned child address. Must be a multiple of page_size_ and < alignment;
+  // 0 (the default) reproduces the original phase-0 behavior exactly.
   virtual bool AllocRange(uint32_t low_address, uint32_t high_address,
                           uint32_t size, uint32_t alignment,
                           uint32_t allocation_type, uint32_t protect,
-                          bool top_down, uint32_t* out_address);
+                          bool top_down, uint32_t* out_address,
+                          uint32_t alignment_phase = 0);
 
   virtual bool AllocSystemHeap(uint32_t size, uint32_t alignment,
                                uint32_t allocation_type, uint32_t protect,
@@ -290,8 +298,8 @@ class PhysicalHeap : public BaseHeap {
                   uint32_t allocation_type, uint32_t protect) override;
   bool AllocRange(uint32_t low_address, uint32_t high_address, uint32_t size,
                   uint32_t alignment, uint32_t allocation_type,
-                  uint32_t protect, bool top_down,
-                  uint32_t* out_address) override;
+                  uint32_t protect, bool top_down, uint32_t* out_address,
+                  uint32_t alignment_phase = 0) override;
   bool AllocSystemHeap(uint32_t size, uint32_t alignment,
                        uint32_t allocation_type, uint32_t protect,
                        bool top_down, uint32_t* out_address) override;


### PR DESCRIPTION
## Problem

`PhysicalHeap::Alloc` / `PhysicalHeap::AllocRange` satisfy a request by allocating
in the parent (0–512 MB physical) heap and translating the result back into the
child heap's address space. The child's address space is offset from the parent's
by a fixed per-heap constant — for the `0xE0000000` heap that offset is `0x1000`
(`GetPhysicalAddress(0xE0000000) == 0x1000`), 4 KB-aligned but not 64 KB-aligned.

`BaseHeap::AllocRange`'s free-block search only ever returns addresses that are
`0 mod alignment`. After the child translation subtracts the `0x1000` offset,
the address handed back to the guest is `(alignment - 0x1000) mod alignment` —
**never `0 mod alignment` for any alignment greater than `0x1000`.**

For a `0x1000`-page physical heap this means:

* `PhysicalHeap::Alloc` (forced top-down) gets a parent address back, translates
  it to a misaligned child address, and returns `false` at its own
  `(address + host_address_offset_) % alignment != 0` guard.
* `PhysicalHeap::AllocRange` returns a child address that is inside the heap
  bounds but misaligned in guest terms. That same guard only checks the *host*
  address; `host_address_offset_` is `0` on Linux so it happens to catch the
  misalignment here, but a build with a non-zero offset can let it through. The
  section comment in the existing test already notes this.

### Repro

Observed from a guest `MmAllocatePhysicalMemoryEx` call in title `4D5307F1`:
`0x280000` bytes at `0x8000` (32 KB) alignment, routed through the 4 KB-page
`0xE0000000` heap. The parent search cannot produce a candidate that translates
to a 32 KB-aligned child address, the allocation fails deterministically (~3,800
`AllocFixed attempting to reserve an already reserved range` retries first,
then `Allocation failed`), `MmAllocatePhysicalMemoryEx` returns null, and the
guest faults on the null pointer downstream. The failure is 100% reproducible,
not a fragmentation-dependent collision.

## Fix

Add an optional `alignment_phase` parameter to `BaseHeap::AllocRange`
(default `0`). The free-block search then targets addresses satisfying
`(address - heap_base_) % alignment == alignment_phase` instead of `== 0`.

`PhysicalHeap::Alloc` and `PhysicalHeap::AllocRange` pass
`physical_base_offset % alignment` as the phase, so the parent-heap candidate,
once translated, lands on a correctly aligned child address.

* `alignment_phase == 0` keeps the search **bit-for-bit identical** to the
  current behavior:
  * top-down: `QuickMod(x - phase, stride)` with `phase == 0` is the existing
    `QuickMod(x, stride)`.
  * bottom-up: the `phase == 0` branch calls the existing
    `xe::round_up(earliest, page_scan_stride, false)` verbatim. The shifted
    form is only evaluated for `phase != 0`.
* The shifted form assumes a power-of-two `page_scan_stride` (it relies on
  `QuickMod`'s mask path to fold the unsigned wraparound). Only `PhysicalHeap`
  passes a non-zero phase, and only with power-of-two alignments, so this holds;
  an `assert_true` documents and guards the precondition. Non-`PhysicalHeap`
  callers that pass non-power-of-two alignments are unaffected because they never
  leave the `phase == 0` path.
* `PhysicalHeap::AllocRange` ignores an incoming `alignment_phase` (it always
  routes through the parent and derives the phase itself); a comment notes this.

## Tests

`src/xenia/base/testing/physical_heap_test.cc` was added upstream in `1e834f8`
(@Gliniak). This PR changes two of its sections and adds one.

**1. `TEST_CASE("PhysicalHeap vE0000000 alignment")` — section "alloc with
alignment larger than page_size…"**

- Before: `REQUIRE_FALSE(ok)` — passes on `canary_experimental`. A
  characterization test; its own comment calls the behavior wrong ("can't
  produce a 64KB-aligned guest address").
- After: `REQUIRE(ok)` plus `REQUIRE(addr % alignment == 0)` — the allocation
  now succeeds, aligned. This is a genuine semantic flip: the behavior changed,
  so the assertion inverts.

**2. `TEST_CASE("PhysicalHeap vE0000000 AllocRange alignment")` — section
"AllocRange with large alignment…"**

- Before: `REQUIRE(ok)` — **fails** on `canary_experimental` today
  (`physical_heap_test.cc:207`, red 5/5 runs on a clean checkout). The section
  comment concedes "the misalignment of the guest address itself is not
  rejected here".
- After: same `REQUIRE(ok)`, now green, plus a new `REQUIRE(addr % alignment ==
  0)`. This is a fix for a currently-failing test, not a flip.

**3. New section "32KB-aligned 2.5MB allocation through the 4KB-page vE0000000
heap"** — the title `4D5307F1` repro:
`AllocRange(0xE0000000, 0xFFFCFFFF, 0x280000, 0x8000, …)`, asserting success and
alignment.

### Results

`xb lint --origin` clean. `xb build --build-tests` then `xenia-base-tests`
(Linux x64, Release):

- `[memory]` tag: **6 cases, 45 assertions, 0 failures**, stable over 5 runs;
  all three sections above execute (verified with `-s`). On a clean
  `canary_experimental` the same tag has 1 failure (`physical_heap_test.cc:207`).
- Full `xenia-base-tests`: **75 cases, 0 failures** over 3 runs. (The suite's
  total assertion count fluctuates run to run — timing-dependent cases
  elsewhere — so only the case/failure counts are meaningful here.) A clean
  `canary_experimental` build has 1 failure, the `:207` case above.

## Validation

* Linux x64, Release.
* Boot test on title `4D5307F1` with **this change alone** (no other local
  patches): the previously-deterministic allocation failure is **gone** — zero
  `AllocFixed attempting to reserve an already reserved range` / `Allocation
  failed` lines across the whole run, and no `0x100000000` SIGSEGV / crash dump.
  The title does **not** reach the menu on this change alone — it stalls later
  during guest thread startup (unrelated POSIX alertable-wait / queued-callback
  issue, addressed separately). This PR's scope is the allocator bug and its
  regression test, which stand on their own; full boot of the repro title also
  needs that separate threading fix.
* Regression spot-check (PR-A-only Release build): two other retail titles each
  ran 5–7 min into real content (200%+ CPU, actively rendering audio), with zero
  `Allocation failed` / `already reserved range` lines and no crash.
* **Not tested on Windows** — no Windows environment available. The change is in
  cross-platform code (`src/xenia/memory.cc`); the `phase == 0` fast path is
  argued above to be a no-op for every existing caller, and the physical-heap
  unit tests run on all platforms in CI. Windows review/testing requested.
