### PR TITLE
[Base/POSIX] Set O_APPEND only for append-only handles

### DIFF
--- a/src/xenia/base/filesystem_posix.cc
+++ b/src/xenia/base/filesystem_posix.cc
@@ -144,8 +144,10 @@ bool CreateEmptyFile(const std::filesystem::path& path) {
 
 class PosixFileHandle : public FileHandle {
  public:
-  PosixFileHandle(std::filesystem::path path, int handle)
-      : FileHandle(std::move(path)), handle_(handle) {}
+  PosixFileHandle(std::filesystem::path path, int handle, bool append_only)
+      : FileHandle(std::move(path)),
+        handle_(handle),
+        append_only_(append_only) {}
   ~PosixFileHandle() override {
     close(handle_);
     handle_ = -1;
@@ -163,7 +165,11 @@ class PosixFileHandle : public FileHandle {
   }
   bool Write(size_t file_offset, const void* buffer, size_t buffer_length,
              size_t* out_bytes_written) override {
-    ssize_t out = pwrite(handle_, buffer, buffer_length, file_offset);
+    // Linux pwrite(2) ignores the offset on an O_APPEND descriptor and
+    // appends instead, so an append-only handle has to use write().
+    ssize_t out = append_only_
+                      ? write(handle_, buffer, buffer_length)
+                      : pwrite(handle_, buffer, buffer_length, file_offset);
     if (out >= 0) {
       *out_bytes_written = out;
       return true;
@@ -179,6 +185,7 @@ class PosixFileHandle : public FileHandle {
 
  private:
   int handle_ = -1;
+  bool append_only_ = false;
 };
 
 std::unique_ptr<FileHandle> FileHandle::OpenExisting(
@@ -196,7 +203,10 @@ std::unique_ptr<FileHandle> FileHandle::OpenExisting(
   if (desired_access & FileAccess::kFileReadData) {
     open_access |= O_RDONLY;
   }
-  if (desired_access & FileAccess::kFileWriteData) {
+  // Append counts as a write right: an append-only handle still has to be
+  // opened writable, or every write to it fails.
+  if (desired_access &
+      (FileAccess::kFileWriteData | FileAccess::kFileAppendData)) {
     open_access |= O_WRONLY;
   }
   if (desired_access & FileAccess::kGenericRead &&
@@ -204,13 +214,23 @@ std::unique_ptr<FileHandle> FileHandle::OpenExisting(
     open_access = O_RDWR;
   }
   if (desired_access & FileAccess::kFileReadData &&
-      desired_access & FileAccess::kFileWriteData) {
+      desired_access &
+          (FileAccess::kFileWriteData | FileAccess::kFileAppendData)) {
     open_access = O_RDWR;
   }
   if (desired_access & FileAccess::kGenericAll) {
     open_access = O_RDWR;
   }
-  if (desired_access & FileAccess::kFileAppendData) {
+  // O_APPEND only when append is the sole write right, matching Win32 where
+  // FILE_APPEND_DATA without FILE_WRITE_DATA is what makes a handle
+  // append-only. Linux pwrite(2) ignores the offset on an O_APPEND
+  // descriptor, so setting it for a handle that also writes normally sends
+  // every positioned write to the end of the file.
+  const bool append_only = (desired_access & FileAccess::kFileAppendData) &&
+                           !(desired_access & (FileAccess::kGenericWrite |
+                                               FileAccess::kFileWriteData |
+                                               FileAccess::kGenericAll));
+  if (append_only) {
     open_access |= O_APPEND;
   }
   int handle = open(path.c_str(), open_access);
@@ -218,7 +238,7 @@ std::unique_ptr<FileHandle> FileHandle::OpenExisting(
     // TODO(benvanik): pick correct response.
     return nullptr;
   }
-  return std::make_unique<PosixFileHandle>(path, handle);
+  return std::make_unique<PosixFileHandle>(path, handle, append_only);
 }
 
 std::optional<FileInfo> GetInfo(const std::filesystem::path& path) {


### PR DESCRIPTION
Linux `pwrite(2)` ignores the offset on an `O_APPEND` descriptor and appends instead, a documented deviation where FreeBSD and macOS honour it. `OpenExisting` sets `O_APPEND` whenever `kFileAppendData` is present, and guests routinely ask for append together with write, so every positioned write to such a handle silently lands at end of file. Win32 treats `FILE_APPEND_DATA` without `FILE_WRITE_DATA` as what makes a handle append-only, so only POSIX is affected.

Reproduced against `FileHandle` directly: seed a 16-byte file, open it read + write + append, write 4 bytes at offset 4.

| | file size | bytes at offset 4 |
| --- | --- | --- |
| before | 20 | `AAAA`, the write went to the end |
| after | 16 | `ZZZZ` |

`O_APPEND` is now set only when append is the sole write right; those handles write with `write()`, every other handle keeps `pwrite`.

Second thing found while testing that: with append as the only access right, `open_access` stays 0 and the handle is opened `O_RDONLY`, so every write to it fails. Already the case before this change, so append-only handles never worked. Append now counts as a write right when picking the mode; append-only goes 16 -> 20 bytes as it should.

Adapted from has207/xenia-edge@c9536890c rather than cherry-picked, whose `OpenExisting` has since been restructured into `wants_read`/`wants_write`.
