### PR TITLE
[CPU/HIR] Select the same vperm half as the backend in the int16 fold

### DIFF
--- a/src/xenia/cpu/hir/value.cc
+++ b/src/xenia/cpu/hir/value.cc
@@ -890,12 +890,13 @@ void Value::Permute(Value* src1, Value* src2, TypeName type) {
       }
     }
 
-    // Blend: select from shuf1 where mask bit is set, shuf2 otherwise
+    // Blend the same way the backends do: vpblendw takes its *second* source
+    // where the mask bit is set, so a set bit selects shuf2.
     for (int i = 0; i < 8; i++) {
       if (mask & (1 << i)) {
-        constant.v128.u16[i] = shuf1.u16[i];
-      } else {
         constant.v128.u16[i] = shuf2.u16[i];
+      } else {
+        constant.v128.u16[i] = shuf1.u16[i];
       }
     }
 


### PR DESCRIPTION
Cherry-picked from has207's xenia-edge d39b10a2, authorship kept.

Two places build the same 8-bit blend mask for a vperm and then read it in
opposite directions. The constant folder in `Value::Permute` treats a set bit as
"take from the first table". The x64 emitter uses `vpblendw`, which takes from
its second source where the bit is set. The folder is called with (src2, src3),
so whenever it runs it produces the exact opposite of what the emitted code
would have.

It never runs today. Folding needs the control and both tables to be constant,
and #860 stopped vectors being promoted out of the context, so the tables stay
opaque and the emitter always handles it. Fixing the fold is what makes that
exclusion unnecessary.

With both in place, a CPU-bound Lost Odyssey scene goes from 30.8-31.4 to
36.4-38.2 fps, and vector context loads and stores in the hot function drop
from 509 to 244. I asked on #860 what the exclusion was for and has207 pointed
at this commit, which he wrote for AC4 Black Flag's packed vertex normals.
