### PR TITLE
[Base] Fix a lost resume of a thread created suspended on POSIX

### DIFF
--- a/src/xenia/base/threading_posix.cc
+++ b/src/xenia/base/threading_posix.cc
@@ -422,6 +422,12 @@ class PosixCondition<Event> : public PosixConditionBase {
     signal_ = false;
   }
 
+  EventInfo Query() {
+    auto lock = std::unique_lock(mutex_);
+    // EVENT_TYPE: NotificationEvent = 0, SynchronizationEvent = 1.
+    return EventInfo{manual_reset_ ? 0u : 1u, signal_ ? 1u : 0u};
+  }
+
  private:
   [[nodiscard]] bool signaled() const override { return signal_; }
   void post_execution() override {
@@ -1130,11 +1136,7 @@ class PosixEvent final : public PosixConditionHandle<Event> {
   ~PosixEvent() override = default;
   void Set() override { handle_.Signal(); }
   void Reset() override { handle_.Reset(); }
-  EventInfo Query() override {
-    EventInfo result{};
-    assert_always();
-    return result;
-  }
+  EventInfo Query() override { return handle_.Query(); }
   void Pulse() override {
     using namespace std::chrono_literals;
     handle_.Signal();
@@ -1319,14 +1321,23 @@ void* PosixCondition<Thread>::ThreadStartRoutine(void* parameter) {
     std::unique_lock lock(thread->handle_.state_mutex_);
     thread->handle_.state_ =
         create_suspended ? State::kSuspended : State::kRunning;
+    // The initial suspend count has to be published together with the
+    // state, before the notify. Resume() returns from WaitStarted() as soon
+    // as the state is set, and if it took the lock between that and a later
+    // "suspend_count_ = 1" it saw a count of zero, did nothing, and this
+    // thread then waited forever for a resume that had already happened.
+    if (create_suspended) {
+      thread->handle_.suspend_count_ = 1;
+    }
     thread->handle_.state_signal_.notify_all();
   }
 
   if (create_suspended) {
-    std::unique_lock lock(thread->handle_.state_mutex_);
-    thread->handle_.suspend_count_ = 1;
-    thread->handle_.state_signal_.wait(
-        lock, [thread] { return thread->handle_.suspend_count_ == 0; });
+    // Block on the same semaphore Resume() posts when the count reaches
+    // zero. A post that lands before this wait is not lost, and using the
+    // semaphore here means Resume()'s post is consumed rather than left
+    // behind for a later Suspend() to trip over.
+    thread->handle_.WaitSuspended();
   }
 
   start_routine();


### PR DESCRIPTION
On Linux a thread created suspended could miss its first `Resume()`. The new thread announced itself as started before it set its suspend count to 1; a `Resume()` arriving in between found nothing to resume, and the thread then waited forever. Xenia creates every guest thread this way, so a stranded thread meant the game waited forever on something it was never going to get. Windows sets the count atomically in `CreateThread`, so the Windows build never saw it.

The fix sets the count together with the state, and makes the new thread wait on the same semaphore `Resume()` posts, so an early post is not lost.

Also implements `PosixEvent::Query()`, which was `assert_always()`.

Lost Odyssey (4D5307FA) hung on "Loading" in 5 of 10 runs on the native Linux build and in 0 of 10 with this change.
