### PR TITLE
[GPU] Don’t drop swizzles from dummy texture headers

### DIFF
--- a/src/xenia/gpu/texture_cache.cc
+++ b/src/xenia/gpu/texture_cache.cc
@@ -999,8 +999,12 @@ void TextureCache::BindingInfoFromFetchConstant(
   texture_util::GetSubresourcesFromFetchConstant(
       fetch, &width_minus_1, &height_minus_1, &depth_or_array_size_minus_1,
       &base_page, &mip_page, nullptr, &mip_max_level);
-  if (base_page == 0 && mip_page == 0) {
-    // No texture data at all.
+  if (base_page == 0 && mip_page == 0 &&
+      (fetch.swizzle & 0b110110110110) != 0b100100100100) {
+    // No texture data at all. Any header taking every swizzle component from
+    // literal 0s or 1s may still be valid. 4D530919 binds one as the dummy
+    // alpha plane of Bink movies. Such examples get a texture with their
+    // dimensions for LOD queries. Zero extents skip the upload and watches.
     return;
   }
   uint32_t pitch = fetch.pitch;


### PR DESCRIPTION
Resolves blended-out FMV and HUD Cortanavision in [4D530919](https://github.com/xenia-canary/game-compatibility/issues/216).
<img width="640" height="360" alt="image" src="https://github.com/user-attachments/assets/79ba9825-296b-4df6-95da-ffb786577520" />
<img width="640" height="360" alt="image" src="https://github.com/user-attachments/assets/5c9073f4-6cc1-4339-a926-8842a633d21f" />
