### PR TITLE
[App] Build the disc picker on the UI thread, not the guest thread

### DIFF
--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -1326,6 +1326,24 @@ bool Emulator::RestoreFromFile(const std::filesystem::path& path) {
 
 const std::filesystem::path Emulator::GetNewDiscPath(
     std::string window_message) {
+  // GTK only allows widgets to be built on the UI thread, and XamSwapDisc
+  // calls this from a guest thread.
+  ui::Window* window = display_window();
+  if (window && !window->app_context().IsInUIThread()) {
+    std::filesystem::path path;
+    if (!window->app_context().CallInUIThreadSynchronous(
+            [this, &window_message, &path]() {
+              path = ShowDiscPicker(window_message);
+            })) {
+      return std::filesystem::path();
+    }
+    return path;
+  }
+  return ShowDiscPicker(window_message);
+}
+
+const std::filesystem::path Emulator::ShowDiscPicker(
+    std::string window_message) {
   std::filesystem::path path = "";
 
   auto file_picker = xe::ui::FilePicker::Create();

--- a/src/xenia/emulator.h
+++ b/src/xenia/emulator.h
@@ -307,6 +307,8 @@ class Emulator {
 
   // The game can request another title to be loaded.
   const std::filesystem::path GetNewDiscPath(std::string window_message = "");
+  // Builds and runs the picker itself. UI thread only.
+  const std::filesystem::path ShowDiscPicker(std::string window_message);
 
   void WaitUntilExit();
 


### PR DESCRIPTION
A game that asks for the next disc kills the emulator on Linux. Lost Odyssey does it the moment the save it tells you to make is loaded, so the game is unfinishable: the file picker Xenia opens is built on the game's own thread, and GTK crashes when a window is built anywhere but the UI thread. It is built on the UI thread now.

`XamSwapDisc` asks `Emulator::GetNewDiscPath` for the next disc image from the guest thread that called the export, and the picker built its widgets there. On GTK only the thread running the loop may touch a widget, so the file chooser segfaulted the process partway through construction:

    #0  gtk_box_get_content_size
    ... GTK widget construction ...
    #57 gtk_file_chooser_dialog_new
    #58 xe::ui::GtkFilePicker::Show
    #59 xe::Emulator::GetNewDiscPath
    #60 XamSwapDisc_entry

Lost Odyssey asks for disc 2 the moment the save it tells you to make is loaded, so the game killed the emulator every time. Two cores from the same evening, both this stack. The log ends mid thread creation with `Unhandled signal 11 looping at pc=... address=0`, which reads like a guest fault and is not one: the pc is host GTK code.

The picker runs through `CallInUIThreadSynchronous` now, so the widgets are built on the UI thread while the calling guest thread waits, which is what the title expects of the call anyway. `ShowDiscPicker` is the UI-thread-only half. Where there is no window, or the caller is already the UI thread, nothing changes.

Verified by calling `GetNewDiscPath` from a thread that is not the UI thread: the dialog opens and the process lives, where the same call crashed before.
