### PR TITLE
[Base/POSIX] Block a multi-object wait instead of polling it

### DIFF
--- a/src/xenia/base/threading_posix.cc
+++ b/src/xenia/base/threading_posix.cc
@@ -223,6 +223,32 @@ bool SetTlsValue(TlsHandle handle, uintptr_t value) {
   return pthread_setspecific(handle, reinterpret_cast<void*>(value)) == 0;
 }
 
+// A wait on several objects at once cannot block on their condition
+// variables, so it used to poll them every millisecond. Instead, every signal
+// bumps this epoch and wakes this one condition variable, and a multi-object
+// wait blocks on it: no CPU while idle, and it wakes as soon as something is
+// signalled rather than up to a millisecond later.
+//
+// The counter keeps the cost off the signalling path: with no multi-object
+// wait in progress - the usual case - signalling is one atomic load. Both
+// sides are sequentially consistent, so a waiter that has registered itself
+// cannot be missed by a signal that has already changed the state.
+std::mutex multi_wait_mutex;
+std::condition_variable multi_wait_condition;
+std::atomic<uint64_t> multi_wait_epoch{0};
+std::atomic<uint32_t> multi_wait_waiters{0};
+
+void NotifyMultiObjectWaiters() {
+  if (multi_wait_waiters.load(std::memory_order_seq_cst) == 0) {
+    return;
+  }
+  {
+    std::lock_guard<std::mutex> lock(multi_wait_mutex);
+    multi_wait_epoch.fetch_add(1, std::memory_order_seq_cst);
+  }
+  multi_wait_condition.notify_all();
+}
+
 class PosixConditionBase {
  public:
   PosixConditionBase() {
@@ -285,15 +311,30 @@ class PosixConditionBase {
       return std::make_pair(result, 0);
     }
 
-    // For multiple handles, we need to poll since we can't wait on multiple
-    // condition variables simultaneously. This is a limitation of the POSIX
-    // condition variable API.
+    // Several condition variables cannot be waited on at once, so the handles
+    // are checked in turn and the wait blocks on the shared multi-object
+    // condition variable between checks, which every signal wakes.
     auto start_time = std::chrono::steady_clock::now();
     auto end_time = (timeout == std::chrono::milliseconds::max())
                         ? std::chrono::steady_clock::time_point::max()
                         : start_time + timeout;
 
+    // Registered before the first check, and every signal after this point
+    // wakes this thread (both sides are sequentially consistent), so the
+    // block below cannot sleep through a signal it has not already seen.
+    multi_wait_waiters.fetch_add(1, std::memory_order_seq_cst);
+    struct MultiWaitRegistration {
+      ~MultiWaitRegistration() {
+        multi_wait_waiters.fetch_sub(1, std::memory_order_seq_cst);
+      }
+    } multi_wait_registration;
     while (true) {
+      // The epoch before the handles are read: a signal that lands while they
+      // are being read changes it, and the block below then re-checks instead
+      // of sleeping.
+      uint64_t epoch_before_check =
+          multi_wait_epoch.load(std::memory_order_seq_cst);
+
       // Check all handles to see if any/all are signaled
       // Use try_lock to avoid deadlocks from lock ordering issues
       size_t first_signaled = std::numeric_limits<size_t>::max();
@@ -377,11 +418,16 @@ class PosixConditionBase {
         return std::make_pair<WaitResult, size_t>(WaitResult::kTimeout, 0);
       }
 
-      // Sleep for a short time before polling again
+      // Block until something is signalled rather than polling. The cap is
+      // only a backstop: a wake is expected, not a timeout.
       auto remaining =
           std::chrono::duration_cast<std::chrono::milliseconds>(end_time - now);
-      auto sleep_time = std::min(remaining, std::chrono::milliseconds(1));
-      std::this_thread::sleep_for(sleep_time);
+      auto block_time = std::min(remaining, std::chrono::milliseconds(50));
+      std::unique_lock<std::mutex> multi_wait_lock(multi_wait_mutex);
+      if (multi_wait_epoch.load(std::memory_order_seq_cst) ==
+          epoch_before_check) {
+        multi_wait_condition.wait_for(multi_wait_lock, block_time);
+      }
     }
   }
 
@@ -414,6 +460,7 @@ class PosixCondition<Event> : public PosixConditionBase {
     auto lock = std::unique_lock(mutex_);
     signal_ = true;
     cond_.notify_all();
+    NotifyMultiObjectWaiters();
     return true;
   }
 
@@ -452,6 +499,7 @@ class PosixCondition<Semaphore> final : public PosixConditionBase {
     }
     count_ += release_count;
     cond_.notify_all();
+    NotifyMultiObjectWaiters();
     return true;
   }
 
@@ -460,6 +508,7 @@ class PosixCondition<Semaphore> final : public PosixConditionBase {
   void post_execution() override {
     count_--;
     cond_.notify_all();
+    NotifyMultiObjectWaiters();
   }
   uint32_t count_;
   const uint32_t maximum_count_;
@@ -484,6 +533,7 @@ class PosixCondition<Mutant> final : public PosixConditionBase {
       // Free to be acquired by another thread
       if (count_ == 0) {
         cond_.notify_all();
+        NotifyMultiObjectWaiters();
       }
       return true;
     }
@@ -518,6 +568,7 @@ class PosixCondition<Timer> final : public PosixConditionBase {
     std::lock_guard lock(mutex_);
     signal_ = true;
     cond_.notify_all();
+    NotifyMultiObjectWaiters();
     return true;
   }
 
@@ -939,6 +990,7 @@ class PosixCondition<Thread> final : public PosixConditionBase {
       exit_code_ = exit_code;
       signaled_ = true;
       cond_.notify_all();
+      NotifyMultiObjectWaiters();
     }
     if (is_current_thread) {
       pthread_exit(reinterpret_cast<void*>(exit_code));
@@ -1341,6 +1393,7 @@ void* PosixCondition<Thread>::ThreadStartRoutine(void* parameter) {
     thread->handle_.exit_code_ = 0;
     thread->handle_.signaled_ = true;
     thread->handle_.cond_.notify_all();
+    NotifyMultiObjectWaiters();
   }
 
   current_thread_ = nullptr;


### PR DESCRIPTION
`WaitMultiple` cannot block on several condition variables, so it polled: every millisecond it trylocked each handle, read its state, unlocked, read the steady clock twice and slept. Profiling Lost Odyssey in a CPU-bound scene on Linux, one guest thread executing no guest code spent 17.7% of all cycles in that loop.

Every signal now bumps an epoch and wakes one shared condition variable, and the wait blocks on that. The epoch is read before the handles, so a signal that lands during the check is not slept through. A count of active multi-object waiters keeps the signalling path to one atomic load when nobody is waiting. The 50 ms cap on the block is a backstop.

Same scene, 15 s perf profiles:

| | before | after |
| --- | --- | --- |
| clock reads + lock ops, share of process | 16.6% | 2.0% |
| total cycles in the window | 134.4 G | 105.6 G |
| fps | 30.6 | 30.5 |

The frame rate does not move because the polling thread was not the bottleneck.

xenia-edge has an equivalent change (rfandango's ad7ff10b, cherry-picked as cfcc929b6 with a follow-up in addda160c); this one was written independently and keeps the waiter count in an RAII guard.

`xenia-base-tests`: 74 of 75, the failure being the PhysicalHeap alignment case #1202 fixes; the nine `Wait on ...` cases 20 runs each, no failures.
