### PR TITLE
[UI] Skip CJK fonts stb_truetype cannot load

### DIFF
--- a/src/xenia/ui/imgui_drawer.cc
+++ b/src/xenia/ui/imgui_drawer.cc
@@ -454,6 +454,13 @@ bool ImGuiDrawer::LoadJapaneseFont(ImGuiIO& io, float font_size) {
   FcCharSet* charset = FcCharSetCreate();
   FcCharSetAddChar(charset, 0x4E00);  // Add a CJK character to the charset
   FcPatternAddCharSet(pattern, FC_CHARSET, charset);
+  // Dear ImGui rasterises with stb_truetype, which cannot parse CFF-outline
+  // OpenType fonts or variable-font collections. Fedora's default CJK match
+  // is NotoSansCJK-VF.ttc, exactly that, and one unloadable font fails the
+  // whole atlas build rather than just its own glyphs. Ask fontconfig for
+  // TrueType outlines only.
+  FcPatternAddString(pattern, FC_FONTFORMAT,
+                     reinterpret_cast<const FcChar8*>("TrueType"));
 
   // Configure the search
   FcConfigSubstitute(config, pattern, FcMatchPattern);
@@ -470,14 +477,27 @@ bool ImGuiDrawer::LoadJapaneseFont(ImGuiIO& io, float font_size) {
       const char* font_path = reinterpret_cast<const char*>(file);
 
       if (std::filesystem::exists(font_path)) {
-        ImFontConfig jp_font_config;
-        jp_font_config.MergeMode = true;
-        jp_font_config.OversampleH = jp_font_config.OversampleV = 2;
-        jp_font_config.PixelSnapH = true;
+        // Prove stb_truetype can build this file before merging it into the
+        // real atlas, where a failure would take the base font down with it.
+        ImFontAtlas trial_atlas;
+        static const ImWchar trial_range[] = {0x4E00, 0x4E01, 0};
+        const bool loadable = trial_atlas.AddFontFromFileTTF(
+                                  font_path, font_size, nullptr, trial_range) &&
+                              trial_atlas.Build();
+        if (loadable) {
+          ImFontConfig jp_font_config;
+          jp_font_config.MergeMode = true;
+          jp_font_config.OversampleH = jp_font_config.OversampleV = 2;
+          jp_font_config.PixelSnapH = true;
 
-        io.Fonts->AddFontFromFileTTF(font_path, font_size, &jp_font_config,
-                                     io.Fonts->GetGlyphRangesJapanese());
-        success = true;
+          io.Fonts->AddFontFromFileTTF(font_path, font_size, &jp_font_config,
+                                       io.Fonts->GetGlyphRangesJapanese());
+          XELOGI("Using CJK font {}", font_path);
+          success = true;
+        } else {
+          XELOGW("CJK font {} cannot be loaded by stb_truetype; skipping",
+                 font_path);
+        }
       }
     }
     FcPatternDestroy(font);


### PR DESCRIPTION
Dear ImGui rasterises with stb_truetype, which cannot parse CFF-outline
OpenType fonts or variable-font collections. `LoadJapaneseFont` asks fontconfig
for anything covering U+4E00 and merges the first match into the shared atlas,
so one unloadable font fails the whole atlas build rather than just its own
glyphs, and every ImGui dialog then faults on the first frame it is drawn.

On Fedora 44 that match is `NotoSansCJK-VF.ttc`. #1101 reaches the same
diagnosis and reports NixOS 26.05 shipping the same variable fonts.

The pattern now asks fontconfig for TrueType outlines only, and the match is
proved against a throwaway atlas before being merged into the real one, so
anything stb_truetype still cannot parse is skipped with a warning instead of
taking the base font down with it.

Adding the fontconfig match to an atlas the way `LoadJapaneseFont` does, ImGui
1.91.9b on Fedora 44:

| font | result |
| --- | --- |
| `NotoSansCJK-VF.ttc` | `Build()` fails, `stbtt_InitFont(): failed to parse FontData` |
| `DroidSansFallbackFull.ttf` | builds, 1024x2048 atlas |

The second is what this selects on that machine, and it covers CJK. In the
emulator the log now reads `Using CJK font .../DroidSansFallbackFull.ttf`
where before it silently loaded the unparseable one.

Fixes #1101.
