### PR TITLE
[CPU/X64] Inline FLOAT16_2 pack and unpack

### DIFF
--- a/src/xenia/cpu/backend/x64/x64_seq_vector.cc
+++ b/src/xenia/cpu/backend/x64/x64_seq_vector.cc
@@ -2668,18 +2668,19 @@ struct PERMUTE_V128
 };
 EMITTER_OPCODE_TABLE(OPCODE_PERMUTE, PERMUTE_I32, PERMUTE_V128);
 
-template <typename Inst>
-static void emit_fast_f16_unpack(X64Emitter& e, const Inst& i,
+static void emit_fast_f16_unpack(X64Emitter& e, Xmm dest, Xmm src,
                                  XmmConst initial_shuffle) {
-  auto src1 = i.src1;
+  e.vpshufb(dest, src, e.GetXmmConstPtr(initial_shuffle));
+  e.vpmovsxwd(e.xmm1, dest);
 
-  e.vpshufb(i.dest, src1, e.GetXmmConstPtr(initial_shuffle));
-  e.vpmovsxwd(e.xmm1, i.dest);
-
-  e.vpsrld(e.xmm2, e.xmm1, 10);
-  e.vpmovsxwd(e.xmm0, i.dest);
+  // Isolate half exponent bits 10-14. The source words are sign-extended so
+  // that their sign reaches float bit 31 below; a logical shift plus a broad
+  // byte mask would incorrectly retain those extension bits for negative
+  // denormals and prevent the exponent-zero flush.
+  e.vpslld(e.xmm2, e.xmm1, 17);
+  e.vpsrld(e.xmm2, e.xmm2, 27);
+  e.vpmovsxwd(e.xmm0, dest);
   e.vpand(e.xmm0, e.xmm0, e.GetXmmConstPtr(XMMSignMaskPS));
-  e.vpand(e.xmm2, e.xmm2, e.GetXmmConstPtr(XMMPermuteByteMask));
 
   e.vpslld(e.xmm3, e.xmm2, 23);
 
@@ -2694,22 +2695,29 @@ static void emit_fast_f16_unpack(X64Emitter& e, const Inst& i,
 
   e.vpand(e.xmm1, e.xmm1, e.GetXmmConstPtr(XMMF16UnpackLCPI3));
   e.vpor(e.xmm0, e.xmm1, e.xmm0);
-  e.vpor(i.dest, e.xmm0, e.xmm2);
+  e.vpor(dest, e.xmm0, e.xmm2);
 }
-template <typename Inst>
-static void emit_fast_f16_pack(X64Emitter& e, const Inst& i,
+template <bool kRoundToNearestEven>
+static void emit_fast_f16_pack(X64Emitter& e, Xmm dest, Xmm src,
                                XmmConst final_shuffle) {
-  // XMMF16PackLCPI0 includes bias (0x08000000) + round-half-down (0xFFF).
-  // For round-to-nearest-even, also add the tie-breaker: bit 13 of src.
-  // Bit 13 of (src + bias) == bit 13 of src since the bias doesn't affect
-  // bits 0-26.
-  e.vpaddd(e.xmm1, i.src1, e.GetXmmConstPtr(XMMF16PackLCPI0));
-  e.vpsrld(e.xmm0, i.src1, 13);
-  e.vpslld(e.xmm0, e.xmm0, 31);
-  e.vpsrld(e.xmm0, e.xmm0, 31);
-  e.vpaddd(e.xmm1, e.xmm1, e.xmm0);
+  if constexpr (kRoundToNearestEven) {
+    // XMMF16PackLCPI0 includes bias (0x08000000) + round-half-down
+    // (0xFFF). For round-to-nearest-even, also add the tie-breaker: bit 13
+    // of src. Bit 13 of (src + bias) equals bit 13 of src because the bias
+    // doesn't affect bits 0-26.
+    e.vpaddd(e.xmm1, src, e.GetXmmConstPtr(XMMF16PackLCPI0));
+    e.vpsrld(e.xmm0, src, 13);
+    e.vpslld(e.xmm0, e.xmm0, 31);
+    e.vpsrld(e.xmm0, e.xmm0, 31);
+    e.vpaddd(e.xmm1, e.xmm1, e.xmm0);
+  } else {
+    // FLOAT16_2 truncates. Subtracting the minimum-normal float exponent
+    // rebiases normalized values directly; the source sign bit is removed
+    // by the later shift and 0x7FFF mask.
+    e.vpsubd(e.xmm1, src, e.GetXmmConstPtr(XMMF16UnpackLCPI2));
+  }
 
-  e.vpand(e.xmm2, i.src1, e.GetXmmConstPtr(XMMAbsMaskPS));
+  e.vpand(e.xmm2, src, e.GetXmmConstPtr(XMMAbsMaskPS));
   e.vmovdqa(e.xmm3, e.GetXmmConstPtr(XMMF16PackLCPI2));
 
   e.vpcmpgtd(e.xmm3, e.xmm3, e.xmm2);
@@ -2726,11 +2734,11 @@ static void emit_fast_f16_pack(X64Emitter& e, const Inst& i,
 
   e.vblendvps(e.xmm1, e.xmm0, e.xmm1, e.xmm3);
 
-  e.vpsrld(e.xmm0, i.src1, 16);
+  e.vpsrld(e.xmm0, src, 16);
   e.vpand(e.xmm0, e.xmm0, e.GetXmmConstPtr(XMMF16PackLCPI6));
   e.vorps(e.xmm0, e.xmm1, e.xmm0);
-  e.vpackusdw(i.dest, e.xmm0, e.xmm2);
-  e.vpshufb(i.dest, i.dest, e.GetXmmConstPtr(final_shuffle));
+  e.vpackusdw(dest, e.xmm0, e.xmm2);
+  e.vpshufb(dest, dest, e.GetXmmConstPtr(final_shuffle));
 }
 // ============================================================================
 // OPCODE_SWIZZLE
@@ -2826,34 +2834,20 @@ struct PACK : Sequence<PACK, I<OPCODE_PACK, V128Op, V128Op, V128Op>> {
     //     ((src1.uy & 0xFF) << 8) | (src1.uz & 0xFF)
     e.vpshufb(i.dest, i.dest, e.GetXmmConstPtr(XMMPackD3DCOLOR));
   }
-  static __m128i EmulateFLOAT16_2(void*, __m128 src1) {
-    alignas(16) float a[4];
-    alignas(16) uint16_t b[8];
-    _mm_store_ps(a, src1);
-    std::memset(b, 0, sizeof(b));
-
-    for (int i = 0; i < 2; i++) {
-      b[7 - i] = float_to_xenos_half(a[i]);
-    }
-
-    return _mm_load_si128(reinterpret_cast<__m128i*>(b));
-  }
   static void EmitFLOAT16_2(X64Emitter& e, const EmitArgType& i) {
     assert_true(i.src2.value->IsConstantZero());
     // http://blogs.msdn.com/b/chuckw/archive/2012/09/11/directxmath-f16c-and-fma.aspx
     // dest = [(src1.x | src1.y), 0, 0, 0]
+    if (i.src1.is_constant) {
+      vec128_t result = vec128b(0);
+      for (unsigned idx = 0; idx < 2; ++idx) {
+        result.u16[7 - idx] = float_to_xenos_half(i.src1.constant().f32[idx]);
+      }
+      e.LoadConstantXmm(i.dest, result);
+      return;
+    }
 
-    auto src1 = GetInputRegOrConstant(e, i.src1, e.xmm3);
-
-#if XE_PLATFORM_WIN32
-    // Windows x64 ABI: __m128 is passed by implicit pointer
-    e.lea(e.GetNativeParam(0), e.StashXmm(0, src1));
-#else
-    // Linux/Mac System V ABI: __m128 passed in xmm0, return in xmm0
-    e.vmovaps(e.xmm0, src1);
-#endif
-    e.CallNativeSafe(reinterpret_cast<void*>(EmulateFLOAT16_2));
-    e.vmovaps(i.dest, e.xmm0);
+    emit_fast_f16_pack<false>(e, i.dest, i.src1, XMMPackFLOAT16_2);
   }
 
   static __m128i EmulateFLOAT16_4_RoundToEven(void*, __m128 src1) {
@@ -2881,7 +2875,7 @@ struct PACK : Sequence<PACK, I<OPCODE_PACK, V128Op, V128Op, V128Op>> {
   static void EmitFLOAT16_4(X64Emitter& e, const EmitArgType& i) {
     if (!i.src1.is_constant) {
 #if XE_ARCH_AMD64
-      emit_fast_f16_pack(e, i, XMMPackFLOAT16_4);
+      emit_fast_f16_pack<true>(e, i.dest, i.src1, XMMPackFLOAT16_4);
 #else
       auto src1 = GetInputRegOrConstant(e, i.src1, e.xmm3);
 #if XE_PLATFORM_WIN32
@@ -3261,21 +3255,6 @@ struct UNPACK : Sequence<UNPACK, I<OPCODE_UNPACK, V128Op, V128Op>> {
     e.vpor(i.dest, e.GetXmmConstPtr(XMMOne));
     // To convert to 0 to 1, games multiply by 0x47008081 and add 0xC7008081.
   }
-  static __m128 EmulateFLOAT16_2(void*, __m128i src1) {
-    alignas(16) uint16_t a[8];
-    alignas(16) float b[4];
-    _mm_store_si128(reinterpret_cast<__m128i*>(a), src1);
-
-    for (int i = 0; i < 2; i++) {
-      b[i] = xenos_half_to_float(a[VEC128_W(6 + i)]);
-    }
-
-    // Constants, or something
-    b[2] = 0.f;
-    b[3] = 1.f;
-
-    return _mm_load_ps(b);
-  }
   static void EmitFLOAT16_2(X64Emitter& e, const EmitArgType& i) {
     // 1 bit sign, 5 bit exponent, 10 bit mantissa
     // D3D10 half float format
@@ -3287,19 +3266,20 @@ struct UNPACK : Sequence<UNPACK, I<OPCODE_UNPACK, V128Op, V128Op>> {
     // Packing half floats: https://gist.github.com/rygorous/2156668
     // Load source, move from tight pack of X16Y16.... to X16...Y16...
     // Also zero out the high end.
-    // TODO(benvanik): special case constant unpacks that just get 0/1/etc.
+    if (i.src1.is_constant) {
+      vec128_t result{};
+      for (unsigned idx = 0; idx < 2; ++idx) {
+        result.f32[idx] =
+            xenos_half_to_float(i.src1.constant().u16[VEC128_W(6 + idx)]);
+      }
+      result.f32[2] = 0.0f;
+      result.f32[3] = 1.0f;
+      e.LoadConstantXmm(i.dest, result);
+      return;
+    }
 
-    auto src1 = GetInputRegOrConstant(e, i.src1, e.xmm3);
-
-#if XE_PLATFORM_WIN32
-    // Windows x64 ABI: __m128i is passed by implicit pointer
-    e.lea(e.GetNativeParam(0), e.StashXmm(0, src1));
-#else
-    // Linux/Mac System V ABI: __m128i passed in xmm0, return in xmm0
-    e.vmovaps(e.xmm0, src1);
-#endif
-    e.CallNativeSafe(reinterpret_cast<void*>(EmulateFLOAT16_2));
-    e.vmovaps(i.dest, e.xmm0);
+    emit_fast_f16_unpack(e, i.dest, i.src1, XMMUnpackFLOAT16_2);
+    e.vblendps(i.dest, i.dest, e.GetXmmConstPtr(XMM0001), 0b1100);
   }
 
   static void EmitFLOAT16_4(X64Emitter& e, const EmitArgType& i) {
@@ -3314,7 +3294,7 @@ struct UNPACK : Sequence<UNPACK, I<OPCODE_UNPACK, V128Op, V128Op>> {
       e.LoadConstantXmm(i.dest, result);
 
     } else {
-      emit_fast_f16_unpack(e, i, XMMUnpackFLOAT16_4);
+      emit_fast_f16_unpack(e, i.dest, i.src1, XMMUnpackFLOAT16_4);
     }
   }
   static void EmitSHORT_2(X64Emitter& e, const EmitArgType& i) {

--- a/src/xenia/cpu/testing/float16_2_codegen_test.cc
+++ b/src/xenia/cpu/testing/float16_2_codegen_test.cc
@@ -1,0 +1,128 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2014 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+
+#include "xenia/base/platform.h"
+
+#if XE_ARCH_AMD64
+#include "third_party/capstone/include/capstone/capstone.h"
+#include "third_party/capstone/include/capstone/x86.h"
+#endif  // XE_ARCH_AMD64
+
+#include "xenia/cpu/function.h"
+#include "xenia/cpu/testing/util.h"
+
+using namespace xe;
+using namespace xe::cpu;
+using namespace xe::cpu::hir;
+using namespace xe::cpu::testing;
+
+#if XE_ARCH_AMD64
+
+namespace {
+
+enum class Float16_2CodegenKernel { kPack, kUnpack };
+
+constexpr uint32_t kRegionBeginGuestAddress = 0x80000000;
+constexpr uint32_t kRegionEndGuestAddress = 0x80000004;
+
+struct CodegenStats {
+  size_t region_byte_count;
+  size_t region_instruction_count;
+  size_t region_call_count;
+  size_t function_byte_count;
+};
+
+CodegenStats AnalyzeFloat16_2Codegen(Float16_2CodegenKernel kernel) {
+  TestFunction test([kernel](HIRBuilder& b) {
+    auto* source = LoadVR(b, 4);
+    b.SourceOffset(kRegionBeginGuestAddress);
+    auto* result = kernel == Float16_2CodegenKernel::kPack
+                       ? b.Pack(source, PACK_TYPE_FLOAT16_2)
+                       : b.Unpack(source, PACK_TYPE_FLOAT16_2);
+    b.SourceOffset(kRegionEndGuestAddress);
+    StoreVR(b, 3, result);
+    b.Return();
+  });
+  REQUIRE(test.processors.size() == 1);
+
+  auto* function = static_cast<GuestFunction*>(
+      test.processors.front()->ResolveFunction(0x80000000));
+  REQUIRE(function != nullptr);
+  REQUIRE(function->machine_code() != nullptr);
+
+  const SourceMapEntry* region_begin =
+      function->LookupGuestAddress(kRegionBeginGuestAddress);
+  const SourceMapEntry* region_end =
+      function->LookupGuestAddress(kRegionEndGuestAddress);
+  REQUIRE(region_begin != nullptr);
+  REQUIRE(region_end != nullptr);
+  REQUIRE(region_end->code_offset > region_begin->code_offset);
+  REQUIRE(region_end->code_offset <= function->machine_code_length());
+
+  const size_t region_byte_count =
+      region_end->code_offset - region_begin->code_offset;
+  const uint8_t* region_code =
+      function->machine_code() + region_begin->code_offset;
+
+  csh capstone_handle = 0;
+  REQUIRE(cs_open(CS_ARCH_X86, CS_MODE_64, &capstone_handle) == CS_ERR_OK);
+  cs_option(capstone_handle, CS_OPT_SYNTAX, CS_OPT_SYNTAX_INTEL);
+  cs_option(capstone_handle, CS_OPT_DETAIL, CS_OPT_OFF);
+
+  cs_insn* instructions = nullptr;
+  const size_t instruction_count =
+      cs_disasm(capstone_handle, region_code, region_byte_count,
+                reinterpret_cast<uint64_t>(region_code), 0, &instructions);
+  if (instruction_count == 0) {
+    cs_close(&capstone_handle);
+    REQUIRE(instruction_count != 0);
+  }
+
+  size_t call_count = 0;
+  size_t decoded_byte_count = 0;
+  for (size_t i = 0; i < instruction_count; ++i) {
+    call_count += instructions[i].id == X86_INS_CALL ? 1 : 0;
+    decoded_byte_count += instructions[i].size;
+  }
+  cs_free(instructions, instruction_count);
+  cs_close(&capstone_handle);
+  REQUIRE(decoded_byte_count == region_byte_count);
+
+  return CodegenStats{region_byte_count, instruction_count, call_count,
+                      function->machine_code_length()};
+}
+
+void PrintCodegenStats(const char* kernel_name, const CodegenStats& stats) {
+  std::printf(
+      "FLOAT16_2 codegen %-6s region_bytes=%zu instructions=%zu calls=%zu "
+      "function_bytes=%zu\n",
+      kernel_name, stats.region_byte_count, stats.region_instruction_count,
+      stats.region_call_count, stats.function_byte_count);
+}
+
+}  // namespace
+
+TEST_CASE("FLOAT16_2_EMITTER_CODEGEN", "[.float16_2_codegen]") {
+  const CodegenStats pack =
+      AnalyzeFloat16_2Codegen(Float16_2CodegenKernel::kPack);
+  const CodegenStats unpack =
+      AnalyzeFloat16_2Codegen(Float16_2CodegenKernel::kUnpack);
+
+  PrintCodegenStats("PACK", pack);
+  PrintCodegenStats("UNPACK", unpack);
+
+  REQUIRE(pack.region_call_count == 0);
+  REQUIRE(unpack.region_call_count == 0);
+}
+
+#endif  // XE_ARCH_AMD64

--- a/src/xenia/cpu/testing/pack_test.cc
+++ b/src/xenia/cpu/testing/pack_test.cc
@@ -7,6 +7,10 @@
  ******************************************************************************
  */
 
+#include <array>
+#include <cstdint>
+#include <cstdio>
+
 #include "xenia/cpu/testing/util.h"
 
 using namespace xe;
@@ -14,6 +18,65 @@ using namespace xe::cpu;
 using namespace xe::cpu::hir;
 using namespace xe::cpu::testing;
 using xe::cpu::ppc::PPCContext;
+
+namespace {
+
+constexpr size_t kFloat16PackTopPrefixCount = 1u << 19;
+constexpr size_t kFloat16PackGridInvocationCount = kFloat16PackTopPrefixCount;
+constexpr size_t kFloat16PackTailCount = 1u << 13;
+constexpr std::array<uint32_t, 10> kFloat16PackRiskPrefixes = {
+    0x387FE000u, 0xB87FE000u,  // Immediately below minimum normal.
+    0x38800000u, 0xB8800000u,  // Minimum normal.
+    0x3F800000u, 0xBF800000u,  // Representative normalized values.
+    0x47FFC000u, 0xC7FFC000u,  // Last full prefix below saturation.
+    0x47FFE000u, 0xC7FFE000u,  // Saturation threshold.
+};
+constexpr size_t kFloat16PackRiskInvocationCount =
+    (kFloat16PackRiskPrefixes.size() / 2) * kFloat16PackTailCount;
+constexpr size_t kFloat16PackSampleCount =
+    kFloat16PackGridInvocationCount + kFloat16PackRiskInvocationCount;
+
+void Float16PackSamplePair(size_t index, uint32_t& x_bits, uint32_t& y_bits) {
+  if (index < kFloat16PackGridInvocationCount) {
+    // Every sign/exponent/top-10-mantissa prefix appears once with a zero tail
+    // in X and once with an all-ones tail in Y. Reversing the Y prefix also
+    // makes lane swaps observable.
+    x_bits = static_cast<uint32_t>(index << 13);
+    y_bits = static_cast<uint32_t>(
+        ((kFloat16PackTopPrefixCount - 1 - index) << 13) | 0x1FFFu);
+    return;
+  }
+
+  const size_t risk_index = index - kFloat16PackGridInvocationCount;
+  const size_t prefix_pair = risk_index / kFloat16PackTailCount;
+  const uint32_t tail =
+      static_cast<uint32_t>(risk_index % kFloat16PackTailCount);
+  x_bits = kFloat16PackRiskPrefixes[prefix_pair * 2] | tail;
+  y_bits = kFloat16PackRiskPrefixes[prefix_pair * 2 + 1] | tail;
+}
+
+// Independent bit-field reference for vpkd3d128 FLOAT16_2. Xenos half has an
+// extended finite range, flushes values below its normalized range, saturates
+// above it, and truncates rather than rounding to nearest.
+uint16_t ReferenceFloatToXenosHalfTrunc(uint32_t float_bits) {
+  const uint32_t sign = float_bits >> 31;
+  const uint32_t exponent = (float_bits >> 23) & 0xFFu;
+  const uint32_t fraction = float_bits & 0x7FFFFFu;
+
+  uint32_t half_magnitude;
+  if (exponent < 113u) {
+    half_magnitude = 0;
+  } else if (exponent > 143u || (exponent == 143u && fraction >= 0x7FE000u)) {
+    half_magnitude = 0x7FFFu;
+  } else {
+    const uint32_t half_exponent = exponent - 112u;
+    const uint32_t half_fraction = fraction >> 13;
+    half_magnitude = (half_exponent << 10) | half_fraction;
+  }
+  return static_cast<uint16_t>((sign << 15) | half_magnitude);
+}
+
+}  // namespace
 
 TEST_CASE("PACK_D3DCOLOR", "[instr]") {
   TestFunction test([](HIRBuilder& b) {
@@ -60,6 +123,194 @@ TEST_CASE("PACK_FLOAT16_2", "[instr]") {
       [](PPCContext* ctx) {
         auto result = ctx->v[3];
         REQUIRE(result == vec128i(0, 0, 0, 0x55556666));
+      });
+  // Exact truncation discriminator: round-to-nearest-even would produce
+  // 0x3C01/0xBC01 instead.
+  test.Run(
+      [](PPCContext* ctx) {
+        ctx->v[4] = vec128i(0x3F801001, 0xBF801001, 0, 0);
+      },
+      [](PPCContext* ctx) {
+        REQUIRE(ctx->v[3] == vec128i(0, 0, 0, 0x3C00BC00));
+      });
+}
+
+TEST_CASE("PACK_FLOAT16_2_SAMPLED_EXACT_BITS", "[instr]") {
+  TestFunction test([](HIRBuilder& b) {
+    StoreVR(b, 3, b.Pack(LoadVR(b, 4), PACK_TYPE_FLOAT16_2));
+    b.Return();
+  });
+
+  size_t invocation_count = 0;
+  size_t lane_comparison_count = 0;
+  size_t mismatch_count = 0;
+  size_t padding_mismatch_count = 0;
+  size_t first_mismatch_index = 0;
+  uint32_t first_mismatch_lane = 0;
+  uint16_t first_expected = 0;
+  uint16_t first_actual = 0;
+
+  test.RunRepeated(
+      kFloat16PackSampleCount,
+      [](PPCContext* ctx, size_t iteration) {
+        uint32_t x_bits;
+        uint32_t y_bits;
+        Float16PackSamplePair(iteration, x_bits, y_bits);
+        vec128_t source = vec128b(0);
+        source.u32[0] = x_bits;
+        source.u32[1] = y_bits;
+        source.u32[2] = 0xDEADBEEFu;
+        source.u32[3] = 0xA5A55A5Au;
+        ctx->v[3] = vec128b(0xCD);
+        ctx->v[4] = source;
+      },
+      [&](PPCContext* ctx, size_t iteration) {
+        uint32_t x_bits;
+        uint32_t y_bits;
+        Float16PackSamplePair(iteration, x_bits, y_bits);
+        const uint16_t expected_x = ReferenceFloatToXenosHalfTrunc(x_bits);
+        const uint16_t expected_y = ReferenceFloatToXenosHalfTrunc(y_bits);
+        const vec128_t actual = ctx->v[3];
+
+        const auto record_mismatch = [&](uint32_t lane, uint16_t expected,
+                                         uint16_t observed) {
+          if (expected == observed) {
+            return;
+          }
+          if (mismatch_count == 0) {
+            first_mismatch_index = iteration;
+            first_mismatch_lane = lane;
+            first_expected = expected;
+            first_actual = observed;
+          }
+          ++mismatch_count;
+        };
+        record_mismatch(0, expected_x, actual.u16[7]);
+        record_mismatch(1, expected_y, actual.u16[6]);
+
+        for (size_t i = 0; i < 6; ++i) {
+          if (actual.u16[i] != 0) {
+            ++padding_mismatch_count;
+          }
+        }
+        ++invocation_count;
+        lane_comparison_count += 2;
+      });
+
+  std::printf("PACK_FLOAT16_2 sampled: %zu invocations, %zu lane comparisons\n",
+              invocation_count, lane_comparison_count);
+  REQUIRE(invocation_count == kFloat16PackSampleCount);
+  REQUIRE(invocation_count == 565248);
+  REQUIRE(lane_comparison_count == kFloat16PackSampleCount * 2);
+  REQUIRE(lane_comparison_count == 1130496);
+  CAPTURE(first_mismatch_index, first_mismatch_lane, first_expected,
+          first_actual);
+  REQUIRE(mismatch_count == 0);
+  REQUIRE(padding_mismatch_count == 0);
+}
+
+TEST_CASE("PACK_FLOAT16_2_CONSTANT_SOURCE", "[instr]") {
+  struct ConstantCase {
+    uint32_t x;
+    uint32_t y;
+  };
+  constexpr std::array<ConstantCase, 10> kCases = {{
+      {0x00000000u, 0x80000000u},
+      {0x387FFFFFu, 0xB87FFFFFu},
+      {0x38800000u, 0xB8800000u},
+      {0x3F801001u, 0xBF801001u},
+      {0x42AAAFFFu, 0xC4CCCFFFu},
+      {0x47FFDFFFu, 0xC7FFDFFFu},
+      {0x47FFE000u, 0xC7FFE000u},
+      {0x7F800000u, 0xFF800000u},
+      {0x7FC00001u, 0xFFC00001u},
+      {0x00800000u, 0x80800000u},
+  }};
+
+  std::array<vec128_t, kCases.size()> sources;
+  std::array<vec128_t, kCases.size()> expected;
+  for (size_t i = 0; i < kCases.size(); ++i) {
+    const ConstantCase& test_case = kCases[i];
+    vec128_t source = vec128b(0);
+    source.u32[0] = test_case.x;
+    source.u32[1] = test_case.y;
+    source.u32[2] = 0xDEADBEEFu;
+    source.u32[3] = 0xA5A55A5Au;
+    sources[i] = source;
+
+    expected[i] = vec128b(0);
+    expected[i].u16[7] = ReferenceFloatToXenosHalfTrunc(test_case.x);
+    expected[i].u16[6] = ReferenceFloatToXenosHalfTrunc(test_case.y);
+  }
+
+  TestFunction test([sources](HIRBuilder& b) {
+    for (size_t i = 0; i < sources.size(); ++i) {
+      StoreVR(b, 3 + static_cast<int>(i),
+              b.Pack(b.LoadConstantVec128(sources[i]), PACK_TYPE_FLOAT16_2));
+    }
+    b.Return();
+  });
+  size_t comparison_count = 0;
+  test.Run([](PPCContext*) {},
+           [&](PPCContext* ctx) {
+             for (size_t i = 0; i < expected.size(); ++i) {
+               REQUIRE(ctx->v[3 + i] == expected[i]);
+               ++comparison_count;
+             }
+             REQUIRE(ctx->v[6] == vec128i(0, 0, 0, 0x3C00BC00));
+           });
+
+  std::printf("PACK_FLOAT16_2 constant source: %zu comparisons\n",
+              comparison_count);
+  REQUIRE(comparison_count == kCases.size());
+}
+
+TEST_CASE("PACK_FLOAT16_2_SOURCE_LIVE_PRESSURE", "[instr]") {
+  constexpr size_t kSurvivorCount = 12;
+  TestFunction test([](HIRBuilder& b) {
+    auto source = LoadVR(b, 4);
+    std::array<Value*, kSurvivorCount> survivors;
+    for (size_t i = 0; i < survivors.size(); ++i) {
+      survivors[i] = LoadVR(b, 5 + static_cast<int>(i));
+    }
+    auto packed = b.Pack(source, PACK_TYPE_FLOAT16_2);
+    StoreVR(b, 3, packed);
+    StoreVR(b, 20, source);
+    for (size_t i = 0; i < survivors.size(); ++i) {
+      StoreVR(b, 21 + static_cast<int>(i), survivors[i]);
+    }
+    b.Return();
+  });
+
+  vec128_t source = vec128b(0);
+  source.u32[0] = 0x42AAAFFFu;
+  source.u32[1] = 0xC4CCCFFFu;
+  source.u32[2] = 0xDEADBEEFu;
+  source.u32[3] = 0xA5A55A5Au;
+  std::array<vec128_t, kSurvivorCount> survivors;
+  for (size_t i = 0; i < survivors.size(); ++i) {
+    survivors[i] = vec128i(0x01020304u + static_cast<uint32_t>(i),
+                           0x11223344u + static_cast<uint32_t>(i),
+                           0x89ABCDEFu - static_cast<uint32_t>(i),
+                           0xF0E1D2C3u - static_cast<uint32_t>(i));
+  }
+  vec128_t expected = vec128b(0);
+  expected.u16[7] = ReferenceFloatToXenosHalfTrunc(source.u32[0]);
+  expected.u16[6] = ReferenceFloatToXenosHalfTrunc(source.u32[1]);
+
+  test.Run(
+      [source, survivors](PPCContext* ctx) {
+        ctx->v[4] = source;
+        for (size_t i = 0; i < survivors.size(); ++i) {
+          ctx->v[5 + i] = survivors[i];
+        }
+      },
+      [source, survivors, expected](PPCContext* ctx) {
+        REQUIRE(ctx->v[3] == expected);
+        REQUIRE(ctx->v[20] == source);
+        for (size_t i = 0; i < survivors.size(); ++i) {
+          REQUIRE(ctx->v[21 + i] == survivors[i]);
+        }
       });
 }
 

--- a/src/xenia/cpu/testing/unpack_test.cc
+++ b/src/xenia/cpu/testing/unpack_test.cc
@@ -7,6 +7,10 @@
  ******************************************************************************
  */
 
+#include <array>
+#include <cstdint>
+#include <cstdio>
+
 #include "xenia/cpu/testing/util.h"
 
 using namespace xe;
@@ -14,6 +18,23 @@ using namespace xe::cpu;
 using namespace xe::cpu::hir;
 using namespace xe::cpu::testing;
 using xe::cpu::ppc::PPCContext;
+
+namespace {
+
+// Independent exact-bit reference for the default Xenos half conversion used
+// by vupkd3d128. Half denormals flush to signed zero; exponent 31 remains part
+// of the Xenos extended finite range rather than becoming IEEE infinity/NaN.
+uint32_t ReferenceXenosHalfToFloatBits(uint16_t half_bits) {
+  const uint32_t sign = uint32_t(half_bits & 0x8000u) << 16;
+  const uint32_t exponent = (half_bits >> 10) & 0x1Fu;
+  const uint32_t mantissa = half_bits & 0x3FFu;
+  if (exponent == 0) {
+    return sign;
+  }
+  return sign | ((exponent + 112u) << 23) | (mantissa << 13);
+}
+
+}  // namespace
 
 TEST_CASE("UNPACK_D3DCOLOR", "[instr]") {
   TestFunction test([](HIRBuilder& b) {
@@ -65,6 +86,178 @@ TEST_CASE("UNPACK_FLOAT16_2", "[instr]") {
            });
 }
 
+TEST_CASE("UNPACK_FLOAT16_2_EXHAUSTIVE_EXACT_BITS", "[instr]") {
+  TestFunction test([](HIRBuilder& b) {
+    StoreVR(b, 3, b.Unpack(LoadVR(b, 4), PACK_TYPE_FLOAT16_2));
+    b.Return();
+  });
+
+  constexpr size_t kInvocationCount = 1u << 16;
+  constexpr size_t kExpectedLaneConversions = kInvocationCount * 2;
+  size_t invocation_count = 0;
+  size_t lane_conversion_count = 0;
+  size_t mismatch_count = 0;
+  size_t fill_mismatch_count = 0;
+  size_t first_mismatch_index = 0;
+  uint32_t first_mismatch_lane = 0;
+  uint32_t first_expected = 0;
+  uint32_t first_actual = 0;
+
+  test.RunRepeated(
+      kInvocationCount,
+      [](PPCContext* ctx, size_t iteration) {
+        const uint16_t x = static_cast<uint16_t>(iteration);
+        const uint16_t y = static_cast<uint16_t>(x ^ 0xFFFFu);
+        vec128_t source = vec128b(0xA5);
+        source.u16[7] = x;
+        source.u16[6] = y;
+        ctx->v[3] = vec128b(0xCD);
+        ctx->v[4] = source;
+      },
+      [&](PPCContext* ctx, size_t iteration) {
+        const uint16_t x = static_cast<uint16_t>(iteration);
+        const uint16_t y = static_cast<uint16_t>(x ^ 0xFFFFu);
+        const uint32_t expected_x = ReferenceXenosHalfToFloatBits(x);
+        const uint32_t expected_y = ReferenceXenosHalfToFloatBits(y);
+        const vec128_t actual = ctx->v[3];
+
+        const auto record_mismatch = [&](uint32_t lane, uint32_t expected,
+                                         uint32_t observed) {
+          if (expected == observed) {
+            return;
+          }
+          if (mismatch_count == 0) {
+            first_mismatch_index = iteration;
+            first_mismatch_lane = lane;
+            first_expected = expected;
+            first_actual = observed;
+          }
+          ++mismatch_count;
+        };
+        record_mismatch(0, expected_x, actual.u32[0]);
+        record_mismatch(1, expected_y, actual.u32[1]);
+        if (actual.u32[2] != 0 || actual.u32[3] != 0x3F800000u) {
+          ++fill_mismatch_count;
+        }
+        ++invocation_count;
+        lane_conversion_count += 2;
+      });
+
+  std::printf(
+      "UNPACK_FLOAT16_2 exhaustive: %zu invocations, %zu lane conversions\n",
+      invocation_count, lane_conversion_count);
+  REQUIRE(invocation_count == kInvocationCount);
+  REQUIRE(lane_conversion_count == kExpectedLaneConversions);
+  CAPTURE(first_mismatch_index, first_mismatch_lane, first_expected,
+          first_actual);
+  REQUIRE(mismatch_count == 0);
+  REQUIRE(fill_mismatch_count == 0);
+}
+
+TEST_CASE("UNPACK_FLOAT16_2_CONSTANT_SOURCE", "[instr]") {
+  struct ConstantCase {
+    uint16_t x;
+    uint16_t y;
+  };
+  constexpr std::array<ConstantCase, 10> kCases = {{
+      {0x0000u, 0x8000u},
+      {0x0001u, 0x83FFu},
+      {0x0400u, 0x8400u},
+      {0x3C00u, 0xBC00u},
+      {0x5555u, 0x6666u},
+      {0x7BFFu, 0xFBFFu},
+      {0x7C00u, 0xFC00u},
+      {0x7FFFu, 0xFFFFu},
+      {0x3555u, 0xB666u},
+      {0x03FFu, 0x8001u},
+  }};
+
+  std::array<vec128_t, kCases.size()> sources;
+  std::array<vec128_t, kCases.size()> expected;
+  for (size_t i = 0; i < kCases.size(); ++i) {
+    const ConstantCase& test_case = kCases[i];
+    vec128_t source = vec128b(0xA5);
+    source.u16[7] = test_case.x;
+    source.u16[6] = test_case.y;
+    sources[i] = source;
+
+    expected[i] = vec128b(0);
+    expected[i].u32[0] = ReferenceXenosHalfToFloatBits(test_case.x);
+    expected[i].u32[1] = ReferenceXenosHalfToFloatBits(test_case.y);
+    expected[i].u32[3] = 0x3F800000u;
+  }
+
+  TestFunction test([sources](HIRBuilder& b) {
+    for (size_t i = 0; i < sources.size(); ++i) {
+      StoreVR(b, 3 + static_cast<int>(i),
+              b.Unpack(b.LoadConstantVec128(sources[i]), PACK_TYPE_FLOAT16_2));
+    }
+    b.Return();
+  });
+  size_t comparison_count = 0;
+  test.Run(
+      [](PPCContext*) {},
+      [&](PPCContext* ctx) {
+        for (size_t i = 0; i < expected.size(); ++i) {
+          REQUIRE(ctx->v[3 + i] == expected[i]);
+          ++comparison_count;
+        }
+        REQUIRE(ctx->v[7] == vec128i(0x42AAA000, 0x44CCC000, 0, 0x3F800000));
+      });
+
+  std::printf("UNPACK_FLOAT16_2 constant source: %zu comparisons\n",
+              comparison_count);
+  REQUIRE(comparison_count == kCases.size());
+}
+
+TEST_CASE("UNPACK_FLOAT16_2_SOURCE_LIVE_PRESSURE", "[instr]") {
+  constexpr size_t kSurvivorCount = 12;
+  TestFunction test([](HIRBuilder& b) {
+    auto source = LoadVR(b, 4);
+    std::array<Value*, kSurvivorCount> survivors;
+    for (size_t i = 0; i < survivors.size(); ++i) {
+      survivors[i] = LoadVR(b, 5 + static_cast<int>(i));
+    }
+    auto unpacked = b.Unpack(source, PACK_TYPE_FLOAT16_2);
+    StoreVR(b, 3, unpacked);
+    StoreVR(b, 20, source);
+    for (size_t i = 0; i < survivors.size(); ++i) {
+      StoreVR(b, 21 + static_cast<int>(i), survivors[i]);
+    }
+    b.Return();
+  });
+
+  vec128_t source = vec128b(0xA5);
+  source.u16[7] = 0x5555u;
+  source.u16[6] = 0xD666u;
+  std::array<vec128_t, kSurvivorCount> survivors;
+  for (size_t i = 0; i < survivors.size(); ++i) {
+    survivors[i] = vec128i(0x01020304u + static_cast<uint32_t>(i),
+                           0x11223344u + static_cast<uint32_t>(i),
+                           0x89ABCDEFu - static_cast<uint32_t>(i),
+                           0xF0E1D2C3u - static_cast<uint32_t>(i));
+  }
+  vec128_t expected = vec128b(0);
+  expected.u32[0] = ReferenceXenosHalfToFloatBits(source.u16[7]);
+  expected.u32[1] = ReferenceXenosHalfToFloatBits(source.u16[6]);
+  expected.u32[3] = 0x3F800000u;
+
+  test.Run(
+      [source, survivors](PPCContext* ctx) {
+        ctx->v[4] = source;
+        for (size_t i = 0; i < survivors.size(); ++i) {
+          ctx->v[5 + i] = survivors[i];
+        }
+      },
+      [source, survivors, expected](PPCContext* ctx) {
+        REQUIRE(ctx->v[3] == expected);
+        REQUIRE(ctx->v[20] == source);
+        for (size_t i = 0; i < survivors.size(); ++i) {
+          REQUIRE(ctx->v[21 + i] == survivors[i]);
+        }
+      });
+}
+
 TEST_CASE("UNPACK_FLOAT16_4", "[instr]") {
   TestFunction test([](HIRBuilder& b) {
     StoreVR(b, 3, b.Unpack(LoadVR(b, 4), PACK_TYPE_FLOAT16_4));
@@ -83,6 +276,14 @@ TEST_CASE("UNPACK_FLOAT16_4", "[instr]") {
         auto result = ctx->v[3];
         REQUIRE(result ==
                 vec128i(0x449A4000, 0x45B16000, 0x41102000, 0x40922000));
+      });
+  test.Run(
+      [](PPCContext* ctx) {
+        ctx->v[4] = vec128s(0, 0, 0, 0, 0x0001, 0x8001, 0x03FF, 0x83FF);
+      },
+      [](PPCContext* ctx) {
+        REQUIRE(ctx->v[3] ==
+                vec128i(0x00000000, 0x80000000, 0x00000000, 0x80000000));
       });
 }
 

--- a/src/xenia/cpu/testing/util.h
+++ b/src/xenia/cpu/testing/util.h
@@ -98,6 +98,41 @@ class TestFunction {
     }
   }
 
+  template <typename PreCall, typename PostCall>
+  void RunRepeated(size_t iteration_count, PreCall&& pre_call,
+                   PostCall&& post_call) {
+    for (auto& processor : processors) {
+      auto fn = processor->ResolveFunction(0x80000000);
+      REQUIRE(fn != nullptr);
+
+      uint32_t stack_size = 64 * 1024;
+      uint32_t stack_address = memory->SystemHeapAlloc(stack_size);
+      uint32_t stack_base = stack_address + stack_size;
+      auto thread_state =
+          std::make_unique<ThreadState>(processor.get(), 0x100, stack_base);
+      auto ctx = thread_state->context();
+
+      // Establish the same clean initial rounding mode as Run. The emitted
+      // function may switch to VMX mode, so resetting the host mode without
+      // also resetting the emitter's runtime mode state between invocations
+      // would make the next invocation internally inconsistent.
+      processor->backend()->SetGuestRoundingMode(ctx, 0);
+
+      size_t successful_call_count = 0;
+      for (size_t iteration = 0; iteration < iteration_count; ++iteration) {
+        ctx->lr = 0xBCBCBCBC;
+        pre_call(ctx, iteration);
+        if (fn->Call(thread_state.get(), uint32_t(ctx->lr))) {
+          ++successful_call_count;
+        }
+        post_call(ctx, iteration);
+      }
+      thread_state.reset();
+      memory->SystemHeapFree(stack_address);
+      REQUIRE(successful_call_count == iteration_count);
+    }
+  }
+
   std::unique_ptr<Memory> memory;
   std::vector<std::unique_ptr<Processor>> processors;
 };


### PR DESCRIPTION
Replaces the x64 native helper calls for FLOAT16_2 pack and unpack with inline emitted sequences, while retaining constant folding and the existing truncation, saturation, lane-order, and unpack-fill behavior.

Coverage includes sampled exact-bit packing, exhaustive unpacking, constant operands, live-register pressure, and a Capstone codegen guard requiring zero call instructions in both emitted regions.

Verification:
- `xb lint --origin`
- Release `xenia-cpu-tests`: 252 test cases / 893 assertions
- Focused FLOAT16_2 coverage: 9 test cases / 93 assertions
- Pack and unpack codegen regions: 0 calls

Was AI used in this change: Yes
