### PR TITLE
[CPU] Promote VEC128 context values again

### DIFF
--- a/src/xenia/cpu/compiler/passes/context_promotion_pass.cc
+++ b/src/xenia/cpu/compiler/passes/context_promotion_pass.cc
@@ -113,19 +113,15 @@ void ContextPromotionPass::PromoteBlock(Block* block) {
         i->set_src1(previous_value);
       } else {
         // Store the loaded value into the table.
-        if (i->dest->type != TypeName::VEC128_TYPE) {
-          context_values_[offset] = i->dest;
-          validity.set(static_cast<uint32_t>(offset));
-        }
+        context_values_[offset] = i->dest;
+        validity.set(static_cast<uint32_t>(offset));
       }
     } else if (i->opcode == &OPCODE_STORE_CONTEXT_info) {
       const size_t offset = i->src1.offset;
       Value* value = i->src2.value;
-      if (value->type != TypeName::VEC128_TYPE) {
-        // Store value into the table for later.
-        context_values_[offset] = value;
-        validity.set(static_cast<uint32_t>(offset));
-      }
+      // Store value into the table for later.
+      context_values_[offset] = value;
+      validity.set(static_cast<uint32_t>(offset));
     }
     i = next;
   }
@@ -145,15 +141,12 @@ void ContextPromotionPass::RemoveDeadStoresBlock(Block* block) {
       validity.reset();
     } else if (i->opcode == &OPCODE_STORE_CONTEXT_info) {
       const size_t offset = i->src1.offset;
-      const Value* value = i->src2.value;
-      if (value->type != TypeName::VEC128_TYPE) {
-        if (!validity.test(static_cast<uint32_t>(offset))) {
-          // Offset not yet written, mark and continue.
-          validity.set(static_cast<uint32_t>(offset));
-        } else {
-          // Already written to. Remove this store.
-          i->UnlinkAndNOP();
-        }
+      if (!validity.test(static_cast<uint32_t>(offset))) {
+        // Offset not yet written, mark and continue.
+        validity.set(static_cast<uint32_t>(offset));
+      } else {
+        // Already written to. Remove this store.
+        i->UnlinkAndNOP();
       }
     }
     i = prev;


### PR DESCRIPTION
Depends on #1199: the fold and register fixes there only become reachable once vector operands can be constants, which this makes them.

a74fe21f7 (#860) kept vectors out of context promotion and dead store removal, so a vector loaded from the context was never reused, even twice in a row in the same block. Per the reply on #860 it worked around the int16 vperm fold reading the vpblendw mask inverted, which #1198 fixed, so this removes the exclusion.

Lost Odyssey on Linux, the guest function that is 36.5% of all time in generated code:

| | excluded | promoted |
| --- | --- | --- |
| vector context loads/stores in the function | 509 | 244 |
| function size (bytes) | 37965 | 35525 |
| fps, CPU-bound scene | 30.8-31.4 | 36.4-38.2 |

Blue Dragon and Eternal Sonata sit at their frame caps either way with the picture unchanged. Lost Odyssey, Blue Dragon and Eternal Sonata boot and run on this branch. `xenia-cpu-tests`: 246 of 246.
