### PR TITLE
[GPU] Pace the vblank heartbeat on a deadline on Linux

### DIFF
--- a/src/xenia/gpu/graphics_system.cc
+++ b/src/xenia/gpu/graphics_system.cc
@@ -126,6 +126,13 @@ X_STATUS GraphicsSystem::Setup(cpu::Processor* processor,
                                                     normalized_framerate_limit))
                     : 1.0;
             uint64_t last_frame_time = Clock::QueryGuestTickCount();
+            // Deadline the Linux branch paces to, and the most lateness it
+            // will try to make up before giving the missed beats up.
+            using steady_time_point = std::chrono::steady_clock::time_point;
+            steady_time_point next_vblank_deadline{};
+            constexpr auto kMaxVblankCatchUp = std::chrono::seconds(1);
+            (void)next_vblank_deadline;
+            (void)kMaxVblankCatchUp;
     // Sleep for 90% of the vblank duration on Windows, spin for 10%
     // Linux uses full sleep duration due to scheduler quantum issues
 #if XE_PLATFORM_WIN32
@@ -182,7 +189,6 @@ X_STATUS GraphicsSystem::Setup(cpu::Processor* processor,
               }
 #endif
 #if XE_PLATFORM_LINUX
-              // Linux: Use simplified timing logic to avoid oversleeping
               MarkVblank();
 
               if (cvars::vsync || normalized_framerate_limit > 0) {
@@ -191,7 +197,35 @@ X_STATUS GraphicsSystem::Setup(cpu::Processor* processor,
                 if (!cvars::vsync && normalized_framerate_limit > 0) {
                   sleep_duration_ns = 1000000000 / normalized_framerate_limit;
                 }
-                threading::NanoSleep(sleep_duration_ns);
+                // Sleeping a flat period from wherever the thread woke makes
+                // the real period that period plus the interrupt dispatch
+                // plus the scheduler's wake-up latency, and none of it is
+                // ever made up. Audio drains at the device's own fixed rate,
+                // so a beat the guest does not get is picture time lost
+                // against the sound for good. Pace to a deadline instead and
+                // deliver the missed beats, which is what the Windows branch
+                // above gets from testing the elapsed guest time.
+                const auto period = std::chrono::nanoseconds(
+                    std::max<uint64_t>(1, sleep_duration_ns));
+                auto now = std::chrono::steady_clock::now();
+                if (next_vblank_deadline == steady_time_point()) {
+                  next_vblank_deadline = now;
+                }
+                next_vblank_deadline += period;
+                if (next_vblank_deadline > now) {
+                  threading::NanoSleep(
+                      std::chrono::duration_cast<std::chrono::nanoseconds>(
+                          next_vblank_deadline - now)
+                          .count());
+                } else if (now - next_vblank_deadline > kMaxVblankCatchUp) {
+                  // Further behind than catching up could hide: give the
+                  // missed beats up rather than running the guest fast
+                  // through what was a real freeze.
+                  next_vblank_deadline = now + period;
+                }
+                // Otherwise loop straight round without sleeping, delivering
+                // the missed beats until the guest has had as many as real
+                // time says it should.
               } else {
                 xe::threading::Sleep(std::chrono::milliseconds(1));
               }
@@ -204,8 +238,18 @@ X_STATUS GraphicsSystem::Setup(cpu::Processor* processor,
   frame_limiter_worker_thread_->set_can_debugger_suspend(true);
   frame_limiter_worker_thread_->set_name("GPU Frame limiter");
   frame_limiter_worker_thread_->Create();
+  // The Windows branch spins for part of each period, which is what the
+  // lowest priority is for. The Linux branch only sleeps, so there it buys
+  // nothing and costs wake-up latency: kLowest maps to nice 15 against nice 0
+  // for every other thread in the process, and any other busy program then
+  // delays the guest's vblanks.
+#if XE_PLATFORM_WIN32
   frame_limiter_worker_thread_->thread()->set_priority(
       threading::ThreadPriority::kLowest);
+#else
+  frame_limiter_worker_thread_->thread()->set_priority(
+      threading::ThreadPriority::kNormal);
+#endif
   if (cvars::trace_gpu_stream) {
     BeginTracing();
   }


### PR DESCRIPTION
The Linux branch of the frame limiter marks a vblank and then sleeps a flat period, so the real period is that period plus the interrupt dispatch plus the scheduler's wake-up latency, and none of it is ever made up. The Windows branch immediately above tests `elapsed >= vsync_duration` against the guest clock and self-corrects; Linux has no equivalent check.

The thread is also created at `ThreadPriority::kLowest`, which on POSIX is 1 and maps to nice 15 when SCHED_FIFO is not permitted, against nice 0 for every other thread in the process. That priority is there for the Windows branch, which spins for 10% of each period; the Linux branch only sleeps, so it buys nothing and costs wake-up latency whenever another process is busy.

Audio drains at the device's own fixed rate, so a beat the guest does not get is picture time lost against the sound and never recovered. It shows up as lip movement and subtitles drifting behind the voices in a cutscene once something else loads the machine, and it does not come back.

Measured on a Lost Odyssey cutscene restored from a save state, counting vblanks per 5 s (300 is correct), with a ten second CPU hog partway through each run:

| window | current | with this change |
| --- | --- | --- |
| idle | 299 | 300 |
| save state restore stall | 258, 255 | 300, 300 |
| 40 s including the hog, ideal 2400 | 2382, 2371 | 2400, 2400 |

Two runs each; with the deadline every measured window read exactly 300. Presented frames still dip under the load in both configurations, which is the renderer genuinely missing frames, but the guest's timeline no longer drifts away from the sound.

The deadline advances by one period per beat, a late wake-up shortens the next sleep, missed beats are delivered back to back until the count matches real time, and lateness beyond one second is given up so a real freeze resyncs rather than fast-forwarding the guest. Windows is untouched.
