### PR TITLE
[Vulkan] Lock the binding layout tables during parallel shader translation

### DIFF
--- a/src/xenia/gpu/vulkan/vulkan_pipeline_cache.cc
+++ b/src/xenia/gpu/vulkan/vulkan_pipeline_cache.cc
@@ -959,6 +959,9 @@ bool VulkanPipelineCache::TranslateAnalyzedShader(
           texture_binding_count * sizeof(*texture_bindings.data());
       uint64_t texture_binding_layout_hash =
           XXH3_64bits(texture_bindings.data(), texture_binding_layout_bytes);
+      // The layout vector and map are shared by every thread translating
+      // shaders for the storage at startup.
+      std::lock_guard<std::mutex> layouts_lock(layouts_mutex_);
       auto found_range =
           texture_binding_layout_map_.equal_range(texture_binding_layout_hash);
       for (auto it = found_range.first; it != found_range.second; ++it) {


### PR DESCRIPTION
`TranslateShadersForStorage` (64e51c544) translates the stored shaders on several threads at startup, and each translation registers its texture binding layout in `texture_binding_layouts_` and `texture_binding_layout_map_`, which the whole cache shares with nothing serialising them. Two threads growing the vector at once corrupt the heap, and the process aborts in `free` inside `VulkanPipelineCache::TranslateAnalyzedShader` before the title starts, with glibc's `double free or corruption (out)` or `malloc(): unaligned tcache chunk detected`.

`layouts_mutex_` has been declared for this since 46202dd27 and is never taken; the D3D12 cache takes it around the same block (`d3d12/pipeline_cache.cc:1006`). This takes it.

Seen on Linux launching Lost Odyssey: three cores with that stack, at a low natural rate (0 of 8 launches one day, 1 of 4 and 3 of 5 the day before). To check the reading, a test build makes every thread on the new-layout path wake on the same 20 ms clock tick before growing the vector:

| forced collision, Lost Odyssey launches | aborts |
| --- | --- |
| without the lock | 3 of 3 |
| with the lock | 0 of 3 |
