### PR TITLE
[CPU/X64] Inline unsigned PACK 8_IN_16 paths

### DIFF
--- a/src/xenia/cpu/backend/x64/x64_emitter.cc
+++ b/src/xenia/cpu/backend/x64/x64_emitter.cc
@@ -1077,6 +1077,8 @@ static const vec128_t xmm_consts[] = {
     vec128i(0xFFFFFFFFu, 0xFFFFFFFFu, 0x0A0908FFu, 0xFF020100u),
     /* XMMPackULONG_4202020_PermuteYW */
     vec128i(0xFFFFFFFFu, 0xFFFFFFFFu, 0x0CFFFF06u, 0x0504FFFFu),
+    /* XMMPack8_IN_16_UnsignedByteMax */
+    vec128i(0x00FF00FFu, 0x00FF00FFu, 0x00FF00FFu, 0x00FF00FFu),
     /* XMMUnpackULONG_4202020_Permute */
     vec128i(0xFF0E0D0Cu, 0xFF0B0A09u, 0xFF080F0Eu, 0xFFFFFF0Bu),
     /* XMMUnpackULONG_4202020_Overflow */ vec128i(0x40380000u),

--- a/src/xenia/cpu/backend/x64/x64_emitter.h
+++ b/src/xenia/cpu/backend/x64/x64_emitter.h
@@ -126,6 +126,7 @@ enum XmmConst {
   XMMPackULONG_4202020_MaskUnpacked,
   XMMPackULONG_4202020_PermuteXZ,
   XMMPackULONG_4202020_PermuteYW,
+  XMMPack8_IN_16_UnsignedByteMax,
   XMMUnpackULONG_4202020_Permute,
   XMMUnpackULONG_4202020_Overflow,
   XMMOneOver255,

--- a/src/xenia/cpu/backend/x64/x64_seq_vector.cc
+++ b/src/xenia/cpu/backend/x64/x64_seq_vector.cc
@@ -9,7 +9,6 @@
 
 #include "xenia/cpu/backend/x64/x64_sequences.h"
 
-#include <algorithm>
 #include <cstring>
 
 #include "xenia/cpu/backend/x64/x64_op.h"
@@ -2994,71 +2993,31 @@ struct PACK : Sequence<PACK, I<OPCODE_PACK, V128Op, V128Op, V128Op>> {
     // Merge XZ and YW.
     e.vorps(i.dest, e.xmm0);
   }
-  static __m128i EmulatePack8_IN_16_UN_UN_SAT(void*, __m128i src1,
-                                              __m128i src2) {
-    alignas(16) uint16_t a[8];
-    alignas(16) uint16_t b[8];
-    alignas(16) uint8_t c[16];
-    _mm_store_si128(reinterpret_cast<__m128i*>(a), src1);
-    _mm_store_si128(reinterpret_cast<__m128i*>(b), src2);
-    for (int i = 0; i < 8; ++i) {
-      c[i] = uint8_t(std::max(uint16_t(0), std::min(uint16_t(255), a[i])));
-      c[i + 8] = uint8_t(std::max(uint16_t(0), std::min(uint16_t(255), b[i])));
-    }
-    return _mm_load_si128(reinterpret_cast<__m128i*>(c));
-  }
-  static __m128i EmulatePack8_IN_16_UN_UN(void*, __m128i src1, __m128i src2) {
-    alignas(16) uint8_t a[16];
-    alignas(16) uint8_t b[16];
-    alignas(16) uint8_t c[16];
-    _mm_store_si128(reinterpret_cast<__m128i*>(a), src1);
-    _mm_store_si128(reinterpret_cast<__m128i*>(b), src2);
-    for (int i = 0; i < 8; ++i) {
-      c[i] = a[i * 2];
-      c[i + 8] = b[i * 2];
-    }
-    return _mm_load_si128(reinterpret_cast<__m128i*>(c));
-  }
   static void Emit8_IN_16(X64Emitter& e, const EmitArgType& i, uint32_t flags) {
     // TODO(benvanik): handle src2 (or src1) being constant zero
     if (IsPackInUnsigned(flags)) {
       if (IsPackOutUnsigned(flags)) {
         if (IsPackOutSaturate(flags)) {
           // unsigned -> unsigned + saturate
-          auto src1 = GetInputRegOrConstant(e, i.src1, e.xmm3);
-          auto src2 = GetInputRegOrConstant(e, i.src2, e.xmm4);
-
-#if XE_PLATFORM_WIN32
-          // Windows x64 ABI: __m128i is passed by implicit pointer
-          e.lea(e.GetNativeParam(0), e.StashXmm(0, src1));
-          e.lea(e.GetNativeParam(1), e.StashXmm(1, src2));
-#else
-          // Linux/Mac System V ABI: __m128i passed in xmm0/xmm1, return in xmm0
-          e.vmovaps(e.xmm0, src1);
-          e.vmovaps(e.xmm1, src2);
-#endif
-          e.CallNativeSafe(
-              reinterpret_cast<void*>(EmulatePack8_IN_16_UN_UN_SAT));
-          e.vmovaps(i.dest, e.xmm0);
-          e.vpshufb(i.dest, i.dest, e.GetXmmConstPtr(XMMByteOrderMask));
+          // Clamp each unsigned word to 255 before signed-word byte packing.
+          const Xmm src1 = GetInputRegOrConstant(e, i.src1, e.xmm0);
+          e.vpminuw(e.xmm0, src1,
+                    e.GetXmmConstPtr(XMMPack8_IN_16_UnsignedByteMax));
+          const Xmm src2 = GetInputRegOrConstant(e, i.src2, e.xmm1);
+          e.vpminuw(e.xmm1, src2,
+                    e.GetXmmConstPtr(XMMPack8_IN_16_UnsignedByteMax));
         } else {
           // unsigned -> unsigned
-          auto src1 = GetInputRegOrConstant(e, i.src1, e.xmm3);
-          auto src2 = GetInputRegOrConstant(e, i.src2, e.xmm4);
-
-#if XE_PLATFORM_WIN32
-          // Windows x64 ABI: __m128i is passed by implicit pointer
-          e.lea(e.GetNativeParam(0), e.StashXmm(0, src1));
-          e.lea(e.GetNativeParam(1), e.StashXmm(1, src2));
-#else
-          // Linux/Mac System V ABI: __m128i passed in xmm0/xmm1, return in xmm0
-          e.vmovaps(e.xmm0, src1);
-          e.vmovaps(e.xmm1, src2);
-#endif
-          e.CallNativeSafe(reinterpret_cast<void*>(EmulatePack8_IN_16_UN_UN));
-          e.vmovaps(i.dest, e.xmm0);
-          e.vpshufb(i.dest, i.dest, e.GetXmmConstPtr(XMMByteOrderMask));
+          // Keep each word's low byte before signed-word byte packing.
+          const Xmm src1 = GetInputRegOrConstant(e, i.src1, e.xmm0);
+          e.vpand(e.xmm0, src1,
+                  e.GetXmmConstPtr(XMMPack8_IN_16_UnsignedByteMax));
+          const Xmm src2 = GetInputRegOrConstant(e, i.src2, e.xmm1);
+          e.vpand(e.xmm1, src2,
+                  e.GetXmmConstPtr(XMMPack8_IN_16_UnsignedByteMax));
         }
+        e.vpackuswb(i.dest, e.xmm0, e.xmm1);
+        e.vpshufb(i.dest, i.dest, e.GetXmmConstPtr(XMMByteOrderMask));
       } else {
         if (IsPackOutSaturate(flags)) {
           // unsigned -> signed + saturate

--- a/src/xenia/cpu/testing/pack_test.cc
+++ b/src/xenia/cpu/testing/pack_test.cc
@@ -9,11 +9,63 @@
 
 #include "xenia/cpu/testing/util.h"
 
+#include <array>
+
+#include "xenia/base/platform.h"
+#if XE_ARCH_AMD64
+#include "third_party/capstone/include/capstone/capstone.h"
+#include "third_party/capstone/include/capstone/x86.h"
+#include "xenia/cpu/function.h"
+#endif  // XE_ARCH_AMD64
+
 using namespace xe;
 using namespace xe::cpu;
 using namespace xe::cpu::hir;
 using namespace xe::cpu::testing;
 using xe::cpu::ppc::PPCContext;
+
+#if XE_ARCH_AMD64
+namespace {
+
+size_t CountCallsInRegion(TestFunction& test, uint32_t begin_address,
+                          uint32_t end_address) {
+  REQUIRE(test.processors.size() == 1);
+  auto* function = static_cast<GuestFunction*>(
+      test.processors.front()->ResolveFunction(0x80000000));
+  REQUIRE(function != nullptr);
+  REQUIRE(function->machine_code() != nullptr);
+  const SourceMapEntry* begin = function->LookupGuestAddress(begin_address);
+  const SourceMapEntry* end = function->LookupGuestAddress(end_address);
+  REQUIRE(begin != nullptr);
+  REQUIRE(end != nullptr);
+  REQUIRE(end->code_offset > begin->code_offset);
+  REQUIRE(end->code_offset <= function->machine_code_length());
+
+  const size_t byte_count = end->code_offset - begin->code_offset;
+  const uint8_t* code = function->machine_code() + begin->code_offset;
+  csh handle = 0;
+  REQUIRE(cs_open(CS_ARCH_X86, CS_MODE_64, &handle) == CS_ERR_OK);
+  cs_insn* instructions = nullptr;
+  const size_t instruction_count =
+      cs_disasm(handle, code, byte_count, 0, 0, &instructions);
+  size_t decoded_bytes = 0;
+  size_t call_count = 0;
+  for (size_t i = 0; i < instruction_count; ++i) {
+    decoded_bytes += instructions[i].size;
+    call_count += instructions[i].id == X86_INS_CALL;
+  }
+  if (instructions != nullptr) {
+    cs_free(instructions, instruction_count);
+  }
+  cs_close(&handle);
+
+  REQUIRE(instruction_count > 0);
+  REQUIRE(decoded_bytes == byte_count);
+  return call_count;
+}
+
+}  // namespace
+#endif  // XE_ARCH_AMD64
 
 TEST_CASE("PACK_D3DCOLOR", "[instr]") {
   TestFunction test([](HIRBuilder& b) {
@@ -181,4 +233,126 @@ TEST_CASE("PACK_ULONG_4202020", "[instr]") {
         REQUIRE(ctx->v[3].u32[2] == 0xAFFFFF00);
         REQUIRE(ctx->v[3].u32[3] == 0x032FFF9C);
       });
+}
+
+TEST_CASE("PACK_8_IN_16_UNSIGNED", "[instr]") {
+  const vec128_t src1 =
+      vec128s(0x0000, 0x0001, 0x007F, 0x0080, 0x00FE, 0x00FF, 0x0100, 0xFFFF);
+  const vec128_t src2 =
+      vec128s(0x0101, 0x01FF, 0x1234, 0x7FFF, 0x8000, 0xABCD, 0xFF00, 0xFFFE);
+  const vec128_t expected_modulo =
+      vec128b(0x00, 0x01, 0x7F, 0x80, 0xFE, 0xFF, 0x00, 0xFF, 0x01, 0xFF, 0x34,
+              0xFF, 0x00, 0xCD, 0x00, 0xFE);
+  const vec128_t expected_saturating =
+      vec128b(0x00, 0x01, 0x7F, 0x80, 0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+              0xFF, 0xFF, 0xFF, 0xFF, 0xFF);
+  constexpr uint32_t kModuloFlags = PACK_TYPE_8_IN_16 | PACK_TYPE_IN_UNSIGNED |
+                                    PACK_TYPE_OUT_UNSIGNED |
+                                    PACK_TYPE_OUT_UNSATURATE;
+  constexpr uint32_t kSaturatingFlags =
+      PACK_TYPE_8_IN_16 | PACK_TYPE_IN_UNSIGNED | PACK_TYPE_OUT_UNSIGNED |
+      PACK_TYPE_OUT_SATURATE;
+  constexpr uint32_t kPackCodegenBegin = 0x80000000;
+  constexpr uint32_t kPackCodegenEnd = 0x80000004;
+
+  {
+    TestFunction test([=](HIRBuilder& b) {
+      auto* dynamic_src1 = LoadVR(b, 4);
+      auto* dynamic_src2 = LoadVR(b, 5);
+      auto* constant_src1 = b.LoadConstantVec128(src1);
+      auto* constant_src2 = b.LoadConstantVec128(src2);
+
+      b.SourceOffset(kPackCodegenBegin);
+      auto* dynamic_modulo = b.Pack(dynamic_src1, dynamic_src2, kModuloFlags);
+      auto* dynamic_saturating =
+          b.Pack(dynamic_src1, dynamic_src2, kSaturatingFlags);
+      auto* constant_src1_modulo =
+          b.Pack(constant_src1, dynamic_src2, kModuloFlags);
+      auto* constant_src2_modulo =
+          b.Pack(dynamic_src1, constant_src2, kModuloFlags);
+      auto* constant_src1_saturating =
+          b.Pack(constant_src1, dynamic_src2, kSaturatingFlags);
+      auto* constant_src2_saturating =
+          b.Pack(dynamic_src1, constant_src2, kSaturatingFlags);
+      b.SourceOffset(kPackCodegenEnd);
+
+      StoreVR(b, 3, dynamic_modulo);
+      StoreVR(b, 6, dynamic_saturating);
+      StoreVR(b, 7, constant_src1_modulo);
+      StoreVR(b, 8, constant_src2_modulo);
+      StoreVR(b, 9, constant_src1_saturating);
+      StoreVR(b, 10, constant_src2_saturating);
+      b.Return();
+    });
+
+    test.Run(
+        [=](PPCContext* ctx) {
+          ctx->v[4] = src1;
+          ctx->v[5] = src2;
+        },
+        [=](PPCContext* ctx) {
+          REQUIRE(ctx->v[3] == expected_modulo);
+          REQUIRE(ctx->v[6] == expected_saturating);
+          REQUIRE(ctx->v[7] == expected_modulo);
+          REQUIRE(ctx->v[8] == expected_modulo);
+          REQUIRE(ctx->v[9] == expected_saturating);
+          REQUIRE(ctx->v[10] == expected_saturating);
+        });
+
+#if XE_ARCH_AMD64
+    REQUIRE(CountCallsInRegion(test, kPackCodegenBegin, kPackCodegenEnd) == 0);
+#endif  // XE_ARCH_AMD64
+  }
+
+#if XE_ARCH_AMD64
+  constexpr size_t kSurvivorCount = 12;
+  std::array<vec128_t, kSurvivorCount> sentinels{};
+  for (size_t i = 0; i < sentinels.size(); ++i) {
+    const uint32_t value = 0x11000000u + static_cast<uint32_t>(i);
+    sentinels[i] =
+        vec128i(value, value + 0x100u, value + 0x200u, value + 0x300u);
+  }
+
+  TestFunction pressure_test([=](HIRBuilder& b) {
+    auto* modulo_src1 = LoadVR(b, 4);
+    auto* modulo_src2 = LoadVR(b, 5);
+    auto* saturating_src1 = LoadVR(b, 4);
+    auto* saturating_src2 = LoadVR(b, 5);
+    std::array<Value*, kSurvivorCount> survivors{};
+    for (size_t i = 0; i < survivors.size(); ++i) {
+      survivors[i] = LoadVR(b, 16 + static_cast<int>(i));
+    }
+
+    auto* modulo = b.Pack(modulo_src1, modulo_src2, kModuloFlags);
+    auto* saturating =
+        b.Pack(saturating_src1, saturating_src2, kSaturatingFlags);
+
+    StoreVR(b, 11, modulo);
+    StoreVR(b, 12, saturating);
+    StoreVR(b, 13, modulo_src2);
+    StoreVR(b, 14, saturating_src1);
+    for (size_t i = 0; i < survivors.size(); ++i) {
+      StoreVR(b, 32 + static_cast<int>(i), survivors[i]);
+    }
+    b.Return();
+  });
+
+  pressure_test.Run(
+      [=](PPCContext* ctx) {
+        ctx->v[4] = src1;
+        ctx->v[5] = src2;
+        for (size_t i = 0; i < sentinels.size(); ++i) {
+          ctx->v[16 + i] = sentinels[i];
+        }
+      },
+      [=](PPCContext* ctx) {
+        REQUIRE(ctx->v[11] == expected_modulo);
+        REQUIRE(ctx->v[12] == expected_saturating);
+        REQUIRE(ctx->v[13] == src2);
+        REQUIRE(ctx->v[14] == src1);
+        for (size_t i = 0; i < sentinels.size(); ++i) {
+          REQUIRE(ctx->v[32 + i] == sentinels[i]);
+        }
+      });
+#endif  // XE_ARCH_AMD64
 }


### PR DESCRIPTION
Supersedes #1192. The original submission was closed because it was not adequately validated; this replacement uses the rebuilt and tested one-commit candidate.

Replaces the unsigned modulo and unsigned saturating `PACK 8_IN_16` native helper calls with inline x64 sequences.

- Unsigned modulo masks every source word to its low byte before `vpackuswb`.
- Unsigned saturating clamps every source word to 255 before `vpackuswb`.
- Both paths retain the existing guest byte-order shuffle.
- The per-execution native helper call and ABI-specific operand stashing are removed.

Focused permanent coverage checks boundary and lane ordering, both constant-operand positions, register pressure, source liveness, spill survival, complete decoding of the marked x64 region, and zero emitted `call` instructions.

Verification for exact candidate `391f7efa93ebb1098f51f4c2097fe1bbf4f78563`, rebased onto upstream `3494b56a0b8b60efbcc66e46afa67977787b2c6d`:

- Existing branch rebased in place; the PACK patch is unchanged (one commit, four files).
- Local clang-format 20.1.8 over all four touched files: pass
- Local Release `xenia-app` rebuild: pass
- Full local Release `xenia-cpu-tests`: pass (247 cases / 858 assertions)
- Focused local `*PACK_8_IN_16*` test: pass (1 case / 33 assertions)
- [Public fork GitHub Actions run](https://github.com/eternalgr3y/xenia-canary/actions/runs/33748703204): pass (Windows Release build/package, Linux Release build/AppImage, and lint)
- [Public Codacy check](https://github.com/xenia-canary/xenia-canary/runs/100627175038): pass (zero issues)

The fork run uses the unchanged upstream build/lint workflows. They build/package the application but do not execute the CPU tests; the test results above are local. Commit-message validation is PR-only and is intentionally skipped for this fork push.

The [upstream PR workflow](https://github.com/xenia-canary/xenia-canary/actions/runs/33748703700) is awaiting maintainer approval and has not run any jobs. It is not being claimed as passed.

Clarification: the earlier pre-publication hosted results were from a separate private CI rehearsal, not runs in this public fork or this upstream PR.

Known limitation: this preserves Xenia's existing `VSCR.SAT` behavior. It validates packed-byte output and helper removal, but does not make sticky saturation state architecturally correct. That broader issue requires original-operand overflow detection, sticky-state plumbing, and x64/AArch64 coverage in a separate change.

Related prior work: [has207/xenia-edge#255](https://github.com/has207/xenia-edge/pull/255) explored the same `vpminuw` / `vpand` plus `vpackuswb` instruction strategy in a broader optimization patch. It was closed without a final x64 test run; this PR keeps the change focused on `PACK 8_IN_16` and adds current x64 coverage.

Was AI used in this change: Yes


