### PR TITLE
[CPU] Constant-fold and constant-operand fixes in the vector path

### DIFF
--- a/src/xenia/cpu/backend/x64/x64_seq_vector.cc
+++ b/src/xenia/cpu/backend/x64/x64_seq_vector.cc
@@ -458,21 +458,23 @@ struct VECTOR_COMPARE_SGE_V128
                 break;
             }
           } else {
+            // Not xmm0: EmitAssociativeBinaryXmmOp materializes a constant
+            // operand there, and both compares read it.
             switch (i.instr->flags) {
               case INT8_TYPE:
-                e.vpcmpeqb(e.xmm0, src1, src2);
+                e.vpcmpeqb(e.xmm1, src1, src2);
                 e.vpcmpgtb(dest, src1, src2);
-                e.vpor(dest, e.xmm0);
+                e.vpor(dest, e.xmm1);
                 break;
               case INT16_TYPE:
-                e.vpcmpeqw(e.xmm0, src1, src2);
+                e.vpcmpeqw(e.xmm1, src1, src2);
                 e.vpcmpgtw(dest, src1, src2);
-                e.vpor(dest, e.xmm0);
+                e.vpor(dest, e.xmm1);
                 break;
               case INT32_TYPE:
-                e.vpcmpeqd(e.xmm0, src1, src2);
+                e.vpcmpeqd(e.xmm1, src1, src2);
                 e.vpcmpgtd(dest, src1, src2);
-                e.vpor(dest, e.xmm0);
+                e.vpor(dest, e.xmm1);
                 break;
               case FLOAT32_TYPE:
                 e.ChangeMxcsrMode(MXCSRMode::Vmx);
@@ -3026,7 +3028,7 @@ struct PACK : Sequence<PACK, I<OPCODE_PACK, V128Op, V128Op, V128Op>> {
         if (IsPackOutSaturate(flags)) {
           // unsigned -> unsigned + saturate
           auto src1 = GetInputRegOrConstant(e, i.src1, e.xmm3);
-          auto src2 = GetInputRegOrConstant(e, i.src2, e.xmm4);
+          auto src2 = GetInputRegOrConstant(e, i.src2, e.xmm1);
 
 #if XE_PLATFORM_WIN32
           // Windows x64 ABI: __m128i is passed by implicit pointer
@@ -3044,7 +3046,7 @@ struct PACK : Sequence<PACK, I<OPCODE_PACK, V128Op, V128Op, V128Op>> {
         } else {
           // unsigned -> unsigned
           auto src1 = GetInputRegOrConstant(e, i.src1, e.xmm3);
-          auto src2 = GetInputRegOrConstant(e, i.src2, e.xmm4);
+          auto src2 = GetInputRegOrConstant(e, i.src2, e.xmm1);
 
 #if XE_PLATFORM_WIN32
           // Windows x64 ABI: __m128i is passed by implicit pointer

--- a/src/xenia/cpu/backend/x64/x64_seq_vector.cc
+++ b/src/xenia/cpu/backend/x64/x64_seq_vector.cc
@@ -104,11 +104,11 @@ struct VECTOR_CONVERT_F2I
         Opmask mask = e.k1;
         // Mask non-negative, non-NaN values (ordered, >= 0)
         // _CMP_GE_OQ
-        e.vcmpps(mask, i.src1, e.GetXmmConstPtr(XMMZero), 0x1D);
+        e.vcmpps(mask, src1, e.GetXmmConstPtr(XMMZero), 0x1D);
 
         // vcvttps2udq will saturate overflowing positive values to UINT_MAX.
         // Zero-masking writes zero for negative values and NaN
-        e.vcvttps2udq(i.dest.reg() | mask | e.T_z, i.src1);
+        e.vcvttps2udq(i.dest.reg() | mask | e.T_z, src1);
         return;
       }
 
@@ -2209,13 +2209,16 @@ struct EXTRACT_I8
     : Sequence<EXTRACT_I8, I<OPCODE_EXTRACT, I8Op, V128Op, I8Op>> {
   static void Emit(X64Emitter& e, const EmitArgType& i) {
     if (i.src2.is_constant) {
-      e.vpextrb(i.dest.reg().cvt32(), i.src1, VEC128_B(i.src2.constant()));
+      Xmm src1 = GetInputRegOrConstant(e, i.src1, e.xmm0);
+      e.vpextrb(i.dest.reg().cvt32(), src1, VEC128_B(i.src2.constant()));
     } else {
+      // Not xmm0: that holds the shuffle control below.
+      Xmm src1 = GetInputRegOrConstant(e, i.src1, e.xmm1);
       e.mov(e.eax, 0x00000003);
       e.xor_(e.al, i.src2);
       e.and_(e.al, 0x1F);
       e.vmovd(e.xmm0, e.eax);
-      e.vpshufb(e.xmm0, i.src1, e.xmm0);
+      e.vpshufb(e.xmm0, src1, e.xmm0);
       e.vmovd(i.dest.reg().cvt32(), e.xmm0);
       e.and_(i.dest, uint8_t(0xFF));
     }
@@ -2225,15 +2228,18 @@ struct EXTRACT_I16
     : Sequence<EXTRACT_I16, I<OPCODE_EXTRACT, I16Op, V128Op, I8Op>> {
   static void Emit(X64Emitter& e, const EmitArgType& i) {
     if (i.src2.is_constant) {
-      e.vpextrw(i.dest.reg().cvt32(), i.src1, VEC128_W(i.src2.constant()));
+      Xmm src1 = GetInputRegOrConstant(e, i.src1, e.xmm0);
+      e.vpextrw(i.dest.reg().cvt32(), src1, VEC128_W(i.src2.constant()));
     } else {
+      // Not xmm0: that holds the shuffle control below.
+      Xmm src1 = GetInputRegOrConstant(e, i.src1, e.xmm1);
       e.mov(e.al, i.src2);
       e.xor_(e.al, 0x01);
       e.shl(e.al, 1);
       e.mov(e.ah, e.al);
       e.add(e.ah, 1);
       e.vmovd(e.xmm0, e.eax);
-      e.vpshufb(e.xmm0, i.src1, e.xmm0);
+      e.vpshufb(e.xmm0, src1, e.xmm0);
       e.vmovd(i.dest.reg().cvt32(), e.xmm0);
       e.and_(i.dest.reg().cvt32(), 0xFFFFu);
     }

--- a/src/xenia/cpu/hir/value.cc
+++ b/src/xenia/cpu/hir/value.cc
@@ -830,17 +830,18 @@ void Value::RotateLeft(Value* other) {
 void Value::Extract(Value* vec, Value* index) {
   assert_true(vec->type == VEC128_TYPE);
   switch (type) {
+    // Guest element numbers need the backends' VEC128_B/W flip.
     case INT8_TYPE:
-      constant.u8 = vec->constant.v128.u8[index->constant.u8 & 0x1F];
+      constant.u8 = vec->constant.v128.u8[(index->constant.u8 & 0xF) ^ 3];
       break;
     case INT16_TYPE:
-      constant.u16 = vec->constant.v128.u16[index->constant.u16 & 0x7];
+      constant.u16 = vec->constant.v128.u16[(index->constant.u8 & 0x7) ^ 1];
       break;
     case INT32_TYPE:
-      constant.u32 = vec->constant.v128.u32[index->constant.u32 & 0x3];
+      constant.u32 = vec->constant.v128.u32[index->constant.u8 & 0x3];
       break;
     case INT64_TYPE:
-      constant.u64 = vec->constant.v128.u64[index->constant.u64 & 0x1];
+      constant.u64 = vec->constant.v128.u64[index->constant.u8 & 0x1];
       break;
     default:
       assert_unhandled_case(type);

--- a/src/xenia/cpu/hir/value.cc
+++ b/src/xenia/cpu/hir/value.cc
@@ -1007,17 +1007,29 @@ void Value::VectorCompareEQ(Value* other, TypeName type) {
       }
       break;
     case INT32_TYPE:
-    case FLOAT32_TYPE:
       for (int i = 0; i < 4; i++) {
         constant.v128.u32[i] =
             constant.v128.u32[i] == other->constant.v128.u32[i] ? -1 : 0;
       }
       break;
     case INT64_TYPE:
-    case FLOAT64_TYPE:
       for (int i = 0; i < 2; i++) {
         constant.v128.u64[i] =
             constant.v128.u64[i] == other->constant.v128.u64[i] ? -1 : 0;
+      }
+      break;
+    // Float compares are unordered and treat the two zeroes as equal, which
+    // a bitwise compare gets wrong both ways.
+    case FLOAT32_TYPE:
+      for (int i = 0; i < 4; i++) {
+        constant.v128.u32[i] =
+            constant.v128.f32[i] == other->constant.v128.f32[i] ? -1 : 0;
+      }
+      break;
+    case FLOAT64_TYPE:
+      for (int i = 0; i < 2; i++) {
+        constant.v128.u64[i] =
+            constant.v128.f64[i] == other->constant.v128.f64[i] ? -1 : 0;
       }
       break;
     default:

--- a/src/xenia/cpu/testing/byte_swap_test.cc
+++ b/src/xenia/cpu/testing/byte_swap_test.cc
@@ -44,3 +44,11 @@ TEST_CASE("BYTE_SWAP_V128", "[instr]") {
                     vec128i(0x0F10130C, 0x0B0C0D0E, 0x0000000A, 0x00000000));
           });
 }
+
+TEST_CASE("BYTE_SWAP_V128_FOLD_MATCHES_BACKEND", "[instr]") {
+  RequireVectorFoldMatchesBackend(
+      {vec128i(0x00010203, 0x04050607, 0x08090A0B, 0x0C0D0E0F)},
+      [](HIRBuilder& b, const std::vector<Value*>& ops) {
+        return b.ByteSwap(ops[0]);
+      });
+}

--- a/src/xenia/cpu/testing/extract_test.cc
+++ b/src/xenia/cpu/testing/extract_test.cc
@@ -181,3 +181,46 @@ TEST_CASE("EXTRACT_INT32_FOLD_MATCHES_BACKEND", "[instr]") {
         });
   }
 }
+
+// stvebx and stvehx extract with a runtime index. The fold cannot fire so the
+// vector reaches the emitter as a constant.
+TEST_CASE("EXTRACT_INT8_CONSTANT_VECTOR_MATCHES_REGISTER", "[instr]") {
+  const vec128_t vec =
+      vec128b(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+  for (int i = 0; i < 16; ++i) {
+    RequireScalarFoldMatchesBackend(
+        {vec},
+        [](HIRBuilder& b, const std::vector<Value*>& ops) {
+          return b.Extract(ops[0], b.Truncate(LoadGPR(b, 5), INT8_TYPE),
+                           INT8_TYPE);
+        },
+        {uint64_t(i)});
+  }
+}
+
+TEST_CASE("EXTRACT_INT16_CONSTANT_VECTOR_MATCHES_REGISTER", "[instr]") {
+  const vec128_t vec =
+      vec128s(0x0000, 0x1001, 0x2002, 0x3003, 0x4004, 0x5005, 0x6006, 0x7007);
+  for (int i = 0; i < 8; ++i) {
+    RequireScalarFoldMatchesBackend(
+        {vec},
+        [](HIRBuilder& b, const std::vector<Value*>& ops) {
+          return b.Extract(ops[0], b.Truncate(LoadGPR(b, 5), INT8_TYPE),
+                           INT16_TYPE);
+        },
+        {uint64_t(i)});
+  }
+}
+
+TEST_CASE("EXTRACT_INT32_CONSTANT_VECTOR_MATCHES_REGISTER", "[instr]") {
+  const vec128_t vec = vec128i(0x00010203, 0x04050607, 0x08090A0B, 0x0C0D0E0F);
+  for (int i = 0; i < 4; ++i) {
+    RequireScalarFoldMatchesBackend(
+        {vec},
+        [](HIRBuilder& b, const std::vector<Value*>& ops) {
+          return b.Extract(ops[0], b.Truncate(LoadGPR(b, 5), INT8_TYPE),
+                           INT32_TYPE);
+        },
+        {uint64_t(i)});
+  }
+}

--- a/src/xenia/cpu/testing/extract_test.cc
+++ b/src/xenia/cpu/testing/extract_test.cc
@@ -148,3 +148,36 @@ TEST_CASE("EXTRACT_INT32_CONSTANT", "[instr]") {
             });
   }
 }
+
+// The folded and emitted forms must pick the same lane.
+TEST_CASE("EXTRACT_INT8_FOLD_MATCHES_BACKEND", "[instr]") {
+  const vec128_t vec =
+      vec128b(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+  for (int i = 0; i < 16; ++i) {
+    RequireScalarFoldMatchesBackend(
+        {vec}, [i](HIRBuilder& b, const std::vector<Value*>& ops) {
+          return b.Extract(ops[0], b.LoadConstantUint8(uint8_t(i)), INT8_TYPE);
+        });
+  }
+}
+
+TEST_CASE("EXTRACT_INT16_FOLD_MATCHES_BACKEND", "[instr]") {
+  const vec128_t vec =
+      vec128s(0x0000, 0x1001, 0x2002, 0x3003, 0x4004, 0x5005, 0x6006, 0x7007);
+  for (int i = 0; i < 8; ++i) {
+    RequireScalarFoldMatchesBackend(
+        {vec}, [i](HIRBuilder& b, const std::vector<Value*>& ops) {
+          return b.Extract(ops[0], b.LoadConstantUint8(uint8_t(i)), INT16_TYPE);
+        });
+  }
+}
+
+TEST_CASE("EXTRACT_INT32_FOLD_MATCHES_BACKEND", "[instr]") {
+  const vec128_t vec = vec128i(0x00010203, 0x04050607, 0x08090A0B, 0x0C0D0E0F);
+  for (int i = 0; i < 4; ++i) {
+    RequireScalarFoldMatchesBackend(
+        {vec}, [i](HIRBuilder& b, const std::vector<Value*>& ops) {
+          return b.Extract(ops[0], b.LoadConstantUint8(uint8_t(i)), INT32_TYPE);
+        });
+  }
+}

--- a/src/xenia/cpu/testing/opcode_coverage_test.cc
+++ b/src/xenia/cpu/testing/opcode_coverage_test.cc
@@ -1003,3 +1003,27 @@ TEST_CASE("VECTOR_COMPARE_FOLD_MATCHES_BACKEND", "[vector]") {
         });
   }
 }
+
+// ============================================================================
+// VECTOR_CONVERT_F2I — constant operand
+// ============================================================================
+// DISALLOW_CONSTANT_FOLDING keeps this unfolded, so a constant operand always
+// reaches the emitter. The unsigned AVX-512 path is the one at risk.
+TEST_CASE("VECTOR_CONVERT_F2I_CONSTANT_MATCHES_REGISTER", "[vector]") {
+  const vec128_t values[] = {
+      vec128f(0.0f, 1.5f, 100.0f, 2.0f),
+      // Past INT_MAX and past UINT_MAX to reach the saturating paths.
+      vec128f(3.0e9f, 4.5e9f, -1.0f, 1.0f),
+      vec128f(std::numeric_limits<float>::quiet_NaN(), 0.0f, -0.0f, 7.0f),
+  };
+  for (const vec128_t& value : values) {
+    RequireVectorFoldMatchesBackend(
+        {value}, [](HIRBuilder& b, const std::vector<Value*>& ops) {
+          return b.VectorConvertF2I(ops[0], ARITHMETIC_UNSIGNED);
+        });
+    RequireVectorFoldMatchesBackend(
+        {value}, [](HIRBuilder& b, const std::vector<Value*>& ops) {
+          return b.VectorConvertF2I(ops[0]);
+        });
+  }
+}

--- a/src/xenia/cpu/testing/opcode_coverage_test.cc
+++ b/src/xenia/cpu/testing/opcode_coverage_test.cc
@@ -809,3 +809,197 @@ TEST_CASE("VECTOR_COMPARE_UGE_I32", "[vector]") {
         REQUIRE(ctx->v[3].u32[3] == 0xFFFFFFFF);
       });
 }
+
+// ============================================================================
+// Gates that only open when an operand's definition is visible
+// ============================================================================
+// The three below pick structurally different code, not just different
+// registers, based on what the backend can prove about an operand. Every other
+// test feeds operands in through registers, where nothing is provable, so none
+// of these paths ran until VEC128 context promotion made definitions visible
+// in real code. Each compares the gated path against the ungated one rather
+// than a hand-derived result.
+
+// x64's SELECT_V128 drops the bitwise select for vblendvps or vpblendvb once
+// GetPermittedBlendForSelectV128 can prove the selector is a lane or byte
+// mask, which it does by walking the selector's definition.
+TEST_CASE("SELECT_V128_BLEND_MATCHES_BITWISE", "[vector]") {
+  const vec128_t lhs = vec128f(1.0f, 2.0f, 3.0f, 4.0f);
+  const vec128_t rhs = vec128f(1.0f, 9.0f, 3.0f, 9.0f);
+  const vec128_t a = vec128i(0xAAAAAAAA, 0xBBBBBBBB, 0xCCCCCCCC, 0xDDDDDDDD);
+  const vec128_t c = vec128i(0x11111111, 0x22222222, 0x33333333, 0x44444444);
+
+  // Some lanes set and some clear, so a lane granular blend and a bitwise
+  // select disagree if the classification is wrong. Taken from the compare
+  // itself so the mask needs no hand derivation.
+  vec128_t mask = vec128i(0, 0, 0, 0);
+  TestFunction([](HIRBuilder& b) {
+    StoreVR(b, 3, b.VectorCompareEQ(LoadVR(b, 4), LoadVR(b, 5), FLOAT32_TYPE));
+    b.Return();
+  })
+      .Run(
+          [&](PPCContext* ctx) {
+            ctx->v[4] = lhs;
+            ctx->v[5] = rhs;
+          },
+          [&](PPCContext* ctx) { mask = ctx->v[3]; });
+
+  vec128_t blended = vec128i(0, 0, 0, 0);
+  TestFunction([](HIRBuilder& b) {
+    StoreVR(
+        b, 3,
+        b.Select(b.VectorCompareEQ(LoadVR(b, 4), LoadVR(b, 5), FLOAT32_TYPE),
+                 LoadVR(b, 6), LoadVR(b, 7)));
+    b.Return();
+  })
+      .Run(
+          [&](PPCContext* ctx) {
+            ctx->v[4] = lhs;
+            ctx->v[5] = rhs;
+            ctx->v[6] = a;
+            ctx->v[7] = c;
+          },
+          [&](PPCContext* ctx) { blended = ctx->v[3]; });
+
+  vec128_t bitwise = vec128i(0, 0, 0, 0);
+  TestFunction([](HIRBuilder& b) {
+    // Selector arrives in a register, so its definition is opaque and the
+    // bitwise fallback is emitted.
+    StoreVR(b, 3, b.Select(LoadVR(b, 8), LoadVR(b, 6), LoadVR(b, 7)));
+    b.Return();
+  })
+      .Run(
+          [&](PPCContext* ctx) {
+            ctx->v[8] = mask;
+            ctx->v[6] = a;
+            ctx->v[7] = c;
+          },
+          [&](PPCContext* ctx) { bitwise = ctx->v[3]; });
+
+  REQUIRE(blended == bitwise);
+}
+
+// DOT_PRODUCT_3/4 take a shorter route when both operands are the same Value,
+// squaring one conversion instead of multiplying two.
+TEST_CASE("DOT_PRODUCT_LENSQR_MATCHES_GENERAL", "[vector]") {
+  const vec128_t input = vec128f(1.5f, -2.25f, 3.0f, 0.5f);
+
+  for (int width = 3; width <= 4; ++width) {
+    vec128_t one_value = vec128i(0, 0, 0, 0);
+    TestFunction([width](HIRBuilder& b) {
+      auto v = LoadVR(b, 4);
+      StoreVR(b, 3, width == 3 ? b.DotProduct3(v, v) : b.DotProduct4(v, v));
+      b.Return();
+    })
+        .Run([&](PPCContext* ctx) { ctx->v[4] = input; },
+             [&](PPCContext* ctx) { one_value = ctx->v[3]; });
+
+    vec128_t two_values = vec128i(0, 0, 0, 0);
+    TestFunction([width](HIRBuilder& b) {
+      auto v1 = LoadVR(b, 4);
+      auto v2 = LoadVR(b, 5);
+      StoreVR(b, 3, width == 3 ? b.DotProduct3(v1, v2) : b.DotProduct4(v1, v2));
+      b.Return();
+    })
+        .Run(
+            [&](PPCContext* ctx) {
+              ctx->v[4] = input;
+              ctx->v[5] = input;
+            },
+            [&](PPCContext* ctx) { two_values = ctx->v[3]; });
+
+    REQUIRE(one_value == two_values);
+  }
+}
+
+// RSQRT_V128 computes a single lane and broadcasts it once
+// AllFloatVectorLanesSameValue can prove every lane is equal, which swaps one
+// hand written vrsqrte helper for another. A splat proves it, a register does
+// not.
+TEST_CASE("RSQRT_V128_SCALAR_PATH_MATCHES_VECTOR_PATH", "[vector]") {
+  const float value = 4.0f;
+
+  vec128_t from_splat = vec128i(0, 0, 0, 0);
+  TestFunction([&](HIRBuilder& b) {
+    StoreVR(b, 3, b.RSqrt(b.Splat(b.LoadConstantFloat32(value), VEC128_TYPE)));
+    b.Return();
+  })
+      .Run([](PPCContext* ctx) {},
+           [&](PPCContext* ctx) { from_splat = ctx->v[3]; });
+
+  vec128_t from_register = vec128i(0, 0, 0, 0);
+  TestFunction([](HIRBuilder& b) {
+    StoreVR(b, 3, b.RSqrt(LoadVR(b, 4)));
+    b.Return();
+  })
+      .Run(
+          [&](PPCContext* ctx) {
+            ctx->v[4] = vec128f(value, value, value, value);
+          },
+          [&](PPCContext* ctx) { from_register = ctx->v[3]; });
+
+  REQUIRE(from_splat == from_register);
+}
+
+// ============================================================================
+// VECTOR_COMPARE_* — folder vs backend
+// ============================================================================
+// No float guard on these. The FLOAT32 forms reach a folder too.
+TEST_CASE("VECTOR_COMPARE_FOLD_MATCHES_BACKEND", "[vector]") {
+  const vec128_t int_lhs =
+      vec128b(0x00, 0x01, 0x7F, 0x80, 0xFF, 0xFE, 0x40, 0xC0, 0x01, 0x02, 0x03,
+              0x04, 0x7F, 0x81, 0x00, 0xFF);
+  const vec128_t int_rhs =
+      vec128b(0x00, 0xFF, 0x01, 0x80, 0x01, 0x02, 0x40, 0xC0, 0x7F, 0x80, 0xFF,
+              0x7E, 0x7F, 0x81, 0x01, 0xFF);
+
+  for (TypeName part : {INT8_TYPE, INT16_TYPE, INT32_TYPE}) {
+    RequireVectorFoldMatchesBackend(
+        {int_lhs, int_rhs},
+        [part](HIRBuilder& b, const std::vector<Value*>& ops) {
+          return b.VectorCompareEQ(ops[0], ops[1], part);
+        });
+    RequireVectorFoldMatchesBackend(
+        {int_lhs, int_rhs},
+        [part](HIRBuilder& b, const std::vector<Value*>& ops) {
+          return b.VectorCompareSGT(ops[0], ops[1], part);
+        });
+    RequireVectorFoldMatchesBackend(
+        {int_lhs, int_rhs},
+        [part](HIRBuilder& b, const std::vector<Value*>& ops) {
+          return b.VectorCompareSGE(ops[0], ops[1], part);
+        });
+    RequireVectorFoldMatchesBackend(
+        {int_lhs, int_rhs},
+        [part](HIRBuilder& b, const std::vector<Value*>& ops) {
+          return b.VectorCompareUGT(ops[0], ops[1], part);
+        });
+    RequireVectorFoldMatchesBackend(
+        {int_lhs, int_rhs},
+        [part](HIRBuilder& b, const std::vector<Value*>& ops) {
+          return b.VectorCompareUGE(ops[0], ops[1], part);
+        });
+  }
+
+  const float qnan = std::numeric_limits<float>::quiet_NaN();
+  const float pinf = std::numeric_limits<float>::infinity();
+  const vec128_t float_pairs[][2] = {
+      {vec128f(1.0f, -1.0f, 0.0f, 2.0f), vec128f(1.0f, 1.0f, -0.0f, 1.0f)},
+      {vec128f(qnan, 1.0f, qnan, -pinf), vec128f(1.0f, qnan, qnan, pinf)},
+      {vec128f(pinf, -pinf, 0.0f, -0.0f), vec128f(pinf, -pinf, -0.0f, 0.0f)},
+  };
+  for (const auto& pair : float_pairs) {
+    RequireVectorFoldMatchesBackend(
+        {pair[0], pair[1]}, [](HIRBuilder& b, const std::vector<Value*>& ops) {
+          return b.VectorCompareEQ(ops[0], ops[1], FLOAT32_TYPE);
+        });
+    RequireVectorFoldMatchesBackend(
+        {pair[0], pair[1]}, [](HIRBuilder& b, const std::vector<Value*>& ops) {
+          return b.VectorCompareSGT(ops[0], ops[1], FLOAT32_TYPE);
+        });
+    RequireVectorFoldMatchesBackend(
+        {pair[0], pair[1]}, [](HIRBuilder& b, const std::vector<Value*>& ops) {
+          return b.VectorCompareSGE(ops[0], ops[1], FLOAT32_TYPE);
+        });
+  }
+}

--- a/src/xenia/cpu/testing/swizzle_test.cc
+++ b/src/xenia/cpu/testing/swizzle_test.cc
@@ -47,3 +47,19 @@ TEST_CASE("SWIZZLE_V128", "[instr]") {
              REQUIRE(result == vec128i(1, 1, 2, 2));
            });
 }
+
+TEST_CASE("SWIZZLE_V128_FOLD_MATCHES_BACKEND", "[instr]") {
+  const vec128_t vec = vec128i(0x00010203, 0x04050607, 0x08090A0B, 0x0C0D0E0F);
+  const uint32_t masks[] = {
+      SWIZZLE_XYZW_TO_XYZW,        SWIZZLE_XYZW_TO_YZWX,
+      SWIZZLE_XYZW_TO_ZWXY,        SWIZZLE_XYZW_TO_WXYZ,
+      MakeSwizzleMask(3, 2, 1, 0), MakeSwizzleMask(0, 0, 0, 0),
+      MakeSwizzleMask(2, 2, 3, 3),
+  };
+  for (uint32_t mask : masks) {
+    RequireVectorFoldMatchesBackend(
+        {vec}, [mask](HIRBuilder& b, const std::vector<Value*>& ops) {
+          return b.Swizzle(ops[0], INT32_TYPE, mask);
+        });
+  }
+}

--- a/src/xenia/cpu/testing/util.h
+++ b/src/xenia/cpu/testing/util.h
@@ -123,6 +123,73 @@ inline void StoreVR(hir::HIRBuilder& b, int reg, hir::Value* value) {
   b.StoreContext(offsetof(PPCContext, v) + reg * 16, value);
 }
 
+// Runs the op twice and requires a match. Operands from the guest context
+// stay opaque and the backend emits it. Operands as HIR constants reach
+// the folder. Give inputs distinct lanes or a wrong-lane fold will not show.
+template <typename T>
+inline void RequireFoldMatchesBackend(
+    const std::vector<vec128_t>& inputs,
+    std::function<hir::Value*(hir::HIRBuilder&,
+                              const std::vector<hir::Value*>&)>
+        build,
+    std::function<void(hir::HIRBuilder&, hir::Value*)> store,
+    std::function<T(PPCContext*)> read) {
+  T from_backend{};
+  TestFunction([&](hir::HIRBuilder& b) {
+    std::vector<hir::Value*> ops;
+    for (size_t n = 0; n < inputs.size(); ++n) {
+      ops.push_back(LoadVR(b, static_cast<int>(4 + n)));
+    }
+    store(b, build(b, ops));
+    b.Return();
+  })
+      .Run(
+          [&](PPCContext* ctx) {
+            for (size_t n = 0; n < inputs.size(); ++n) {
+              ctx->v[4 + n] = inputs[n];
+            }
+          },
+          [&](PPCContext* ctx) { from_backend = read(ctx); });
+
+  T from_fold{};
+  TestFunction([&](hir::HIRBuilder& b) {
+    std::vector<hir::Value*> ops;
+    for (const vec128_t& input : inputs) {
+      ops.push_back(b.LoadConstantVec128(input));
+    }
+    store(b, build(b, ops));
+    b.Return();
+  }).Run([](PPCContext*) {}, [&](PPCContext* ctx) { from_fold = read(ctx); });
+
+  REQUIRE(from_fold == from_backend);
+}
+
+// Result goes to VR3.
+inline void RequireVectorFoldMatchesBackend(
+    const std::vector<vec128_t>& inputs,
+    std::function<hir::Value*(hir::HIRBuilder&,
+                              const std::vector<hir::Value*>&)>
+        build) {
+  RequireFoldMatchesBackend<vec128_t>(
+      inputs, build,
+      [](hir::HIRBuilder& b, hir::Value* v) { StoreVR(b, 3, v); },
+      [](PPCContext* ctx) { return ctx->v[3]; });
+}
+
+// Result is zero extended into GPR3.
+inline void RequireScalarFoldMatchesBackend(
+    const std::vector<vec128_t>& inputs,
+    std::function<hir::Value*(hir::HIRBuilder&,
+                              const std::vector<hir::Value*>&)>
+        build) {
+  RequireFoldMatchesBackend<uint64_t>(
+      inputs, build,
+      [](hir::HIRBuilder& b, hir::Value* v) {
+        StoreGPR(b, 3, b.ZeroExtend(v, hir::INT64_TYPE));
+      },
+      [](PPCContext* ctx) { return ctx->r[3]; });
+}
+
 }  // namespace testing
 }  // namespace cpu
 }  // namespace xe

--- a/src/xenia/cpu/testing/util.h
+++ b/src/xenia/cpu/testing/util.h
@@ -125,10 +125,12 @@ inline void StoreVR(hir::HIRBuilder& b, int reg, hir::Value* value) {
 
 // Runs the op twice and requires a match. Operands from the guest context
 // stay opaque and the backend emits it. Operands as HIR constants reach
-// the folder. Give inputs distinct lanes or a wrong-lane fold will not show.
+// the folder. When another operand keeps the op unfolded they instead
+// reach the emitter's constant path. Give inputs distinct lanes or a
+// wrong-lane fold will not show. gprs seed r5 upward for both runs.
 template <typename T>
 inline void RequireFoldMatchesBackend(
-    const std::vector<vec128_t>& inputs,
+    const std::vector<vec128_t>& inputs, const std::vector<uint64_t>& gprs,
     std::function<hir::Value*(hir::HIRBuilder&,
                               const std::vector<hir::Value*>&)>
         build,
@@ -148,6 +150,9 @@ inline void RequireFoldMatchesBackend(
             for (size_t n = 0; n < inputs.size(); ++n) {
               ctx->v[4 + n] = inputs[n];
             }
+            for (size_t n = 0; n < gprs.size(); ++n) {
+              ctx->r[5 + n] = gprs[n];
+            }
           },
           [&](PPCContext* ctx) { from_backend = read(ctx); });
 
@@ -159,7 +164,14 @@ inline void RequireFoldMatchesBackend(
     }
     store(b, build(b, ops));
     b.Return();
-  }).Run([](PPCContext*) {}, [&](PPCContext* ctx) { from_fold = read(ctx); });
+  })
+      .Run(
+          [&](PPCContext* ctx) {
+            for (size_t n = 0; n < gprs.size(); ++n) {
+              ctx->r[5 + n] = gprs[n];
+            }
+          },
+          [&](PPCContext* ctx) { from_fold = read(ctx); });
 
   REQUIRE(from_fold == from_backend);
 }
@@ -169,9 +181,10 @@ inline void RequireVectorFoldMatchesBackend(
     const std::vector<vec128_t>& inputs,
     std::function<hir::Value*(hir::HIRBuilder&,
                               const std::vector<hir::Value*>&)>
-        build) {
+        build,
+    const std::vector<uint64_t>& gprs = {}) {
   RequireFoldMatchesBackend<vec128_t>(
-      inputs, build,
+      inputs, gprs, build,
       [](hir::HIRBuilder& b, hir::Value* v) { StoreVR(b, 3, v); },
       [](PPCContext* ctx) { return ctx->v[3]; });
 }
@@ -181,9 +194,10 @@ inline void RequireScalarFoldMatchesBackend(
     const std::vector<vec128_t>& inputs,
     std::function<hir::Value*(hir::HIRBuilder&,
                               const std::vector<hir::Value*>&)>
-        build) {
+        build,
+    const std::vector<uint64_t>& gprs = {}) {
   RequireFoldMatchesBackend<uint64_t>(
-      inputs, build,
+      inputs, gprs, build,
       [](hir::HIRBuilder& b, hir::Value* v) {
         StoreGPR(b, 3, b.ZeroExtend(v, hir::INT64_TYPE));
       },

--- a/src/xenia/cpu/testing/vector_add_test.cc
+++ b/src/xenia/cpu/testing/vector_add_test.cc
@@ -309,3 +309,54 @@ TEST_CASE("VECTOR_ADD_F32", "[instr]") {
         REQUIRE(result == vec128i(0x7F7FFFFF));
       });
 }
+
+// No float guard on these. Every lane type reaches a folder.
+namespace {
+const vec128_t kFoldLhs =
+    vec128b(0x00, 0x01, 0x7F, 0x80, 0xFF, 0xFE, 0x40, 0xC0, 0x01, 0x02, 0x03,
+            0x04, 0x7F, 0x81, 0x00, 0xFF);
+const vec128_t kFoldRhs =
+    vec128b(0x00, 0xFF, 0x01, 0x80, 0x01, 0x02, 0x40, 0xC0, 0x7F, 0x80, 0xFF,
+            0x7E, 0x7F, 0x81, 0x01, 0xFF);
+}  // namespace
+
+TEST_CASE("VECTOR_ADD_FOLD_MATCHES_BACKEND", "[instr]") {
+  for (TypeName part : {INT8_TYPE, INT16_TYPE, INT32_TYPE}) {
+    const uint32_t ariths[] = {0, ARITHMETIC_SATURATE, ARITHMETIC_UNSIGNED,
+                               ARITHMETIC_SATURATE | ARITHMETIC_UNSIGNED};
+    for (uint32_t arith : ariths) {
+      RequireVectorFoldMatchesBackend(
+          {kFoldLhs, kFoldRhs},
+          [part, arith](HIRBuilder& b, const std::vector<Value*>& ops) {
+            return b.VectorAdd(ops[0], ops[1], part, arith);
+          });
+    }
+  }
+}
+
+TEST_CASE("VECTOR_SUB_FOLD_MATCHES_BACKEND", "[instr]") {
+  for (TypeName part : {INT8_TYPE, INT16_TYPE, INT32_TYPE}) {
+    const uint32_t ariths[] = {0, ARITHMETIC_SATURATE, ARITHMETIC_UNSIGNED,
+                               ARITHMETIC_SATURATE | ARITHMETIC_UNSIGNED};
+    for (uint32_t arith : ariths) {
+      RequireVectorFoldMatchesBackend(
+          {kFoldLhs, kFoldRhs},
+          [part, arith](HIRBuilder& b, const std::vector<Value*>& ops) {
+            return b.VectorSub(ops[0], ops[1], part, arith);
+          });
+    }
+  }
+}
+
+TEST_CASE("VECTOR_AVERAGE_FOLD_MATCHES_BACKEND", "[instr]") {
+  for (TypeName part : {INT8_TYPE, INT16_TYPE, INT32_TYPE}) {
+    const uint32_t ariths[] = {0, ARITHMETIC_UNSIGNED};
+    for (uint32_t arith : ariths) {
+      RequireVectorFoldMatchesBackend(
+          {kFoldLhs, kFoldRhs},
+          [part, arith](HIRBuilder& b, const std::vector<Value*>& ops) {
+            return b.VectorAverage(ops[0], ops[1], part, arith);
+          });
+    }
+  }
+}

--- a/src/xenia/cpu/testing/vector_rotate_left_test.cc
+++ b/src/xenia/cpu/testing/vector_rotate_left_test.cc
@@ -70,3 +70,17 @@ TEST_CASE("VECTOR_ROTATE_LEFT_I32", "[instr]") {
                 vec128i(0x00000001, 0x00000002, 0x00000001, 0x00000002));
       });
 }
+
+TEST_CASE("VECTOR_ROTATE_LEFT_FOLD_MATCHES_BACKEND", "[instr]") {
+  const vec128_t value =
+      vec128b(0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0xFE, 0xDC, 0xBA,
+              0x98, 0x76, 0x54, 0x32, 0x10);
+  const vec128_t counts =
+      vec128b(0, 1, 2, 3, 7, 8, 15, 16, 17, 31, 32, 33, 63, 64, 127, 255);
+  for (TypeName part : {INT8_TYPE, INT16_TYPE, INT32_TYPE}) {
+    RequireVectorFoldMatchesBackend(
+        {value, counts}, [part](HIRBuilder& b, const std::vector<Value*>& ops) {
+          return b.VectorRotateLeft(ops[0], ops[1], part);
+        });
+  }
+}

--- a/src/xenia/cpu/testing/vector_shl_test.cc
+++ b/src/xenia/cpu/testing/vector_shl_test.cc
@@ -223,3 +223,18 @@ TEST_CASE("VECTOR_SHL_I32_CONSTANT", "[instr]") {
                 vec128i(0x00000000, 0xFFFF0000, 0x00000002, 0x12345678));
       });
 }
+
+TEST_CASE("VECTOR_SHL_FOLD_MATCHES_BACKEND", "[instr]") {
+  const vec128_t value =
+      vec128b(0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0xFE, 0xDC, 0xBA,
+              0x98, 0x76, 0x54, 0x32, 0x10);
+  // Counts past the element width exercise the masking.
+  const vec128_t counts =
+      vec128b(0, 1, 2, 3, 7, 8, 15, 16, 17, 31, 32, 33, 63, 64, 127, 255);
+  for (TypeName part : {INT8_TYPE, INT16_TYPE, INT32_TYPE}) {
+    RequireVectorFoldMatchesBackend(
+        {value, counts}, [part](HIRBuilder& b, const std::vector<Value*>& ops) {
+          return b.VectorShl(ops[0], ops[1], part);
+        });
+  }
+}

--- a/src/xenia/cpu/testing/vector_shr_test.cc
+++ b/src/xenia/cpu/testing/vector_shr_test.cc
@@ -213,3 +213,18 @@ TEST_CASE("VECTOR_SHR_I32_CONSTANT", "[instr]") {
                 vec128i(0x00000001, 0x0000FFFF, 0x00000000, 0x12345678));
       });
 }
+
+// Shifts in zeros where VECTOR_SHA shifts in sign.
+TEST_CASE("VECTOR_SHR_FOLD_MATCHES_BACKEND", "[instr]") {
+  const vec128_t value =
+      vec128b(0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0xFE, 0xDC, 0xBA,
+              0x98, 0x76, 0x54, 0x32, 0x10);
+  const vec128_t counts =
+      vec128b(0, 1, 2, 3, 7, 8, 15, 16, 17, 31, 32, 33, 63, 64, 127, 255);
+  for (TypeName part : {INT8_TYPE, INT16_TYPE, INT32_TYPE}) {
+    RequireVectorFoldMatchesBackend(
+        {value, counts}, [part](HIRBuilder& b, const std::vector<Value*>& ops) {
+          return b.VectorShr(ops[0], ops[1], part);
+        });
+  }
+}


### PR DESCRIPTION
Four fixes in the same family, three cherry-picked from has207/xenia-edge with authorship kept. All are reachable only when a vector operand is constant, so the folds and the emitter's constant paths stayed dead until something made VEC128 context values visible.

- `166439c79` `VECTOR_COMPARE_SGE_V128` uses xmm0 for its `vpcmpeq` result, where `EmitAssociativeBinaryXmmOp` materializes a constant operand. `PACK`'s unsigned paths pass `e.xmm4` to `GetInputRegOrConstant`, and `xmm_reg_map_` starts at xmm4.
- `45827cc2b` `Value::Extract` misses the backends' `VEC128_B`/`VEC128_W` flip, so INT8 and INT16 fold the wrong element. INT8 also masks with `0x1F` over 16 bytes.
- `850f45610` `EXTRACT_I8`/`EXTRACT_I16` and the AVX-512 F2I path never materialize a constant `src1`.
- Last commit: FLOAT32/FLOAT64 `VectorCompareEQ` shared the integer cases, so the fold compared bit patterns; `+0.0 == -0.0` and NaN against an identical NaN both come out wrong. `value.cc` hunk from has207's `e4b13738c`, without its vcmpbfp changes.

`45827cc2b` also adds differential tests running each fold against the emitted code. `xenia-cpu-tests` passes 265 cases; with those tests kept and the two fixed files reverted, five fail:

```
EXTRACT_INT8_FOLD_MATCHES_BACKEND
EXTRACT_INT16_FOLD_MATCHES_BACKEND
EXTRACT_INT8_CONSTANT_VECTOR_MATCHES_REGISTER
EXTRACT_INT16_CONSTANT_VECTOR_MATCHES_REGISTER
VECTOR_COMPARE_FOLD_MATCHES_BACKEND
```

`166439c79` is the one no test covers. edge's `select_test.cc` is left out; its Select case is in `opcode_coverage_test.cc` anyway.
