### PR TITLE
[VFS] Bounds check the STFS reader

### DIFF
--- a/src/xenia/kernel/xam/xcontent/xcontent_package_container.cc
+++ b/src/xenia/kernel/xam/xcontent/xcontent_package_container.cc
@@ -156,6 +156,20 @@ std::unique_ptr<vfs::Device> ContentPackageContainer::MountPackage() {
       xe::round_up(header_.content_header.header_size,
                    vfs::XContentContainerDevice::kBlockSize);
 
+  // The metadata records how much data the package should hold, so an
+  // incomplete download can be named as such instead of reading off the end
+  // of the mapping later. Some packages leave the field at zero.
+  const uint64_t expected_size = header_.content_metadata.content_size;
+  if (expected_size && package_->size() >= package_data_offset &&
+      expected_size > package_->size() - package_data_offset) {
+    XELOGE(
+        "XContent: {} holds {} bytes of data where its metadata describes {}. "
+        "The package is incomplete and will not be mounted.",
+        xe::path_to_utf8(host_path_), package_->size() - package_data_offset,
+        expected_size);
+    return nullptr;
+  }
+
   std::unique_ptr<vfs::Device> device = nullptr;
   switch (header_.content_metadata.volume_type) {
     case XContentVolumeType::kStfs:

--- a/src/xenia/vfs/devices/xcontent_devices/stfs_container_device.cc
+++ b/src/xenia/vfs/devices/xcontent_devices/stfs_container_device.cc
@@ -77,6 +77,11 @@ StfsContainerDevice::Result StfsContainerDevice::Read() {
     }
 
     const StfsHashEntry* block_hash = GetBlockHash(table_block_index);
+    if (!block_hash) {
+      XELOGE("STFS: the file table chain leaves the package at block {}",
+             table_block_index);
+      return Result::kReadError;
+    }
     table_block_index = block_hash->level0_next_block();
     if (table_block_index == kEndOfChain) {
       break;
@@ -136,6 +141,11 @@ std::unique_ptr<StfsContainerEntry> StfsContainerDevice::ReadEntry(
       entry->block_list_.push_back({0, offset, block_size});
       remaining_size -= block_size;
       auto block_hash = GetBlockHash(block_index);
+      if (!block_hash) {
+        XELOGE("STFS: the block chain of {} leaves the package at block {}",
+               name, block_index);
+        break;
+      }
       block_index = block_hash->level0_next_block();
     }
 
@@ -224,14 +234,30 @@ const uint8_t StfsContainerDevice::GetAmountOfHashLevelsToCheck(
   return 0;
 }
 
-void StfsContainerDevice::UpdateCachedHashTable(
+bool StfsContainerDevice::InBounds(size_t offset, size_t length) const {
+  if (!data_) {
+    return false;
+  }
+  const size_t end = offset + length;
+  return end >= offset && end <= data_->size();
+}
+
+bool StfsContainerDevice::UpdateCachedHashTable(
     uint32_t block_index, uint8_t hash_level,
     uint32_t& secondary_table_offset) {
   const size_t hash_offset = BlockToHashBlockOffset(block_index, hash_level);
   // Do nothing. It's already there.
   if (!cached_hash_tables_.count(hash_offset)) {
-    cached_hash_tables_[hash_offset] = *reinterpret_cast<StfsHashTable*>(
-        data_->data() + hash_offset + secondary_table_offset);
+    const size_t at = hash_offset + secondary_table_offset;
+    if (!InBounds(at, sizeof(StfsHashTable))) {
+      XELOGE(
+          "STFS: the hash table for block {} (level {}) is at {:X}, past the "
+          "end of the {} byte package",
+          block_index, hash_level, at, data_ ? data_->size() : 0);
+      return false;
+    }
+    cached_hash_tables_[hash_offset] =
+        *reinterpret_cast<StfsHashTable*>(data_->data() + at);
   }
 
   uint32_t record = block_index % kBlocksPerHashLevel[0];
@@ -242,14 +268,18 @@ void StfsContainerDevice::UpdateCachedHashTable(
   const StfsHashEntry* record_data =
       &cached_hash_tables_[hash_offset].entries[record];
   secondary_table_offset = record_data->levelN_active_index() ? kBlockSize : 0;
+  return true;
 }
 
-void StfsContainerDevice::UpdateCachedHashTables(
+bool StfsContainerDevice::UpdateCachedHashTables(
     uint32_t block_index, uint8_t highest_hash_level_to_update,
     uint32_t& secondary_table_offset) {
   for (int8_t level = highest_hash_level_to_update; level >= 0; level--) {
-    UpdateCachedHashTable(block_index, level, secondary_table_offset);
+    if (!UpdateCachedHashTable(block_index, level, secondary_table_offset)) {
+      return false;
+    }
   }
+  return true;
 }
 
 const StfsHashEntry* StfsContainerDevice::GetBlockHash(uint32_t block_index) {
@@ -266,8 +296,10 @@ const StfsHashEntry* StfsContainerDevice::GetBlockHash(uint32_t block_index) {
     hash_levels_to_process = 0;
   }
 
-  UpdateCachedHashTables(block_index, hash_levels_to_process,
-                         secondary_table_offset);
+  if (!UpdateCachedHashTables(block_index, hash_levels_to_process,
+                              secondary_table_offset)) {
+    return nullptr;
+  }
 
   const size_t hash_offset = BlockToHashBlockOffset(block_index, 0);
   const uint32_t record = block_index % kBlocksPerHashLevel[0];

--- a/src/xenia/vfs/devices/xcontent_devices/stfs_container_device.h
+++ b/src/xenia/vfs/devices/xcontent_devices/stfs_container_device.h
@@ -67,10 +67,14 @@ class StfsContainerDevice : public XContentContainerDevice {
                                 uint32_t hash_level) const;
   const uint8_t GetAmountOfHashLevelsToCheck(uint32_t total_block_count) const;
 
+  // True when [offset, offset + length) is inside the mapped package.
+  bool InBounds(size_t offset, size_t length) const;
+
+  // Null when the hash table the block needs is not in the file.
   const StfsHashEntry* GetBlockHash(uint32_t block_index);
-  void UpdateCachedHashTable(uint32_t block_index, uint8_t hash_level,
+  bool UpdateCachedHashTable(uint32_t block_index, uint8_t hash_level,
                              uint32_t& secondary_table_offset);
-  void UpdateCachedHashTables(uint32_t block_index,
+  bool UpdateCachedHashTables(uint32_t block_index,
                               uint8_t highest_hash_level_to_update,
                               uint32_t& secondary_table_offset);
 


### PR DESCRIPTION
`StfsContainerDevice` indexes the mapped package with offsets computed from its own headers and never checks them, so an incomplete or damaged package crashes the emulator while it is being mounted:

    __memcpy_avx_unaligned_erms
    StfsContainerDevice::GetBlockHash
    StfsContainerDevice::Read
    XContentContainerDevice::Initialize

One installed Guitar Hero 5 DLC pack holds 82,452,480 bytes of data where its metadata describes 135,081,984, and its block chain leaves the file at block 20060, offset 0x4ED3000.

`MountPackage` compares the metadata's `content_size` against the data the file actually holds and refuses the package before it is mounted, naming it in the log. For the rest, `GetBlockHash` returns null when the hash table a block needs is not in the file, and its two callers stop the chain instead of walking off the end. A package that is whole behaves exactly as before.
