### PR TITLE
[CPU] Fix mcrf: copy the CR field instead of comparing it against zero

### DIFF
--- a/src/xenia/cpu/ppc/ppc_emit_control.cc
+++ b/src/xenia/cpu/ppc/ppc_emit_control.cc
@@ -422,11 +422,13 @@ int InstrEmit_crxor(PPCHIRBuilder& f, const InstrData& i) {
 }
 
 int InstrEmit_mcrf(PPCHIRBuilder& f, const InstrData& i) {
+  // CR[4*bf:4*bf+3] <- CR[4*bfa:4*bfa+3]   bf=bo, bfa=bi
+  // LoadCR/StoreCR bake the field position into the word and cannot cross it.
   uint32_t crfd = i.XL.BO >> 2;
-  Value* bi = f.LoadCR(i.XL.BI >> 2);
-
-  f.StoreCR(crfd, bi);
-  f.UpdateCR(crfd, bi);
+  uint32_t crfs = i.XL.BI >> 2;
+  for (uint32_t bit = 0; bit < 4; ++bit) {
+    f.StoreCRField(crfd, bit, f.LoadCRField(crfs, bit));
+  }
   return 0;
 }
 

--- a/src/xenia/cpu/ppc/testing/instr_mcrf.s
+++ b/src/xenia/cpu/ppc/testing/instr_mcrf.s
@@ -51,7 +51,8 @@ test_mcrf_3:
   blr
   #_ REGISTER_OUT r3 5
   #_ REGISTER_OUT r4 5
-  #_ REGISTER_OUT r12 0x40020000
+  # cr0 = eq, cr3 = eq
+  #_ REGISTER_OUT r12 0x20020000
 
 test_mcrf_3_constant:
   li r3, 5
@@ -62,7 +63,8 @@ test_mcrf_3_constant:
   blr
   #_ REGISTER_OUT r3 5
   #_ REGISTER_OUT r4 5
-  #_ REGISTER_OUT r12 0x40020000
+  # cr0 = eq, cr3 = eq
+  #_ REGISTER_OUT r12 0x20020000
 
 test_mcrf_4:
   #_ REGISTER_IN r3 100
@@ -100,7 +102,8 @@ test_mcrf_5:
   #_ REGISTER_OUT r4 20
   #_ REGISTER_OUT r5 30
   #_ REGISTER_OUT r6 30
-  #_ REGISTER_OUT r12 0x00802040
+  # cr2 = lt, cr4 = eq, cr6 = lt
+  #_ REGISTER_OUT r12 0x00802080
 
 test_mcrf_5_constant:
   li r3, 10
@@ -116,4 +119,49 @@ test_mcrf_5_constant:
   #_ REGISTER_OUT r4 20
   #_ REGISTER_OUT r5 30
   #_ REGISTER_OUT r6 30
-  #_ REGISTER_OUT r12 0x00802040
+  # cr2 = lt, cr4 = eq, cr6 = lt
+  #_ REGISTER_OUT r12 0x00802080
+
+test_mcrf_6:
+  #_ REGISTER_IN r3 5
+  #_ REGISTER_IN r4 5
+  cmpw cr3, r3, r4
+  mcrf cr3, cr3
+  mfcr r12
+  blr
+  #_ REGISTER_OUT r3 5
+  #_ REGISTER_OUT r4 5
+  # cr3 = eq
+  #_ REGISTER_OUT r12 0x00020000
+
+test_mcrf_6_constant:
+  li r3, 5
+  li r4, 5
+  cmpw cr3, r3, r4
+  mcrf cr3, cr3
+  mfcr r12
+  blr
+  #_ REGISTER_OUT r3 5
+  #_ REGISTER_OUT r4 5
+  # cr3 = eq
+  #_ REGISTER_OUT r12 0x00020000
+
+test_mcrf_7:
+  #_ REGISTER_IN r3 9
+  mtcrf 0xFF, r3
+  mcrf cr0, cr7
+  mfcr r12
+  blr
+  #_ REGISTER_OUT r3 9
+  # cr7 = lt|so, copied to cr0
+  #_ REGISTER_OUT r12 0x90000009
+
+test_mcrf_7_constant:
+  li r3, 9
+  mtcrf 0xFF, r3
+  mcrf cr0, cr7
+  mfcr r12
+  blr
+  #_ REGISTER_OUT r3 9
+  # cr7 = lt|so, copied to cr0
+  #_ REGISTER_OUT r12 0x90000009


### PR DESCRIPTION
`mcrf BF,BFA` copies a four bit condition field, SO included. The lowering was `LoadCR(BFA)` then `StoreCR(BF)` then `UpdateCR(BF)`, but `LoadCR` and `StoreCR` bake the field's bit position into the word, so for `BF != BFA` the store read zeros and `UpdateCR` then rewrote lt, gt and eq from a signed compare against zero and dropped SO. A copied `eq` came out as `gt`.

It now copies the four bits with `LoadCRField` and `StoreCRField`, which is what `mcrf` is.

Nothing faults, so the only symptom is a branch after `mcrf` taking the wrong arm somewhere later.

From has207's xenia-edge, 46e8fd8dccba, authorship kept. It brings four new `instr_mcrf.s` fixtures and re-derives two existing expectations. `xenia-cpu-tests` on this branch: 246 of 246.
