### PR TITLE
[Base/POSIX] Classify directory entries from stat, not d_type

### DIFF
--- a/src/xenia/base/filesystem_posix.cc
+++ b/src/xenia/base/filesystem_posix.cc
@@ -23,6 +23,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <cstring>
 #if XE_PLATFORM_MAC
 #include <limits.h>
 #include <mach-o/dyld.h>
@@ -259,13 +260,23 @@ std::vector<FileInfo> ListFiles(const std::filesystem::path& path) {
     FileInfo info;
 
     info.name = ent->d_name;
+    const auto child_path = path / info.name;
     struct stat st;
-    stat((path / info.name).c_str(), &st);
+    // A failed stat leaves the struct indeterminate, and it fed the
+    // timestamps and the size: a dangling symlink, an entry deleted between
+    // the readdir and the stat, or EACCES on a path component.
+    if (stat(child_path.c_str(), &st) != 0 &&
+        lstat(child_path.c_str(), &st) != 0) {
+      std::memset(&st, 0, sizeof(st));
+    }
     info.create_timestamp = convertUnixtimeToWinFiletime(st.st_ctime);
     info.access_timestamp = convertUnixtimeToWinFiletime(st.st_atime);
     info.write_timestamp = convertUnixtimeToWinFiletime(st.st_mtime);
     info.path = path;
-    if (ent->d_type == DT_DIR) {
+    // d_type is unreliable: DT_LNK for a symlinked directory, and DT_UNKNOWN
+    // on filesystems that do not fill it in, which includes many FUSE and
+    // network mounts and some XFS configurations. Classify from the stat.
+    if (S_ISDIR(st.st_mode)) {
       info.type = FileInfo::Type::kDirectory;
       info.total_size = 0;
     } else {

--- a/src/xenia/base/testing/filesystem_test.cc
+++ b/src/xenia/base/testing/filesystem_test.cc
@@ -1,0 +1,115 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2026 Ben Vanik. All rights reserved.                             *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "xenia/base/filesystem.h"
+#include "xenia/base/platform.h"
+
+#include "third_party/catch/include/catch.hpp"
+
+namespace xe::base::test {
+
+using xe::filesystem::FileInfo;
+
+namespace {
+
+// A directory of our own under the system temp directory, removed with the
+// test.
+class ScratchDir {
+ public:
+  ScratchDir() {
+    std::error_code ec;
+    path_ = std::filesystem::temp_directory_path(ec) /
+            "xenia_filesystem_test_scratch";
+    std::filesystem::remove_all(path_, ec);
+    std::filesystem::create_directories(path_, ec);
+  }
+  ~ScratchDir() {
+    std::error_code ec;
+    std::filesystem::remove_all(path_, ec);
+  }
+
+  const std::filesystem::path& path() const { return path_; }
+
+ private:
+  std::filesystem::path path_;
+};
+
+const FileInfo* Find(const std::vector<FileInfo>& infos,
+                     const std::string& name) {
+  for (const auto& info : infos) {
+    if (info.name == name) {
+      return &info;
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+TEST_CASE("List Files", "[filesystem]") {
+  ScratchDir scratch;
+  REQUIRE(std::filesystem::exists(scratch.path()));
+
+  std::error_code ec;
+  std::filesystem::create_directory(scratch.path() / "a_directory", ec);
+  REQUIRE(!ec);
+  {
+    std::ofstream file(scratch.path() / "a_file");
+    file << "1234";
+  }
+
+  SECTION("a directory and a file are told apart") {
+    auto infos = xe::filesystem::ListFiles(scratch.path());
+    const auto* dir = Find(infos, "a_directory");
+    const auto* file = Find(infos, "a_file");
+    REQUIRE(dir);
+    REQUIRE(file);
+    REQUIRE(dir->type == FileInfo::Type::kDirectory);
+    REQUIRE(dir->total_size == 0);
+    REQUIRE(file->type == FileInfo::Type::kFile);
+    REQUIRE(file->total_size == 4);
+  }
+
+#if !XE_PLATFORM_WIN32
+  SECTION("a symlinked directory is a directory") {
+    // dirent::d_type reports DT_LNK here, so classifying from it made a
+    // symlinked directory look like a file.
+    std::filesystem::create_directory_symlink(
+        scratch.path() / "a_directory", scratch.path() / "linked_directory",
+        ec);
+    REQUIRE(!ec);
+    auto infos = xe::filesystem::ListFiles(scratch.path());
+    const auto* link = Find(infos, "linked_directory");
+    REQUIRE(link);
+    REQUIRE(link->type == FileInfo::Type::kDirectory);
+  }
+
+  SECTION("a dangling symlink reports the link, not a garbage size") {
+    // stat fails on it, and its return used to be discarded, leaving the
+    // struct indeterminate and feeding the size and the timestamps from it.
+    // The lstat fallback describes the link itself, whose size is the length
+    // of the path it holds.
+    const auto target = scratch.path() / "not_here";
+    std::filesystem::create_symlink(target, scratch.path() / "dangling", ec);
+    REQUIRE(!ec);
+    auto infos = xe::filesystem::ListFiles(scratch.path());
+    const auto* dangling = Find(infos, "dangling");
+    REQUIRE(dangling);
+    REQUIRE(dangling->type == FileInfo::Type::kFile);
+    REQUIRE(dangling->total_size == target.string().size());
+  }
+#endif  // !XE_PLATFORM_WIN32
+}
+
+}  // namespace xe::base::test

--- a/src/xenia/vfs/devices/host_path_device.cc
+++ b/src/xenia/vfs/devices/host_path_device.cc
@@ -61,6 +61,33 @@ Entry* HostPathDevice::ResolvePath(const std::string_view path) {
 }
 
 void HostPathDevice::PopulateEntry(HostPathEntry* parent_entry) {
+  std::vector<std::filesystem::path> ancestors;
+  PopulateEntry(parent_entry, ancestors);
+}
+
+void HostPathDevice::PopulateEntry(
+    HostPathEntry* parent_entry,
+    std::vector<std::filesystem::path>& ancestors) {
+  // Directory symlinks are walked now that the type comes from the stat, so a
+  // link back into a directory already on this path would recurse until the
+  // stack runs out. A link to a sibling subtree still gets walked: it
+  // duplicates entries but ends, so only genuine self-containment is cut.
+  std::error_code ec;
+  auto canonical_self =
+      std::filesystem::canonical(parent_entry->host_path(), ec);
+  if (!ec) {
+    for (const auto& seen : ancestors) {
+      if (seen == canonical_self) {
+        XELOGW(
+            "HostPathDevice: {} is already on the path being walked; not "
+            "following it again",
+            xe::path_to_utf8(parent_entry->host_path()));
+        return;
+      }
+    }
+    ancestors.push_back(canonical_self);
+  }
+
   auto child_infos = xe::filesystem::ListFiles(parent_entry->host_path());
   for (auto& child_info : child_infos) {
     auto child = HostPathEntry::Create(
@@ -69,8 +96,12 @@ void HostPathDevice::PopulateEntry(HostPathEntry* parent_entry) {
     parent_entry->children_.push_back(std::unique_ptr<Entry>(child));
 
     if (child_info.type == xe::filesystem::FileInfo::Type::kDirectory) {
-      PopulateEntry(child);
+      PopulateEntry(child, ancestors);
     }
+  }
+
+  if (!ec) {
+    ancestors.pop_back();
   }
 }
 

--- a/src/xenia/vfs/devices/host_path_device.h
+++ b/src/xenia/vfs/devices/host_path_device.h
@@ -10,7 +10,9 @@
 #ifndef XENIA_VFS_DEVICES_HOST_PATH_DEVICE_H_
 #define XENIA_VFS_DEVICES_HOST_PATH_DEVICE_H_
 
+#include <filesystem>
 #include <string>
+#include <vector>
 
 #include "xenia/vfs/device.h"
 
@@ -46,6 +48,10 @@ class HostPathDevice : public Device {
 
  private:
   void PopulateEntry(HostPathEntry* parent_entry);
+  // Walks one directory, with the canonical path of every directory already
+  // on this branch, so a symlink into one of them is not followed again.
+  void PopulateEntry(HostPathEntry* parent_entry,
+                     std::vector<std::filesystem::path>& ancestors);
 
   std::string name_;
   std::filesystem::path host_path_;


### PR DESCRIPTION
Xenia asks the operating system a shortcut question about which entries in a folder are folders, and some filesystems do not answer it: network shares, many FUSE mounts, some XFS setups. On those, every folder in a games or content directory is reported as a file with a random size, so the folders never appear and nothing under them is scanned. This reads the entry type properly instead.

Split out of has207's xenia-edge `2e1580261` and kept under his authorship.

`ListFiles` classified entries from `dirent::d_type`, which is optional: `DT_LNK` for a symlinked directory, `DT_UNKNOWN` wherever the filesystem does not fill it in. It also called `stat` and discarded the return, so a failure - a dangling symlink, an entry deleted between the `readdir` and the `stat`, `EACCES` on a path component - left `struct stat` indeterminate and fed the timestamps and `total_size` from it.

Classifying from `st_mode` makes `HostPathDevice::PopulateEntry` follow directory symlinks for the first time, so `content/x -> content` would recurse until the stack is exhausted. It now carries the canonical path of each directory on the recursion stack and stops when a child resolves to one already on it. A link to a sibling subtree is still followed: it duplicates entries but ends, so only genuine self-containment is cut.

`filesystem_test.cc` is new and covers both. Without the fix, on Linux:

    REQUIRE( link->type == FileInfo::Type::kDirectory )   0 == 1
    REQUIRE( dangling->total_size == target.string().size() )
      139863876771833 (0x7f3498b11ff9) == 43

`xenia-base-tests`: 76 of 77, the failure being the pre-existing `PhysicalHeap vE0000000 AllocRange alignment` case.
