### PR TITLE
[CPU/X64] Inline unsigned PACK 8_IN_16 paths

### DIFF
--- a/src/xenia/cpu/backend/x64/x64_emitter.cc
+++ b/src/xenia/cpu/backend/x64/x64_emitter.cc
@@ -1077,6 +1077,8 @@ static const vec128_t xmm_consts[] = {
     vec128i(0xFFFFFFFFu, 0xFFFFFFFFu, 0x0A0908FFu, 0xFF020100u),
     /* XMMPackULONG_4202020_PermuteYW */
     vec128i(0xFFFFFFFFu, 0xFFFFFFFFu, 0x0CFFFF06u, 0x0504FFFFu),
+    /* XMMPack8_IN_16_LowByteMask */
+    vec128i(0x00FF00FFu, 0x00FF00FFu, 0x00FF00FFu, 0x00FF00FFu),
     /* XMMUnpackULONG_4202020_Permute */
     vec128i(0xFF0E0D0Cu, 0xFF0B0A09u, 0xFF080F0Eu, 0xFFFFFF0Bu),
     /* XMMUnpackULONG_4202020_Overflow */ vec128i(0x40380000u),

--- a/src/xenia/cpu/backend/x64/x64_emitter.h
+++ b/src/xenia/cpu/backend/x64/x64_emitter.h
@@ -126,6 +126,7 @@ enum XmmConst {
   XMMPackULONG_4202020_MaskUnpacked,
   XMMPackULONG_4202020_PermuteXZ,
   XMMPackULONG_4202020_PermuteYW,
+  XMMPack8_IN_16_LowByteMask,
   XMMUnpackULONG_4202020_Permute,
   XMMUnpackULONG_4202020_Overflow,
   XMMOneOver255,

--- a/src/xenia/cpu/backend/x64/x64_seq_vector.cc
+++ b/src/xenia/cpu/backend/x64/x64_seq_vector.cc
@@ -2994,69 +2994,51 @@ struct PACK : Sequence<PACK, I<OPCODE_PACK, V128Op, V128Op, V128Op>> {
     // Merge XZ and YW.
     e.vorps(i.dest, e.xmm0);
   }
-  static __m128i EmulatePack8_IN_16_UN_UN_SAT(void*, __m128i src1,
-                                              __m128i src2) {
-    alignas(16) uint16_t a[8];
-    alignas(16) uint16_t b[8];
-    alignas(16) uint8_t c[16];
-    _mm_store_si128(reinterpret_cast<__m128i*>(a), src1);
-    _mm_store_si128(reinterpret_cast<__m128i*>(b), src2);
-    for (int i = 0; i < 8; ++i) {
-      c[i] = uint8_t(std::max(uint16_t(0), std::min(uint16_t(255), a[i])));
-      c[i + 8] = uint8_t(std::max(uint16_t(0), std::min(uint16_t(255), b[i])));
-    }
-    return _mm_load_si128(reinterpret_cast<__m128i*>(c));
-  }
-  static __m128i EmulatePack8_IN_16_UN_UN(void*, __m128i src1, __m128i src2) {
-    alignas(16) uint8_t a[16];
-    alignas(16) uint8_t b[16];
-    alignas(16) uint8_t c[16];
-    _mm_store_si128(reinterpret_cast<__m128i*>(a), src1);
-    _mm_store_si128(reinterpret_cast<__m128i*>(b), src2);
-    for (int i = 0; i < 8; ++i) {
-      c[i] = a[i * 2];
-      c[i + 8] = b[i * 2];
-    }
-    return _mm_load_si128(reinterpret_cast<__m128i*>(c));
-  }
   static void Emit8_IN_16(X64Emitter& e, const EmitArgType& i, uint32_t flags) {
     // TODO(benvanik): handle src2 (or src1) being constant zero
     if (IsPackInUnsigned(flags)) {
       if (IsPackOutUnsigned(flags)) {
         if (IsPackOutSaturate(flags)) {
           // unsigned -> unsigned + saturate
-          auto src1 = GetInputRegOrConstant(e, i.src1, e.xmm3);
-          auto src2 = GetInputRegOrConstant(e, i.src2, e.xmm4);
-
-#if XE_PLATFORM_WIN32
-          // Windows x64 ABI: __m128i is passed by implicit pointer
-          e.lea(e.GetNativeParam(0), e.StashXmm(0, src1));
-          e.lea(e.GetNativeParam(1), e.StashXmm(1, src2));
-#else
-          // Linux/Mac System V ABI: __m128i passed in xmm0/xmm1, return in xmm0
-          e.vmovaps(e.xmm0, src1);
-          e.vmovaps(e.xmm1, src2);
-#endif
-          e.CallNativeSafe(
-              reinterpret_cast<void*>(EmulatePack8_IN_16_UN_UN_SAT));
-          e.vmovaps(i.dest, e.xmm0);
+          // Clamp each unsigned word to 255 before signed-word byte packing.
+          if (i.src1.is_constant) {
+            e.LoadConstantXmm(e.xmm0, i.src1.constant());
+            e.vpminuw(e.xmm0, e.xmm0,
+                      e.GetXmmConstPtr(XMMPack8_IN_16_LowByteMask));
+          } else {
+            e.vpminuw(e.xmm0, i.src1,
+                      e.GetXmmConstPtr(XMMPack8_IN_16_LowByteMask));
+          }
+          if (i.src2.is_constant) {
+            e.LoadConstantXmm(e.xmm1, i.src2.constant());
+            e.vpminuw(e.xmm1, e.xmm1,
+                      e.GetXmmConstPtr(XMMPack8_IN_16_LowByteMask));
+          } else {
+            e.vpminuw(e.xmm1, i.src2,
+                      e.GetXmmConstPtr(XMMPack8_IN_16_LowByteMask));
+          }
+          e.vpackuswb(i.dest, e.xmm0, e.xmm1);
           e.vpshufb(i.dest, i.dest, e.GetXmmConstPtr(XMMByteOrderMask));
         } else {
           // unsigned -> unsigned
-          auto src1 = GetInputRegOrConstant(e, i.src1, e.xmm3);
-          auto src2 = GetInputRegOrConstant(e, i.src2, e.xmm4);
-
-#if XE_PLATFORM_WIN32
-          // Windows x64 ABI: __m128i is passed by implicit pointer
-          e.lea(e.GetNativeParam(0), e.StashXmm(0, src1));
-          e.lea(e.GetNativeParam(1), e.StashXmm(1, src2));
-#else
-          // Linux/Mac System V ABI: __m128i passed in xmm0/xmm1, return in xmm0
-          e.vmovaps(e.xmm0, src1);
-          e.vmovaps(e.xmm1, src2);
-#endif
-          e.CallNativeSafe(reinterpret_cast<void*>(EmulatePack8_IN_16_UN_UN));
-          e.vmovaps(i.dest, e.xmm0);
+          // Keep each word's low byte before signed-word byte packing.
+          if (i.src1.is_constant) {
+            e.LoadConstantXmm(e.xmm0, i.src1.constant());
+            e.vpand(e.xmm0, e.xmm0,
+                    e.GetXmmConstPtr(XMMPack8_IN_16_LowByteMask));
+          } else {
+            e.vpand(e.xmm0, i.src1,
+                    e.GetXmmConstPtr(XMMPack8_IN_16_LowByteMask));
+          }
+          if (i.src2.is_constant) {
+            e.LoadConstantXmm(e.xmm1, i.src2.constant());
+            e.vpand(e.xmm1, e.xmm1,
+                    e.GetXmmConstPtr(XMMPack8_IN_16_LowByteMask));
+          } else {
+            e.vpand(e.xmm1, i.src2,
+                    e.GetXmmConstPtr(XMMPack8_IN_16_LowByteMask));
+          }
+          e.vpackuswb(i.dest, e.xmm0, e.xmm1);
           e.vpshufb(i.dest, i.dest, e.GetXmmConstPtr(XMMByteOrderMask));
         }
       } else {

--- a/src/xenia/cpu/testing/pack8_in_16_codegen_test.cc
+++ b/src/xenia/cpu/testing/pack8_in_16_codegen_test.cc
@@ -1,0 +1,132 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2014 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+
+#include "xenia/base/platform.h"
+
+#if XE_ARCH_AMD64
+#include "third_party/capstone/include/capstone/capstone.h"
+#include "third_party/capstone/include/capstone/x86.h"
+#endif  // XE_ARCH_AMD64
+
+#include "xenia/cpu/function.h"
+#include "xenia/cpu/testing/util.h"
+
+using namespace xe;
+using namespace xe::cpu;
+using namespace xe::cpu::hir;
+using namespace xe::cpu::testing;
+
+#if XE_ARCH_AMD64
+
+namespace {
+
+enum class Pack8In16CodegenKernel { kModulo, kSaturating };
+
+constexpr uint32_t kRegionBeginGuestAddress = 0x80000000;
+constexpr uint32_t kRegionEndGuestAddress = 0x80000004;
+
+struct CodegenStats {
+  size_t region_byte_count;
+  size_t region_instruction_count;
+  size_t region_call_count;
+  size_t function_byte_count;
+};
+
+CodegenStats AnalyzePack8In16Codegen(Pack8In16CodegenKernel kernel) {
+  TestFunction test([kernel](HIRBuilder& b) {
+    auto* source_1 = LoadVR(b, 4);
+    auto* source_2 = LoadVR(b, 5);
+    const uint32_t pack_flags = PACK_TYPE_8_IN_16 | PACK_TYPE_IN_UNSIGNED |
+                                PACK_TYPE_OUT_UNSIGNED |
+                                (kernel == Pack8In16CodegenKernel::kSaturating
+                                     ? PACK_TYPE_OUT_SATURATE
+                                     : PACK_TYPE_OUT_UNSATURATE);
+    b.SourceOffset(kRegionBeginGuestAddress);
+    auto* result = b.Pack(source_1, source_2, pack_flags);
+    b.SourceOffset(kRegionEndGuestAddress);
+    StoreVR(b, 3, result);
+    b.Return();
+  });
+  REQUIRE(test.processors.size() == 1);
+
+  auto* function = static_cast<GuestFunction*>(
+      test.processors.front()->ResolveFunction(0x80000000));
+  REQUIRE(function != nullptr);
+  REQUIRE(function->machine_code() != nullptr);
+
+  const SourceMapEntry* region_begin =
+      function->LookupGuestAddress(kRegionBeginGuestAddress);
+  const SourceMapEntry* region_end =
+      function->LookupGuestAddress(kRegionEndGuestAddress);
+  REQUIRE(region_begin != nullptr);
+  REQUIRE(region_end != nullptr);
+  REQUIRE(region_end->code_offset > region_begin->code_offset);
+  REQUIRE(region_end->code_offset <= function->machine_code_length());
+
+  const size_t region_byte_count =
+      region_end->code_offset - region_begin->code_offset;
+  const uint8_t* region_code =
+      function->machine_code() + region_begin->code_offset;
+
+  csh capstone_handle = 0;
+  REQUIRE(cs_open(CS_ARCH_X86, CS_MODE_64, &capstone_handle) == CS_ERR_OK);
+  cs_option(capstone_handle, CS_OPT_SYNTAX, CS_OPT_SYNTAX_INTEL);
+  cs_option(capstone_handle, CS_OPT_DETAIL, CS_OPT_OFF);
+
+  cs_insn* instructions = nullptr;
+  const size_t instruction_count =
+      cs_disasm(capstone_handle, region_code, region_byte_count,
+                reinterpret_cast<uint64_t>(region_code), 0, &instructions);
+  if (instruction_count == 0) {
+    cs_close(&capstone_handle);
+    REQUIRE(instruction_count != 0);
+  }
+
+  size_t call_count = 0;
+  size_t decoded_byte_count = 0;
+  for (size_t i = 0; i < instruction_count; ++i) {
+    call_count += instructions[i].id == X86_INS_CALL ? 1 : 0;
+    decoded_byte_count += instructions[i].size;
+  }
+  cs_free(instructions, instruction_count);
+  cs_close(&capstone_handle);
+  REQUIRE(decoded_byte_count == region_byte_count);
+
+  return CodegenStats{region_byte_count, instruction_count, call_count,
+                      function->machine_code_length()};
+}
+
+void PrintCodegenStats(const char* kernel_name, const CodegenStats& stats) {
+  std::printf(
+      "PACK_8_IN_16 cold one-site codegen %-10s region_bytes=%zu "
+      "instructions=%zu calls=%zu function_bytes=%zu\n",
+      kernel_name, stats.region_byte_count, stats.region_instruction_count,
+      stats.region_call_count, stats.function_byte_count);
+}
+
+}  // namespace
+
+TEST_CASE("PACK_8_IN_16_EMITTER_CODEGEN", "[.pack8_in_16_codegen]") {
+  const CodegenStats modulo =
+      AnalyzePack8In16Codegen(Pack8In16CodegenKernel::kModulo);
+  const CodegenStats saturating =
+      AnalyzePack8In16Codegen(Pack8In16CodegenKernel::kSaturating);
+
+  PrintCodegenStats("MODULO", modulo);
+  PrintCodegenStats("SATURATING", saturating);
+
+  REQUIRE(modulo.region_call_count == 0);
+  REQUIRE(saturating.region_call_count == 0);
+}
+
+#endif  // XE_ARCH_AMD64

--- a/src/xenia/cpu/testing/pack_test.cc
+++ b/src/xenia/cpu/testing/pack_test.cc
@@ -7,6 +7,10 @@
  ******************************************************************************
  */
 
+#include <array>
+#include <cstdint>
+#include <cstdio>
+
 #include "xenia/cpu/testing/util.h"
 
 using namespace xe;
@@ -14,6 +18,164 @@ using namespace xe::cpu;
 using namespace xe::cpu::hir;
 using namespace xe::cpu::testing;
 using xe::cpu::ppc::PPCContext;
+
+namespace {
+
+enum class Pack8Mode {
+  kUnsignedModulo,
+  kUnsignedSaturate,
+  kSignedUnsignedSaturate,
+  kSignedSignedSaturate,
+};
+
+constexpr size_t kPack8ExhaustiveInvocationCount = 1u << 16;
+constexpr size_t kPack8LaneCount = 16;
+
+uint32_t Pack8Flags(Pack8Mode mode) {
+  switch (mode) {
+    case Pack8Mode::kUnsignedModulo:
+      return PACK_TYPE_8_IN_16 | PACK_TYPE_IN_UNSIGNED |
+             PACK_TYPE_OUT_UNSIGNED | PACK_TYPE_OUT_UNSATURATE;
+    case Pack8Mode::kUnsignedSaturate:
+      return PACK_TYPE_8_IN_16 | PACK_TYPE_IN_UNSIGNED |
+             PACK_TYPE_OUT_UNSIGNED | PACK_TYPE_OUT_SATURATE;
+    case Pack8Mode::kSignedUnsignedSaturate:
+      return PACK_TYPE_8_IN_16 | PACK_TYPE_IN_SIGNED | PACK_TYPE_OUT_UNSIGNED |
+             PACK_TYPE_OUT_SATURATE;
+    case Pack8Mode::kSignedSignedSaturate:
+      return PACK_TYPE_8_IN_16 | PACK_TYPE_IN_SIGNED | PACK_TYPE_OUT_SIGNED |
+             PACK_TYPE_OUT_SATURATE;
+  }
+  assert_unhandled_case(mode);
+  return 0;
+}
+
+const char* Pack8ModeName(Pack8Mode mode) {
+  switch (mode) {
+    case Pack8Mode::kUnsignedModulo:
+      return "unsigned modulo";
+    case Pack8Mode::kUnsignedSaturate:
+      return "unsigned saturate";
+    case Pack8Mode::kSignedUnsignedSaturate:
+      return "signed to unsigned saturate";
+    case Pack8Mode::kSignedSignedSaturate:
+      return "signed saturate";
+  }
+  assert_unhandled_case(mode);
+  return "unknown";
+}
+
+uint8_t ReferencePack8Lane(uint16_t raw, Pack8Mode mode) {
+  switch (mode) {
+    case Pack8Mode::kUnsignedModulo:
+      return static_cast<uint8_t>(raw);
+    case Pack8Mode::kUnsignedSaturate:
+      return raw > 255u ? 255u : static_cast<uint8_t>(raw);
+    case Pack8Mode::kSignedUnsignedSaturate: {
+      const int32_t value = raw < 0x8000u ? static_cast<int32_t>(raw)
+                                          : static_cast<int32_t>(raw) - 0x10000;
+      if (value <= 0) {
+        return 0;
+      }
+      return value > 255 ? 255u : static_cast<uint8_t>(value);
+    }
+    case Pack8Mode::kSignedSignedSaturate: {
+      int32_t value = raw < 0x8000u ? static_cast<int32_t>(raw)
+                                    : static_cast<int32_t>(raw) - 0x10000;
+      if (value < -128) {
+        value = -128;
+      } else if (value > 127) {
+        value = 127;
+      }
+      return value < 0 ? static_cast<uint8_t>(256 + value)
+                       : static_cast<uint8_t>(value);
+    }
+  }
+  assert_unhandled_case(mode);
+  return 0;
+}
+
+// Independent guest-lane reference. Within each 32-bit guest word, halfword
+// lane g is host u16[g ^ 1], while byte lane g is host u8[g ^ 3]. The result
+// concatenates the eight narrowed VA lanes and then the eight VB lanes.
+vec128_t ReferencePack8In16(const vec128_t& src1, const vec128_t& src2,
+                            Pack8Mode mode) {
+  vec128_t result = {};
+  for (size_t guest_lane = 0; guest_lane < 8; ++guest_lane) {
+    result.u8[guest_lane ^ 3] =
+        ReferencePack8Lane(src1.u16[guest_lane ^ 1], mode);
+    result.u8[(guest_lane + 8) ^ 3] =
+        ReferencePack8Lane(src2.u16[guest_lane ^ 1], mode);
+  }
+  return result;
+}
+
+void MakePack8ExhaustiveSources(size_t seed, vec128_t& src1, vec128_t& src2) {
+  src1 = {};
+  src2 = {};
+  for (size_t lane = 0; lane < 8; ++lane) {
+    src1.u16[lane] = static_cast<uint16_t>(seed + lane * uint32_t{0x1111});
+    src2.u16[lane] =
+        static_cast<uint16_t>(seed + (lane + 8) * uint32_t{0x1111});
+  }
+}
+
+void RunPack8In16Exhaustive(Pack8Mode mode) {
+  const uint32_t flags = Pack8Flags(mode);
+  TestFunction test([flags](HIRBuilder& b) {
+    StoreVR(b, 3, b.Pack(LoadVR(b, 4), LoadVR(b, 5), flags));
+    b.Return();
+  });
+
+  size_t invocation_count = 0;
+  size_t lane_comparison_count = 0;
+  size_t mismatch_count = 0;
+  size_t first_mismatch_seed = 0;
+  size_t first_mismatch_host_byte = 0;
+  uint32_t first_expected = 0;
+  uint32_t first_actual = 0;
+
+  test.RunRepeated(
+      kPack8ExhaustiveInvocationCount,
+      [](PPCContext* ctx, size_t seed) {
+        MakePack8ExhaustiveSources(seed, ctx->v[4], ctx->v[5]);
+        ctx->v[3] = vec128b(0xCD);
+      },
+      [&](PPCContext* ctx, size_t seed) {
+        vec128_t src1;
+        vec128_t src2;
+        MakePack8ExhaustiveSources(seed, src1, src2);
+        const vec128_t expected = ReferencePack8In16(src1, src2, mode);
+        for (size_t host_byte = 0; host_byte < kPack8LaneCount; ++host_byte) {
+          if (ctx->v[3].u8[host_byte] != expected.u8[host_byte]) {
+            if (mismatch_count == 0) {
+              first_mismatch_seed = seed;
+              first_mismatch_host_byte = host_byte;
+              first_expected = expected.u8[host_byte];
+              first_actual = ctx->v[3].u8[host_byte];
+            }
+            ++mismatch_count;
+          }
+        }
+        ++invocation_count;
+        lane_comparison_count += kPack8LaneCount;
+      });
+
+  std::printf(
+      "PACK_8_IN_16 %s exhaustive: %zu emitted-code calls, %zu lane "
+      "conversions\n",
+      Pack8ModeName(mode), invocation_count, lane_comparison_count);
+  REQUIRE(invocation_count == kPack8ExhaustiveInvocationCount);
+  REQUIRE(invocation_count == 65536);
+  REQUIRE(lane_comparison_count ==
+          kPack8ExhaustiveInvocationCount * kPack8LaneCount);
+  REQUIRE(lane_comparison_count == 1048576);
+  CAPTURE(first_mismatch_seed, first_mismatch_host_byte, first_expected,
+          first_actual);
+  REQUIRE(mismatch_count == 0);
+}
+
+}  // namespace
 
 TEST_CASE("PACK_D3DCOLOR", "[instr]") {
   TestFunction test([](HIRBuilder& b) {
@@ -181,4 +343,232 @@ TEST_CASE("PACK_ULONG_4202020", "[instr]") {
         REQUIRE(ctx->v[3].u32[2] == 0xAFFFFF00);
         REQUIRE(ctx->v[3].u32[3] == 0x032FFF9C);
       });
+}
+
+TEST_CASE("PACK_8_IN_16_GUEST_ORDER_ANCHOR", "[instr]") {
+  const vec128_t src1 = vec128i(0x00000001, 0x00020003, 0x00040005, 0x00060007);
+  const vec128_t src2 = vec128i(0x00080009, 0x000A000B, 0x000C000D, 0x000E000F);
+  const vec128_t literal_expected =
+      vec128i(0x00010203, 0x04050607, 0x08090A0B, 0x0C0D0E0F);
+  TestFunction test([](HIRBuilder& b) {
+    StoreVR(b, 3,
+            b.Pack(LoadVR(b, 4), LoadVR(b, 5),
+                   Pack8Flags(Pack8Mode::kUnsignedModulo)));
+    b.Return();
+  });
+
+  REQUIRE(ReferencePack8In16(src1, src2, Pack8Mode::kUnsignedModulo) ==
+          literal_expected);
+  test.Run(
+      [src1, src2](PPCContext* ctx) {
+        ctx->v[4] = src1;
+        ctx->v[5] = src2;
+      },
+      [literal_expected](PPCContext* ctx) {
+        REQUIRE(ctx->v[3] == literal_expected);
+      });
+}
+
+TEST_CASE("PACK_8_IN_16_UNSIGNED_MODULO_EXHAUSTIVE", "[instr]") {
+  RunPack8In16Exhaustive(Pack8Mode::kUnsignedModulo);
+}
+
+TEST_CASE("PACK_8_IN_16_UNSIGNED_SATURATE_EXHAUSTIVE", "[instr]") {
+  RunPack8In16Exhaustive(Pack8Mode::kUnsignedSaturate);
+}
+
+TEST_CASE("PACK_8_IN_16_SIGNED_UNSIGNED_SATURATE_EXHAUSTIVE", "[instr]") {
+  RunPack8In16Exhaustive(Pack8Mode::kSignedUnsignedSaturate);
+}
+
+TEST_CASE("PACK_8_IN_16_SIGNED_SATURATE_EXHAUSTIVE", "[instr]") {
+  RunPack8In16Exhaustive(Pack8Mode::kSignedSignedSaturate);
+}
+
+TEST_CASE("PACK_8_IN_16_UNSIGNED_CONSTANT_OPERANDS", "[instr]") {
+  const vec128_t constant_src1 =
+      vec128s(0x0000, 0x0001, 0x007F, 0x0080, 0x00FF, 0x0100, 0x7FFF, 0xFFFF);
+  const vec128_t constant_src2 =
+      vec128s(0xFFFF, 0xFF00, 0x01FF, 0x0101, 0x0100, 0x00FE, 0x0080, 0x0001);
+  const vec128_t constant_zero = vec128b(0);
+  const vec128_t constant_ones = vec128b(0xFF);
+  const uint32_t modulo_flags = Pack8Flags(Pack8Mode::kUnsignedModulo);
+  const uint32_t saturate_flags = Pack8Flags(Pack8Mode::kUnsignedSaturate);
+  TestFunction test([=](HIRBuilder& b) {
+    auto* dynamic_src1 = LoadVR(b, 20);
+    auto* dynamic_src2 = LoadVR(b, 21);
+    auto* const_src1 = b.LoadConstantVec128(constant_src1);
+    auto* const_src2 = b.LoadConstantVec128(constant_src2);
+    auto* const_zero = b.LoadConstantVec128(constant_zero);
+    auto* const_ones = b.LoadConstantVec128(constant_ones);
+
+    StoreVR(b, 3, b.Pack(const_src1, dynamic_src2, modulo_flags));
+    StoreVR(b, 4, b.Pack(dynamic_src1, const_src2, modulo_flags));
+    StoreVR(b, 5, b.Pack(const_zero, const_ones, modulo_flags));
+    StoreVR(b, 6, b.Pack(dynamic_src1, dynamic_src1, modulo_flags));
+    StoreVR(b, 7, b.Pack(const_src1, dynamic_src2, saturate_flags));
+    StoreVR(b, 8, b.Pack(dynamic_src1, const_src2, saturate_flags));
+    StoreVR(b, 9, b.Pack(const_zero, const_ones, saturate_flags));
+    StoreVR(b, 10, b.Pack(dynamic_src2, dynamic_src2, saturate_flags));
+    StoreVR(b, 22, dynamic_src1);
+    StoreVR(b, 23, dynamic_src2);
+    b.Return();
+  });
+
+  const vec128_t dynamic_src1 =
+      vec128s(0xABCD, 0x1234, 0x0100, 0x00FF, 0x00AA, 0x5500, 0x0000, 0xFFFF);
+  const vec128_t dynamic_src2 =
+      vec128s(0x1357, 0x2468, 0x0001, 0x00FE, 0x0101, 0x7FFF, 0xFF00, 0x0080);
+  const std::array<vec128_t, 8> expected = {
+      ReferencePack8In16(constant_src1, dynamic_src2,
+                         Pack8Mode::kUnsignedModulo),
+      ReferencePack8In16(dynamic_src1, constant_src2,
+                         Pack8Mode::kUnsignedModulo),
+      ReferencePack8In16(constant_zero, constant_ones,
+                         Pack8Mode::kUnsignedModulo),
+      ReferencePack8In16(dynamic_src1, dynamic_src1,
+                         Pack8Mode::kUnsignedModulo),
+      ReferencePack8In16(constant_src1, dynamic_src2,
+                         Pack8Mode::kUnsignedSaturate),
+      ReferencePack8In16(dynamic_src1, constant_src2,
+                         Pack8Mode::kUnsignedSaturate),
+      ReferencePack8In16(constant_zero, constant_ones,
+                         Pack8Mode::kUnsignedSaturate),
+      ReferencePack8In16(dynamic_src2, dynamic_src2,
+                         Pack8Mode::kUnsignedSaturate),
+  };
+
+  size_t comparison_count = 0;
+  test.Run(
+      [dynamic_src1, dynamic_src2](PPCContext* ctx) {
+        ctx->v[20] = dynamic_src1;
+        ctx->v[21] = dynamic_src2;
+      },
+      [&](PPCContext* ctx) {
+        for (size_t i = 0; i < expected.size(); ++i) {
+          REQUIRE(ctx->v[3 + i] == expected[i]);
+          ++comparison_count;
+        }
+        REQUIRE(ctx->v[22] == dynamic_src1);
+        REQUIRE(ctx->v[23] == dynamic_src2);
+        comparison_count += 2;
+      });
+  std::printf("PACK_8_IN_16 unsigned constants: %zu comparisons\n",
+              comparison_count);
+  REQUIRE(comparison_count == 10);
+}
+
+TEST_CASE("PACK_8_IN_16_UNSIGNED_ARCHITECTURAL_ALIAS", "[instr]") {
+  struct AliasCase {
+    int dest;
+    int src1;
+    int src2;
+  };
+  constexpr std::array<AliasCase, 4> kAliasCases = {{
+      {4, 4, 5},  // VD == VA
+      {5, 4, 5},  // VD == VB
+      {3, 4, 4},  // VA == VB
+      {4, 4, 4},  // VD == VA == VB
+  }};
+  constexpr std::array<Pack8Mode, 2> kModes = {
+      Pack8Mode::kUnsignedModulo,
+      Pack8Mode::kUnsignedSaturate,
+  };
+  const vec128_t src1 =
+      vec128s(0x0000, 0x00FF, 0x0100, 0x0101, 0x1234, 0xABCD, 0xFF00, 0xFFFF);
+  const vec128_t src2 =
+      vec128s(0xFFFF, 0x7FFF, 0x01FF, 0x0100, 0x00FE, 0x0080, 0x0001, 0x0000);
+
+  size_t run_count = 0;
+  for (Pack8Mode mode : kModes) {
+    for (const AliasCase& alias : kAliasCases) {
+      const uint32_t flags = Pack8Flags(mode);
+      TestFunction test([alias, flags](HIRBuilder& b) {
+        StoreVR(b, alias.dest,
+                b.Pack(LoadVR(b, alias.src1), LoadVR(b, alias.src2), flags));
+        b.Return();
+      });
+      const vec128_t& expected_src2 = alias.src2 == alias.src1 ? src1 : src2;
+      const vec128_t expected = ReferencePack8In16(src1, expected_src2, mode);
+      test.Run(
+          [src1, src2](PPCContext* ctx) {
+            ctx->v[4] = src1;
+            ctx->v[5] = src2;
+          },
+          [alias, expected](PPCContext* ctx) {
+            REQUIRE(ctx->v[alias.dest] == expected);
+          });
+      ++run_count;
+    }
+  }
+  std::printf("PACK_8_IN_16 unsigned architectural aliases: %zu runs\n",
+              run_count);
+  REQUIRE(run_count == kModes.size() * kAliasCases.size());
+  REQUIRE(run_count == 8);
+}
+
+TEST_CASE("PACK_8_IN_16_UNSIGNED_SOURCE_LIVE_PRESSURE", "[instr]") {
+  constexpr size_t kSurvivorCount = 12;
+  const uint32_t modulo_flags = Pack8Flags(Pack8Mode::kUnsignedModulo);
+  const uint32_t saturate_flags = Pack8Flags(Pack8Mode::kUnsignedSaturate);
+  TestFunction test([=](HIRBuilder& b) {
+    auto* src1 = LoadVR(b, 4);
+    auto* src2 = LoadVR(b, 5);
+    std::array<Value*, kSurvivorCount> survivors;
+    for (size_t i = 0; i < survivors.size(); ++i) {
+      survivors[i] = LoadVR(b, 6 + static_cast<int>(i));
+    }
+    auto* modulo = b.Pack(src1, src2, modulo_flags);
+    auto* saturated = b.Pack(src1, src2, saturate_flags);
+    StoreVR(b, 3, modulo);
+    StoreVR(b, 18, saturated);
+    StoreVR(b, 19, src1);
+    StoreVR(b, 20, src2);
+    for (size_t i = 0; i < survivors.size(); ++i) {
+      StoreVR(b, 21 + static_cast<int>(i), survivors[i]);
+    }
+    b.Return();
+  });
+
+  const vec128_t src1 =
+      vec128s(0x0000, 0x00FF, 0x0100, 0x0101, 0x1234, 0xABCD, 0xFF00, 0xFFFF);
+  const vec128_t src2 =
+      vec128s(0xFFFF, 0x7FFF, 0x01FF, 0x0100, 0x00FE, 0x0080, 0x0001, 0x0000);
+  std::array<vec128_t, kSurvivorCount> survivors;
+  for (size_t i = 0; i < survivors.size(); ++i) {
+    survivors[i] = vec128i(0x01020304u + static_cast<uint32_t>(i),
+                           0x11223344u + static_cast<uint32_t>(i),
+                           0x89ABCDEFu - static_cast<uint32_t>(i),
+                           0xF0E1D2C3u - static_cast<uint32_t>(i));
+  }
+  const vec128_t expected_modulo =
+      ReferencePack8In16(src1, src2, Pack8Mode::kUnsignedModulo);
+  const vec128_t expected_saturated =
+      ReferencePack8In16(src1, src2, Pack8Mode::kUnsignedSaturate);
+
+  size_t comparison_count = 0;
+  test.Run(
+      [src1, src2, survivors](PPCContext* ctx) {
+        ctx->v[4] = src1;
+        ctx->v[5] = src2;
+        for (size_t i = 0; i < survivors.size(); ++i) {
+          ctx->v[6 + i] = survivors[i];
+        }
+      },
+      [&](PPCContext* ctx) {
+        REQUIRE(ctx->v[3] == expected_modulo);
+        REQUIRE(ctx->v[18] == expected_saturated);
+        REQUIRE(ctx->v[19] == src1);
+        REQUIRE(ctx->v[20] == src2);
+        comparison_count += 4;
+        for (size_t i = 0; i < survivors.size(); ++i) {
+          REQUIRE(ctx->v[21 + i] == survivors[i]);
+          ++comparison_count;
+        }
+      });
+  std::printf(
+      "PACK_8_IN_16 pressure: 14 live inputs, %zu post-pack comparisons\n",
+      comparison_count);
+  REQUIRE(comparison_count == 4 + kSurvivorCount);
+  REQUIRE(comparison_count == 16);
 }

--- a/src/xenia/cpu/testing/util.h
+++ b/src/xenia/cpu/testing/util.h
@@ -98,6 +98,41 @@ class TestFunction {
     }
   }
 
+  template <typename PreCall, typename PostCall>
+  void RunRepeated(size_t iteration_count, PreCall&& pre_call,
+                   PostCall&& post_call) {
+    for (auto& processor : processors) {
+      auto fn = processor->ResolveFunction(0x80000000);
+      REQUIRE(fn != nullptr);
+
+      uint32_t stack_size = 64 * 1024;
+      uint32_t stack_address = memory->SystemHeapAlloc(stack_size);
+      uint32_t stack_base = stack_address + stack_size;
+      auto thread_state =
+          std::make_unique<ThreadState>(processor.get(), 0x100, stack_base);
+      auto ctx = thread_state->context();
+
+      // Establish the same clean initial rounding mode as Run. The emitted
+      // function may switch to VMX mode, so resetting the host mode without
+      // also resetting the emitter's runtime mode state between invocations
+      // would make the next invocation internally inconsistent.
+      processor->backend()->SetGuestRoundingMode(ctx, 0);
+
+      size_t successful_call_count = 0;
+      for (size_t iteration = 0; iteration < iteration_count; ++iteration) {
+        ctx->lr = 0xBCBCBCBC;
+        pre_call(ctx, iteration);
+        if (fn->Call(thread_state.get(), uint32_t(ctx->lr))) {
+          ++successful_call_count;
+        }
+        post_call(ctx, iteration);
+      }
+      thread_state.reset();
+      memory->SystemHeapFree(stack_address);
+      REQUIRE(successful_call_count == iteration_count);
+    }
+  }
+
   std::unique_ptr<Memory> memory;
   std::vector<std::unique_ptr<Processor>> processors;
 };


### PR DESCRIPTION
Superseded by #1197.

This original submission remains closed at commit `721d5054a60e7bd923c02fafdd5c722a67518893`. It was not adequately validated before submission. The replacement in #1197 was rebuilt as one clean commit with current local, hosted-build, and static-analysis verification.

Was AI used in this change: Yes
