### PR TITLE
[Memory] Check the host alignment PhysicalHeap can actually satisfy

### DIFF
--- a/src/xenia/memory.cc
+++ b/src/xenia/memory.cc
@@ -1830,11 +1830,15 @@ bool PhysicalHeap::Alloc(uint32_t size, uint32_t alignment,
   // Given the address we've reserved in the parent heap, pin that here.
   // Shouldn't be possible for it to be allocated already.
   const uint32_t address = heap_base_ + parent_address - parent_heap_start;
-  if ((address + host_address_offset_) % alignment != 0) {
+  const uint32_t host_alignment = std::min(
+      alignment,
+      std::max(page_size_, uint32_t(xe::memory::allocation_granularity())));
+  if ((address + host_address_offset_) % host_alignment != 0) {
     XELOGE(
         "PhysicalHeap::Alloc translated address {:08X} misaligned "
-        "(alignment {:08X}, physical base offset {:08X})",
-        address, alignment, parent_heap_start);
+        "(host alignment {:08X} of requested {:08X}, physical base "
+        "offset {:08X})",
+        address, host_alignment, alignment, parent_heap_start);
     parent_heap_->Release(parent_address);
     return false;
   }
@@ -1875,11 +1879,15 @@ bool PhysicalHeap::AllocFixed(uint32_t base_address, uint32_t size,
   // Shouldn't be possible for it to be allocated already.
   const uint32_t address =
       heap_base_ + parent_base_address - GetPhysicalAddress(heap_base_);
-  if ((address + host_address_offset_) % alignment != 0) {
+  const uint32_t host_alignment = std::min(
+      alignment,
+      std::max(page_size_, uint32_t(xe::memory::allocation_granularity())));
+  if ((address + host_address_offset_) % host_alignment != 0) {
     XELOGE(
         "PhysicalHeap::AllocFixed translated address {:08X} misaligned "
-        "(alignment {:08X}, physical base offset {:08X})",
-        address, alignment, GetPhysicalAddress(heap_base_));
+        "(host alignment {:08X} of requested {:08X}, physical base "
+        "offset {:08X})",
+        address, host_alignment, alignment, GetPhysicalAddress(heap_base_));
     parent_heap_->Release(parent_base_address);
     return false;
   }
@@ -1927,11 +1935,29 @@ bool PhysicalHeap::AllocRange(uint32_t low_address, uint32_t high_address,
   // Shouldn't be possible for it to be allocated already.
   const uint32_t address =
       heap_base_ + parent_address - GetPhysicalAddress(heap_base_);
-  if ((address + host_address_offset_) % alignment != 0) {
+  // The caller's alignment is a physical one, and the parent heap has already
+  // satisfied it: what the guest reads back through MmGetPhysicalAddress is
+  // parent_address. This check is about the host pointer, which is
+  // membase_ + address + host_address_offset_, so it only has to hold to what
+  // the host itself needs to map and protect at.
+  //
+  // The two can differ. A heap at or above 0xE0000000 has a physical base of
+  // 0x1000 (GetPhysicalAddress), so its host pointer sits 0x1000 below an
+  // aligned parent_address unless host_address_offset_ puts it back. That
+  // offset is only set when the host allocation granularity is above 0x1000,
+  // which is true on Windows and false on Linux, where the granularity is one
+  // 4 KiB page. Testing the caller's alignment here therefore failed every
+  // allocation above page size on that heap on Linux while the same call
+  // succeeded on Windows.
+  const uint32_t host_alignment = std::min(
+      alignment,
+      std::max(page_size_, uint32_t(xe::memory::allocation_granularity())));
+  if ((address + host_address_offset_) % host_alignment != 0) {
     XELOGE(
-        "PhysicalHeap::AllocRange translated address {:08X} misaligned "
-        "(alignment {:08X}, physical base offset {:08X})",
-        address, alignment, GetPhysicalAddress(heap_base_));
+        "PhysicalHeap::AllocRange translated address {:08X} misaligned for the "
+        "host (host alignment {:08X}, requested {:08X}, physical base offset "
+        "{:08X})",
+        address, host_alignment, alignment, GetPhysicalAddress(heap_base_));
     parent_heap_->Release(parent_address);
     return false;
   }


### PR DESCRIPTION
`PhysicalHeap::AllocRange` asks the parent heap for an aligned physical
address, then rejects the result unless the translated address is aligned
too. Those are different addresses.

A heap at or above 0xE0000000 has a physical base of 0x1000
(`GetPhysicalAddress`), so its translated address sits 0x1000 below an
aligned `parent_address` unless `host_address_offset_` puts it back.
`PhysicalHeap::Initialize` only sets that offset when
`allocation_granularity() > 0x1000`: 64 KiB on Windows, one 4 KiB page on
x86-64 Linux. So on Linux `(address + host_address_offset_) % alignment`
is `-0x1000 mod alignment` and can never be 0 for any alignment above the
page size. Every such allocation on that heap fails, and the same call
succeeds on Windows.

`MmAllocatePhysicalMemoryEx` passes the caller's alignment through for
whichever heap the requested page size selects, so a guest asking for
4 KiB pages with a larger alignment cannot allocate on Linux.

The caller's alignment is a physical one and the parent heap has already
satisfied it: what the guest reads back through `MmGetPhysicalAddress` is
`parent_address`. The rejected check is about the host pointer
(`TranslateRelative` is `membase_ + address + host_address_offset_`), so
it now holds only to what the host has to map and protect at,
`max(page_size_, allocation_granularity())`.

`xenia-base-tests` on Linux, this branch against canary_experimental:

| | PhysicalHeap cases | full suite |
| --- | --- | --- |
| canary_experimental | 5 of 6 | 74 of 75 |
| with this change | 6 of 6 | 75 of 75 |

The failing case is `PhysicalHeap vE0000000 AllocRange alignment`,
"AllocRange with large alignment succeeds via bottom-up", already in the
tree from 4fcb8e449.

Three titles ran 70 s each from a save state with no change in frame rate,
audio or errors; none of them reaches the rejected path, so nothing they
do moved.
