### PR TITLE
[Base] POSIX: interrupt an in-progress alertable wait on a queued user callback

### DIFF
--- a/src/xenia/base/threading_posix.cc
+++ b/src/xenia/base/threading_posix.cc
@@ -205,6 +205,31 @@ SleepResult AlertableSleep(std::chrono::microseconds duration) {
   return SleepResult::kSuccess;
 }
 
+class PosixConditionBase;
+
+// Lets Thread::QueueUserCallback interrupt an in-progress alertable
+// PosixConditionBase::Wait, mirroring how a queued APC wakes an alertable
+// wait on Windows. Without this, a callback queued while the target thread
+// is blocked (alertable or not) is never noticed by the wait itself: the
+// wake-up signal has nothing to interrupt, since the underlying condition
+// variable only re-checks its predicate when notified. Owned by the target
+// thread's PosixCondition<Thread> so a callback queued from a different
+// native thread can reach it directly via the WaitHandle it was queued on.
+struct AlertableWaitState {
+  // The PosixConditionBase this thread is currently blocked in, if any and
+  // if that wait is alertable. Set/cleared by PosixConditionBase::Wait.
+  std::atomic<PosixConditionBase*> blocked_on{nullptr};
+  // Sticky until consumed by an alertable wait: sets when queued, so a
+  // callback queued just before the target thread enters its next alertable
+  // wait is not lost even though nothing was there yet to notify.
+  std::atomic<bool> callback_pending{false};
+};
+
+// Points at the running thread's own AlertableWaitState. Set in
+// ThreadStartRoutine/GetCurrentThread so PosixConditionBase::Wait can find
+// it without a cross-thread lookup.
+thread_local AlertableWaitState* current_alertable_wait_state_ = nullptr;
+
 TlsHandle AllocateTlsHandle() {
   auto key = static_cast<pthread_key_t>(-1);
   auto res = pthread_key_create(&key, nullptr);
@@ -243,7 +268,22 @@ class PosixConditionBase {
 
   WaitResult Wait(std::chrono::milliseconds timeout) {
     bool executed;
-    auto predicate = [this] { return this->signaled(); };
+    bool woke_for_callback = false;
+    // Only alertable waits may be interrupted by a queued callback (matches
+    // the alertable flag's meaning for real APC delivery).
+    AlertableWaitState* wait_state =
+        alertable_state_ ? current_alertable_wait_state_ : nullptr;
+    auto predicate = [this, wait_state, &woke_for_callback] {
+      if (this->signaled()) {
+        return true;
+      }
+      if (wait_state &&
+          wait_state->callback_pending.load(std::memory_order_acquire)) {
+        woke_for_callback = true;
+        return true;
+      }
+      return false;
+    };
 
     // Handle robust mutex locking
     auto native_mutex = static_cast<pthread_mutex_t*>(mutex_.native_handle());
@@ -257,6 +297,10 @@ class PosixConditionBase {
 
     std::unique_lock<std::mutex> lock(mutex_, std::adopt_lock);
 
+    if (wait_state) {
+      wait_state->blocked_on.store(this, std::memory_order_release);
+    }
+
     if (predicate()) {
       executed = true;
     } else {
@@ -267,7 +311,16 @@ class PosixConditionBase {
         executed = cond_.wait_for(lock, timeout, predicate);
       }
     }
+
+    if (wait_state) {
+      wait_state->blocked_on.store(nullptr, std::memory_order_release);
+    }
+
     if (executed) {
+      if (woke_for_callback) {
+        wait_state->callback_pending.store(false, std::memory_order_release);
+        return WaitResult::kUserCallback;
+      }
       post_execution();
       return WaitResult::kSuccess;
     }
@@ -293,7 +346,19 @@ class PosixConditionBase {
                         ? std::chrono::steady_clock::time_point::max()
                         : start_time + timeout;
 
+    AlertableWaitState* wait_state =
+        alertable_state_ ? current_alertable_wait_state_ : nullptr;
+
     while (true) {
+      // A queued callback interrupts an alertable multi-wait the same way it
+      // does a single-object Wait() (see AlertableWaitState) -- checked here
+      // rather than via blocked_on/notify since this path already polls.
+      if (wait_state &&
+          wait_state->callback_pending.load(std::memory_order_acquire)) {
+        wait_state->callback_pending.store(false, std::memory_order_release);
+        return std::make_pair(WaitResult::kUserCallback, size_t(0));
+      }
+
       // Check all handles to see if any/all are signaled
       // Use try_lock to avoid deadlocks from lock ordering issues
       size_t first_signaled = std::numeric_limits<size_t>::max();
@@ -387,6 +452,15 @@ class PosixConditionBase {
 
   [[nodiscard]] virtual void* native_handle() const {
     return const_cast<std::condition_variable&>(cond_).native_handle();
+  }
+
+  // Wakes a thread parked in this object's Wait() so it can re-check its
+  // predicate, which is how it notices AlertableWaitState::callback_pending.
+  // Safe to call from any thread's normal execution context (unlike the
+  // pthread_sigqueue-based nudge, this never runs inside a signal handler).
+  void NotifyForUserCallback() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    cond_.notify_all();
   }
 
  protected:
@@ -682,6 +756,8 @@ class PosixCondition<Thread> final : public PosixConditionBase {
 
   bool Signal() override { return true; }
 
+  AlertableWaitState& alertable_wait_state() { return alertable_wait_state_; }
+
   std::string name() const {
     WaitStarted();
     auto result = std::array<char, 17>{'\0'};
@@ -829,8 +905,23 @@ class PosixCondition<Thread> final : public PosixConditionBase {
 
   void QueueUserCallback(std::function<void()> callback) {
     WaitStarted();
-    std::unique_lock lock(callback_mutex_);
-    user_callback_ = std::move(callback);
+    {
+      std::unique_lock lock(callback_mutex_);
+      user_callback_ = std::move(callback);
+    }
+
+    // Sticky-set before checking blocked_on: if the target thread hasn't
+    // entered its wait yet, its next alertable Wait() will see this pending
+    // and return immediately instead of blocking. If it's already blocked,
+    // wake it so it re-checks and picks it up now.
+    alertable_wait_state_.callback_pending.store(true,
+                                                 std::memory_order_release);
+    PosixConditionBase* blocked =
+        alertable_wait_state_.blocked_on.load(std::memory_order_acquire);
+    if (blocked) {
+      blocked->NotifyForUserCallback();
+    }
+
     sigval value{};
     value.sival_ptr = this;
 #if XE_PLATFORM_ANDROID
@@ -998,6 +1089,7 @@ class PosixCondition<Thread> final : public PosixConditionBase {
   mutable std::mutex callback_mutex_;
   mutable std::condition_variable state_signal_;
   std::function<void()> user_callback_;
+  AlertableWaitState alertable_wait_state_;
 #if XE_PLATFORM_ANDROID
   // Name accessible via name() on Android before API 26 which added
   // pthread_getname_np.
@@ -1314,6 +1406,7 @@ void* PosixCondition<Thread>::ThreadStartRoutine(void* parameter) {
   delete start_data;
 
   current_thread_ = thread;
+  current_alertable_wait_state_ = &thread->condition().alertable_wait_state();
   thread->handle_.tid_ = static_cast<pid_t>(syscall(SYS_gettid));
   {
     std::unique_lock lock(thread->handle_.state_mutex_);
@@ -1343,6 +1436,7 @@ void* PosixCondition<Thread>::ThreadStartRoutine(void* parameter) {
     thread->handle_.cond_.notify_all();
   }
 
+  current_alertable_wait_state_ = nullptr;
   current_thread_ = nullptr;
   return nullptr;
 }
@@ -1372,6 +1466,8 @@ Thread* Thread::GetCurrentThread() {
   pthread_t handle = pthread_self();
 
   current_thread_ = new PosixThread(handle);
+  current_alertable_wait_state_ =
+      &current_thread_->condition().alertable_wait_state();
   // TODO(bwrsandman): Disabling deleting thread_local current thread to prevent
   //                   assert in destructor. Since this is thread local, the
   //                   "memory leaking" is controlled.


### PR DESCRIPTION
## Problem

On Windows, queuing an APC to a thread that is sitting in an alertable wait
(`WaitForSingleObjectEx(..., bAlertable=TRUE)` and friends) causes that wait to
return `WAIT_IO_COMPLETION` so the APC can run. The POSIX backend has the
alertable plumbing (`alertable_state_`, the `kThreadUserCallback` signal,
`Thread::QueueUserCallback`) but the wait itself never notices a callback queued
while it is already blocked:

* `PosixConditionBase::Wait` blocks in `std::condition_variable::wait_for` on a
  predicate that only tests `signaled()`. The `kThreadUserCallback` signal
  interrupts the syscall, but `wait_for` just re-evaluates the same predicate and
  goes back to sleep — the callback is not delivered until the wait happens to be
  satisfied for another reason.
* `PosixConditionBase::WaitMultiple` has the same blind spot.
* A callback queued in the window *just before* the target thread enters its next
  alertable wait is lost entirely — nothing is blocked yet to signal.

Guest code that relies on APC-driven wakeups (thread-startup handshakes, some
kernel callback paths) can then stall. Observed as an early boot hang in title
`4D5307F1` that persists even with the physical-heap allocation bug fixed
(#1182): several guest threads spin up, two hit the recurring init-time
`RtlRaiseException`, then the whole process wedges at ~0.15 cores with the log
dead — no crash, no allocation failure.

## Fix

Add a per-thread `AlertableWaitState` (owned by each `PosixCondition<Thread>`,
reached through a `thread_local` pointer set in `ThreadStartRoutine` /
`GetCurrentThread`):

* `std::atomic<bool> callback_pending` — sticky flag, set by
  `QueueUserCallback`. An alertable `Wait` / `WaitMultiple` checks it in its
  predicate / poll loop and, if set, consumes it and returns
  `WaitResult::kUserCallback` instead of continuing to block. Being sticky, a
  callback queued moments before the next alertable wait is still seen.
* `std::atomic<PosixConditionBase*> blocked_on` — set to the condition object
  while an alertable `Wait` is parked, cleared on exit. `QueueUserCallback`,
  after setting `callback_pending`, reads this and calls
  `NotifyForUserCallback()` on that object (a plain `cond_.notify_all()` under
  the mutex) to kick the sleeper so it re-checks. `WaitMultiple` already polls,
  so it needs no notify.

Only alertable waits are affected: `wait_state` is null unless the thread's
`alertable_state_` is set, so non-alertable waits are byte-for-byte unchanged.

### Ordering

`QueueUserCallback` stores `callback_pending` (release) before loading
`blocked_on` (acquire); `Wait` stores `blocked_on` (release) before re-checking
the predicate that loads `callback_pending` (acquire). Either the queuer sees
`blocked_on` and notifies, or the waiter sees `callback_pending` on its next
predicate evaluation under the CV mutex — the sticky flag closes the race in
both directions.

## Scope

* `src/xenia/base/threading_posix.cc` only. This translation unit is POSIX-only
  (`threading_win.cc` is the Windows backend), so **zero Windows surface**.
* No behavior change for non-alertable waits or for threads with no pending
  callback.

## Validation

* Linux x64, Release. `xb lint --origin` clean.
* `xenia-base-tests` full suite on this branch: 75 cases, **1 failure** —
  `physical_heap_test.cc:207`, which is **pre-existing on `canary_experimental`**
  (unrelated to threading; fixed by #1182). Every threading case
  (`[thread]`, `[mutant]`, `[wait]`, `[event]`, `[semaphore]`, `[timer]`,
  `[sleep]`, `Fence`, …) passes, stable across repeated runs. (Suite-wide
  assertion totals fluctuate run to run — timing-dependent cases elsewhere — so
  case and failure counts are the meaningful figures.)
* Clean build of #1182 + this PR (no diagnostic logging): full
  `xenia-base-tests` suite has **0 failures**, and title `4D5307F1` boots past
  the thread-startup stall into menu-asset loading (log reaches
  `\data\scripts\gameface` / `\data\art\gui`, zero `Allocation failed` lines) —
  #1182 alone stalls here.
* An earlier combined build (this fix + the physical-heap fix + diagnostic
  logging) was played into mid-game and, in a prior session, reported clean
  across a 7-title A/B; those logs were not kept, so treat that as indicative
  rather than a preserved result.

## Relationship to #1182

Independent files, independent correctness. Title `4D5307F1` needs both to reach
the menu: #1182 stops the deterministic `MmAllocatePhysicalMemoryEx` failure,
this one unblocks the subsequent thread-startup stall. Either can land first.
