### PR TITLE
[Memory] Round the AllocRange ceiling to the page, not to the alignment

### DIFF
--- a/src/xenia/base/testing/physical_heap_test.cc
+++ b/src/xenia/base/testing/physical_heap_test.cc
@@ -162,11 +162,10 @@ TEST_CASE("PhysicalHeap vE0000000 alignment", "[memory]") {
   }
 
   SECTION("alloc with alignment larger than page_size is rejected") {
-    // vE0000000 has a 0x1000 physical translation offset, so a 64KB
-    // alignment request can't produce a 64KB-aligned guest address.
-    // PhysicalHeap::Alloc forces top-down, which here lands one stride
-    // past the end of the child heap and BaseHeap::AllocFixed rejects
-    // it as out of range.
+    // vE0000000 has a 0x1000 physical translation offset, so the host
+    // alignment check in PhysicalHeap::Alloc, which tests
+    // (address + host_address_offset_) % alignment, cannot be satisfied for
+    // an alignment above the page size where that offset is 0.
     uint32_t alignment = 0x10000;  // 64KB
     uint32_t addr = 0;
     bool ok = heap.Alloc(0x10000, alignment, kMemoryAllocationReserve,
@@ -207,6 +206,30 @@ TEST_CASE("PhysicalHeap vE0000000 AllocRange alignment", "[memory]") {
     REQUIRE(ok);
     REQUIRE(addr >= 0xE0000000);
   }
+}
+
+TEST_CASE("PhysicalHeap::AllocRange stays within the requested range",
+          "[memory]") {
+  VirtualHeap parent;
+  parent.Initialize(nullptr, nullptr, HeapType::kGuestPhysical, 0x00000000,
+                    0x20000000, 4096);
+
+  PhysicalHeap heap;
+  heap.Initialize(nullptr, nullptr, HeapType::kGuestPhysical, 0xA0000000,
+                  0x20000000, 64 * 1024, &parent);
+
+  // A ceiling that is not a multiple of the alignment must not be rounded up
+  // to the next one, which would place the allocation above it.
+  const uint32_t size = 0x10000;
+  const uint32_t alignment = 0x10000;
+  const uint32_t high_address = 0xA0FF8000;
+  uint32_t addr = 0;
+  bool ok = heap.AllocRange(0xA0000000, high_address, size, alignment,
+                            kMemoryAllocationReserve, kMemoryProtectRead, true,
+                            &addr);
+  REQUIRE(ok);
+  REQUIRE(heap.GetPhysicalAddress(addr) % alignment == 0);
+  REQUIRE(addr + size - 1 <= high_address);
 }
 
 }  // namespace test

--- a/src/xenia/memory.cc
+++ b/src/xenia/memory.cc
@@ -1202,11 +1202,17 @@ bool BaseHeap::AllocRange(uint32_t low_address, uint32_t high_address,
   alignment = xe::round_up(alignment, page_size_);
   uint32_t page_count = get_page_count(size, page_size_);
   low_address = std::max(heap_base_, xe::align(low_address, alignment));
-  high_address = std::min(heap_base_ + (heap_size_ - 1),
-                          xe::align(high_address, alignment));
+  // Do not round the ceiling up to the alignment: a window that is not a
+  // multiple of it would then let the search place the allocation above the
+  // address the caller asked for, and an align() of a high_address near
+  // UINT32_MAX wraps to zero. The round-up was there so that a window
+  // exactly the size of the request does not lose a stride at the top; the
+  // page rounding below keeps that, and the search still aligns the base.
+  high_address = std::min(heap_base_ + (heap_size_ - 1), high_address);
 
   uint32_t low_page_number = (low_address - heap_base_) >> page_size_shift_;
-  uint32_t high_page_number = (high_address - heap_base_) >> page_size_shift_;
+  uint32_t high_page_number =
+      (high_address - heap_base_ + (page_size_ - 1)) >> page_size_shift_;
   low_page_number = std::min(uint32_t(page_table_.size()) - 1, low_page_number);
   high_page_number =
       std::min(uint32_t(page_table_.size()) - 1, high_page_number);


### PR DESCRIPTION
Ported from has207's xenia-edge `1ad151d1`, authorship kept.

`BaseHeap::AllocRange` rounds `high_address` **up** to the alignment before clamping it to the heap, so a caller whose window is not a multiple of the alignment can get an allocation above the ceiling it asked for. A `high_address` near `UINT32_MAX` also wraps to zero through `xe::align`.

The round-up was added in `4fcb8e449` so that a window exactly the size of the request does not lose a stride at the top. Rounding `high_page_number` up to the page keeps that without moving the ceiling itself; the search still aligns the base below it.

Adds edge's test that an allocation stays within the requested range, and corrects the comment on the `PhysicalHeap vE0000000` "rejected" case, which attributed the rejection to the top-down search landing past the end of the child heap. Without the rounded ceiling that no longer happens; what rejects it is the host alignment check in `PhysicalHeap::Alloc`. The expectation is unchanged.

| | `xenia-base-tests` on Linux |
| --- | --- |
| `canary_experimental` | 74 of 75 |
| with this change | 74 of 75 |

The failure is the pre-existing `PhysicalHeap vE0000000 AllocRange alignment` case, unrelated to this.

This is the same function whose inclusive/exclusive page number broke Far Cry 3, Far Cry 4 and Watchdogs, so Lost Odyssey and Red Dead Redemption were booted on this branch for a minute each and reached 97 and 37 guest threads with no error lines.
